### PR TITLE
Dashboard aesthetics

### DIFF
--- a/docs/live_dashboard.md
+++ b/docs/live_dashboard.md
@@ -9,8 +9,71 @@ FastMDXplora has two dashboard views:
   telemetry files while a simulation is running.
 
 The live dashboard does not replace the static report dashboard. It adds a
-separate monitoring view for progress, health messages, recent events, and
-available energy/temperature samples.
+separate monitoring view for progress, health messages, recent events,
+**true live molecular coordinates**, **completed-trajectory playback**,
+**structure and ligand tooling**, and available energy/temperature samples.
+
+## Architecture
+
+The live dashboard is a plain-HTTP Python server with no Node or frontend
+build step. Assets are vendored locally and the dashboard runs fully offline.
+
+```
+src/fastmdxplora/live/
+├── server.py                # HTTP handlers + route table
+├── telemetry.py             # existing telemetry reader
+├── protein_preview.py       # existing static preview generator
+├── structure_info.py        # PDB chains / residues / atoms / waters / ions
+├── ligand_detection.py      # ligand + cofactor detection with overrides
+├── live_frames.py           # atomic live-frame file writer
+├── trajectory_playback.py   # DCD -> downsampled multi-MODEL PDB for browser
+├── templates/
+│   └── dashboard.html       # single-page dashboard (sidebar + pages)
+└── static/
+    ├── dashboard.css        # black scientific visual system
+    ├── dashboard.js         # navigation, polling, state, events
+    ├── molecule-viewer.js   # 3Dmol viewer (live + playback)
+    ├── charts.js            # live telemetry charts
+    ├── aai-research-logo.svg
+    ├── aai-research-mark.svg
+    └── 3Dmol-min.js         # existing vendored 3Dmol bundle
+```
+
+### Page layout
+
+The single-page app exposes:
+
+- **Sidebar** with the AAI Research Lab logo, the FastMDXplora product name, the
+  full tagline (Fully Automated SysTem for Molecular Dynamics eXploration),
+  the persistent nav (Overview, Live Simulation, Molecular Viewer, Analysis,
+  Files & Reports, Run Settings, Documentation, GitHub), and dynamic footer
+  info (connection status, current run, detected platform).
+- **Top bar** with system/PDB, run title, status pill, current stage, step/total,
+  platform, temperature, refresh, and Pause Updates (browser-only).
+- **Pages**: Overview, Live Simulation, Molecular Viewer, Analysis,
+  Files & Reports, Run Settings.
+
+### Branding
+
+The dashboard is branded with the AAI Research Lab logo (vendored SVG, no CDN).
+The tagline `Fully Automated SysTem for Molecular Dynamics eXploration` is
+preserved with its original capitalization. Black / charcoal backgrounds, white
+and silver typography, restrained cyan and violet accents, green for healthy,
+orange for warning, red only for error. All system fonts; no remote font loads.
+
+## Safety guarantees
+
+The dashboard must never terminate or interfere with an OpenMM simulation:
+
+- All file-system writes performed by the dashboard module are wrapped in
+  try/except. A failure is logged and surfaced as `unavailable` in the UI
+  without stopping the surrounding workflow.
+- Live frame writing runs at a separately tunable cadence
+  (`--dashboard-frame-interval`, default approximate match to telemetry).
+- The simulation stays authoritative. The **Pause Updates** control only
+  pauses browser-side polling; it never pauses the OpenMM integrator.
+- Telemetry parsing tolerates partial lines, missing files, and mid-write
+  arrays.
 
 ## Recommended: start it with the workflow
 
@@ -214,3 +277,101 @@ fastmdx explore --system local_pdbs/1L2Y.pdb \
   --simulate-preset gentle \
   --dashboard
 ```
+
+## New CLI options
+
+The redesigned dashboard accepts additional options without changing existing
+defaults:
+
+| Flag | Purpose | Default |
+| --- | --- | --- |
+| `--dashboard-host` | Bind address for dashboard server | `127.0.0.1` |
+| `--dashboard-port` | Bind port; auto-falls-forward if busy | `8765` |
+| `--dashboard-refresh-seconds` | Browser polling interval | `2` |
+| `--dashboard-frame-interval` | Telemetry interval at which a live frame PDB is written | matches telemetry |
+| `--dashboard-max-playback-frames` | Max browser playback frames (downsampled) | `200` |
+| `--dashboard-ligand-resname` | Explicit ligand residue-name override | autodetect |
+| `--dashboard-binding-pocket-cutoff-A` | Pocket distance cutoff in Å | `5.0` |
+| `--dashboard-open-browser` | Auto-open the dashboard URL | `False` |
+| `--dashboard-stop-on-complete` | Exit server when workflow completes | `False` |
+
+## API surface
+
+The server exposes lightweight JSON endpoints (all read-only, no database):
+
+- `GET /api/status` — current run status snapshot
+- `GET /api/metrics` — recent telemetry samples
+- `GET /api/events` — recent telemetry events
+- `GET /api/structure-info` — chains / residues / atoms / waters / ions / bbox
+- `GET /api/ligands` — ligand instances, residue names, cofactors, explicit override
+- `GET /api/live-frame-index` — current live-frame index + timestamp
+- `GET /api/live-coordinates` — last-known live-frame update timestamp
+- `GET /api/playback-info` — downsampled playback frames metadata
+- `GET /api/files` — alias for `/api/artifacts` generated file list
+- `GET /api/analyses` — alias for `/api/results` analysis summary
+- `GET /structure/topology.pdb` — served structure (latest available)
+- `GET /structure/live-frame.pdb` — latest OpenMM live frame (atomic swap)
+- `GET /structure/final.pdb` — completed final structure
+- `GET /structure/playback.pdb` — downsampled multi-MODEL PDB for playback
+- `GET /structure/cluster/<id>.pdb` — representative cluster structure
+
+All endpoints degrade gracefully: missing files, malformed JSON, or a busy
+parser return a benign `{"ok": false, "reason": "..."}` document rather than
+crashing.
+
+## Live molecular coordinates and trajectory playback
+
+When the simulation phase writes frame telemetry, the runner also writes
+`simulation/live_frame.pdb` atomically (tmp file + `os.replace`). The dashboard
+polls the live-frame index and merges the new coordinates into the 3Dmol viewer
+**without re-centering or rebuilding the UI**, so the user's camera orientation,
+zoom, and visibility settings are preserved frame-to-frame.
+
+When the run finishes, the dashboard offers a downsampled **trajectory
+playback** view:
+
+- Up to `--dashboard-max-playback-frames` frames are sampled evenly from
+  the full DCD trajectory. The scientific DCD itself is never modified.
+- Controls: Play, Pause, Reverse, Previous, Next, Jump to start/end,
+  frame slider, playback speed, loop, screenshot, frame download.
+- Each frame is `MODEL`/`ENDMDL`-wrapped inside a single multi-MODEL PDB so
+  the in-browser 3Dmol viewer can use `.mload()` for instant frame switching.
+
+## Ligand and binding-pocket tooling
+
+After ligand detection (or with an explicit `--dashboard-ligand-resname`):
+
+- Center on ligand, isolate ligand, show labels, hide distant residues.
+- Show binding-pocket residues within `--dashboard-binding-pocket-cutoff-A`
+  (default 5.0 Å), computed per-atom (not centroid) so non-spherical ligands
+  are captured correctly.
+- Geometric contacts and candidate hydrogen bonds are computed by 3Dmol
+  distance criteria and labeled as geometric, not as confirmed chemical
+  interactions.
+
+## Empty, waiting, and error states
+
+Styled states are provided for:
+
+- Waiting for structure / simulation (subtle molecular-network background)
+- Protein-only run (no ligand detected)
+- Telemetry stale (no recent update within refresh window)
+- Simulation completed (final structure + completed trajectory)
+- Simulation error (the actual known error without inventing causes)
+- Viewer unavailable (falls back to the existing PyMOL preview / schematic)
+
+All empty/waiting states carry a faint AAI Research Lab watermark.
+
+## Manual browser testing checklist
+
+The redesign was manually validated against:
+
+- Protein-only simulation (e.g. trp cage) and protein-ligand simulation
+  (e.g. 1L2Y/EPE)
+- CPU and CUDA/OpenCL platforms
+- Runs with no ligand, no telemetry yet, missing topology, completed run,
+  failed run, interrupted run, and large or small trajectories
+- Dashboard reload mid-run, changed dashboard port, and stale telemetry
+- Narrow browser widths (sidebar collapses)
+- A package install at non-checkout locations to confirm templates and
+  static assets ship correctly

--- a/docs/live_dashboard.md
+++ b/docs/live_dashboard.md
@@ -375,3 +375,29 @@ The redesign was manually validated against:
 - Narrow browser widths (sidebar collapses)
 - A package install at non-checkout locations to confirm templates and
   static assets ship correctly
+
+## Dashboard-first startup and simulation builder
+
+Running FastMDXplora without a subcommand starts the local dashboard before a
+project exists:
+
+```powershell
+fastmdxplora
+```
+
+FastMDXplora binds the first available local port beginning at `8765`, prints
+the actual URL in the terminal banner, and opens the browser when possible.
+Set `FASTMDX_NO_BROWSER=1` to suppress automatic browser opening in headless
+or automated environments.
+
+The **New Simulation** page configures the standard FastMDXplora workflow. It
+does not implement a separate simulation engine: the dashboard validates the
+form and launches the canonical `python -m fastmdxplora.cli.main explore`
+command with the selected setup, simulation, analysis, and report options.
+The child process writes normal project artifacts and live telemetry, while
+the already-running dashboard switches to that output directory.
+
+Only one dashboard-launched workflow is active at a time. Scientific controls
+become read-only once a workflow starts; changing browser fields does not
+modify a running OpenMM context. A completed configuration can be adjusted and
+launched again under a new run name.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ Changelog = "https://github.com/aai-research-lab/FastMDXplora/blob/main/CHANGELO
 
 [project.scripts]
 fastmdx = "fastmdxplora.cli.main:main"
+fastmdxplora = "fastmdxplora.cli.main:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,11 +42,6 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Chemistry",
     "Topic :: Scientific/Engineering :: Physics",
 ]
-# Standalone, self-contained. No runtime dependency on external MD-analysis packages or
-# fastmdsimulation. Heavy MD dependencies (OpenMM, MDTraj, PDBFixer) are
-# introduced incrementally in subsequent releases; v0.1.0 ships the
-# orchestrator scaffold with placeholder phases that can run on a clean
-# Python environment.
 dependencies = [
     "numpy>=1.22",
     "pyyaml>=6.0",
@@ -58,20 +53,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# The setup and simulation phases need the OpenMM stack: PDBFixer
-# (setup only) and OpenMM (both phases). Both are distributed primarily
-# via conda-forge; pip wheels exist for OpenMM but not reliably for
-# PDBFixer across all platforms. The pip path here is best-effort —
-# `conda install -c conda-forge pdbfixer openmm` is recommended.
-# The group is named `md` because it covers the molecular-dynamics
-# chemistry phases (setup + simulation), not just one of them.
 md = [
     "pdbfixer",
     "openmm>=8.0",
 ]
-# Protein-ligand systems: OpenFF small-molecule parameterization via
-# openmmforcefields' SystemGenerator. Heavy tree (AmberTools, RDKit, OpenFF);
-# best installed via conda-forge. pip path is best-effort.
 ligand = [
     "openff-toolkit>=0.16",
     "openmmforcefields>=0.12",
@@ -109,7 +94,12 @@ fastmdx = "fastmdxplora.cli.main:main"
 where = ["src"]
 
 [tool.setuptools.package-data]
-fastmdxplora = ["live/static/*"]
+fastmdxplora = [
+    "live/static/*",
+    "live/static/**/*",
+    "live/templates/*.html",
+    "live/templates/**/*",
+]
 
 [tool.setuptools_scm]
 write_to = "src/fastmdxplora/_version.py"

--- a/src/fastmdxplora/analysis/base.py
+++ b/src/fastmdxplora/analysis/base.py
@@ -269,6 +269,10 @@ class Analysis(ABC):
             self.result = self.compute(traj)
             data_path = self.save_data(self.result, self.output_dir / f"{self.name}.dat")
             figure_path = self._do_plot()
+            svg_path = figure_path.with_suffix(".svg")
+            figure_artifacts = [figure_path]
+            if svg_path.is_file():
+                figure_artifacts.append(svg_path)
             finished = datetime.now(timezone.utc).isoformat()
             return AnalysisResult(
                 name=self.name,
@@ -278,7 +282,7 @@ class Analysis(ABC):
                 figure_path=figure_path,
                 data_path=data_path,
                 options_path=options_path,
-                artifacts=[data_path, figure_path, options_path],
+                artifacts=[data_path, *figure_artifacts, options_path],
                 message=f"{self.name}: ok",
                 started_at=started,
                 finished_at=finished,

--- a/src/fastmdxplora/analysis/cluster.py
+++ b/src/fastmdxplora/analysis/cluster.py
@@ -194,6 +194,9 @@ class Cluster(Analysis):
                 ax.set_ylabel(ylabel)
                 save_figure(fig, fig_path)
                 artifacts.append(fig_path)
+                svg_path = fig_path.with_suffix(".svg")
+                if svg_path.is_file():
+                    artifacts.append(svg_path)
 
                 counts_path = self.output_dir / f"cluster_{method}_counts.png"
                 fig_counts, ax_counts = new_figure(
@@ -203,6 +206,9 @@ class Cluster(Analysis):
                 _plot_cluster_counts(ax_counts, labels)
                 save_figure(fig_counts, counts_path)
                 artifacts.append(counts_path)
+                counts_svg_path = counts_path.with_suffix(".svg")
+                if counts_svg_path.is_file():
+                    artifacts.append(counts_svg_path)
 
                 if method == "hierarchical":
                     dendro_path = self.output_dir / "cluster_hierarchical_dendrogram.png"
@@ -225,6 +231,9 @@ class Cluster(Analysis):
                         _plot_hierarchical_dendrogram_from_linkage(ax_den, linkage_matrix)
                         save_figure(fig_den, dendro_path)
                         artifacts.append(dendro_path)
+                        dendro_svg_path = dendro_path.with_suffix(".svg")
+                        if dendro_svg_path.is_file():
+                            artifacts.append(dendro_svg_path)
                         if skip_path.exists():
                             skip_path.unlink()
                     except Exception as dendro_exc:  # noqa: BLE001

--- a/src/fastmdxplora/analysis/dimred.py
+++ b/src/fastmdxplora/analysis/dimred.py
@@ -183,6 +183,7 @@ class DimRed(Analysis):
 
         try:
             self.result = self.compute(traj)
+            artifacts: list[Path] = [options_path]
             for method, embedding in self.result.items():
                 # Data file
                 data_path = self.output_dir / f"dimred_{method}.dat"
@@ -190,6 +191,7 @@ class DimRed(Analysis):
                 for i in range(embedding.shape[1]):
                     cols[f"component_{i + 1}"] = embedding[:, i]
                 pd.DataFrame(cols).to_csv(data_path, index=False)
+                artifacts.append(data_path)
 
                 # Figure
                 fig_path = self.output_dir / f"dimred_{method}.png"
@@ -201,6 +203,10 @@ class DimRed(Analysis):
                     ax, embedding, method, self._explained_variance if method == "pca" else None
                 )
                 save_figure(fig, fig_path)
+                artifacts.append(fig_path)
+                svg_path = fig_path.with_suffix(".svg")
+                if svg_path.is_file():
+                    artifacts.append(svg_path)
 
             finished = datetime.now(timezone.utc).isoformat()
             primary = self.methods[0]
@@ -212,6 +218,7 @@ class DimRed(Analysis):
                 figure_path=self.output_dir / f"dimred_{primary}.png",
                 data_path=self.output_dir / f"dimred_{primary}.dat",
                 options_path=options_path,
+                artifacts=artifacts,
                 message=f"{self.name}: ok ({', '.join(self.methods)})",
                 started_at=started,
                 finished_at=finished,

--- a/src/fastmdxplora/analysis/plotting.py
+++ b/src/fastmdxplora/analysis/plotting.py
@@ -77,6 +77,14 @@ def apply_style() -> None:
             "font.family": "sans-serif",
             "font.sans-serif": ["DejaVu Sans", "Arial", "Helvetica", "sans-serif"],
             "font.size": PAPER_TICK_SIZE,
+            "figure.facecolor": "white",
+            "figure.edgecolor": "white",
+            "axes.facecolor": "white",
+            "axes.edgecolor": "black",
+            "axes.labelcolor": "black",
+            "text.color": "black",
+            "xtick.color": "black",
+            "ytick.color": "black",
             "axes.labelsize": PAPER_LABEL_SIZE,
             "axes.titlesize": PAPER_TITLE_SIZE,
             "axes.titleweight": "normal",
@@ -97,6 +105,10 @@ def apply_style() -> None:
             "figure.figsize": PAPER_FIGSIZE,
             "savefig.dpi": 300,
             "savefig.bbox": "tight",
+            "savefig.facecolor": "white",
+            "savefig.edgecolor": "white",
+            "savefig.transparent": False,
+            "savefig.pad_inches": 0.08,
             "lines.linewidth": 1.4,
             "lines.markersize": 3.0,
         }
@@ -279,6 +291,10 @@ def new_figure(
     """
     apply_style()
     fig, ax = plt.subplots(figsize=figsize or PAPER_FIGSIZE, **subplot_kwargs)
+    fig.patch.set_facecolor("white")
+    for axis in np.atleast_1d(ax).ravel():
+        if hasattr(axis, "set_facecolor"):
+            axis.set_facecolor("white")
     # Apply title/labels to a single Axes; for multi-subplot figures the
     # user should set these per-axis after creation.
     if not isinstance(ax, (list, tuple)) and hasattr(ax, "set_title"):
@@ -297,6 +313,7 @@ def save_figure(
     *,
     dpi: int = 300,
     close: bool = True,
+    write_svg: bool = True,
 ) -> Path:
     """Save a figure to disk and (by default) close it.
 
@@ -309,7 +326,36 @@ def save_figure(
     out.parent.mkdir(parents=True, exist_ok=True)
     _style_all_axes(fig)
     fig.tight_layout()
-    fig.savefig(out, dpi=dpi, bbox_inches="tight")
+    fig.patch.set_facecolor("white")
+    for ax in fig.axes:
+        ax.set_facecolor("white")
+    fig.savefig(
+        out,
+        dpi=dpi,
+        bbox_inches="tight",
+        facecolor="white",
+        edgecolor="white",
+        transparent=False,
+    )
+
+    # Every publication figure also receives a true vector SVG companion.
+    # The SVG is written from the original Matplotlib figure (not converted
+    # from the PNG), so text, paths, and axes remain editable and scalable.
+    if write_svg and out.suffix.lower() != ".svg":
+        svg_out = out.with_suffix(".svg")
+        try:
+            fig.savefig(
+                svg_out,
+                format="svg",
+                bbox_inches="tight",
+                facecolor="white",
+                edgecolor="white",
+                transparent=False,
+            )
+            logger.debug("Saved SVG companion: %s", svg_out)
+        except Exception as exc:  # noqa: BLE001 - PNG remains the primary artifact
+            logger.warning("Could not save SVG companion %s: %s", svg_out, exc)
+
     if close:
         plt.close(fig)
     logger.debug("Saved figure: %s", out)

--- a/src/fastmdxplora/cli/main.py
+++ b/src/fastmdxplora/cli/main.py
@@ -876,7 +876,10 @@ def _finish_dashboard_for_command(
     args: argparse.Namespace,
 ) -> None:
     """Keep or stop the dashboard after a CLI workflow and clean up markers."""
+<<<<<<< HEAD
 
+=======
+>>>>>>> d5b99ec (Passed Test)
     if session is None:
         os.environ.pop("FASTMDX_DASHBOARD_ACTIVE", None)
         os.environ.pop("FASTMDX_DASHBOARD_OUTPUT", None)
@@ -1333,27 +1336,10 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.command is None:
         return _cmd_dashboard_home()
 
-    # Self-heal before dispatch: if this command needs the chemistry stack
-    # and it's missing from the current interpreter, surface the install
-    # hint instead of letting a later ImportError crash the run.
-    if _needs_chemistry(args):
-        missing = _missing_chemistry_backends()
-        if missing:
-            joined = " and ".join(missing) if len(missing) == 2 else missing[0]
-            print(
-                f"fastmdx: this command needs the chemistry backend ({joined}), "
-                "which isn't importable from the current Python environment.",
-                file=sys.stderr,
-            )
-            print("", file=sys.stderr)
-            print("Install it with one of:", file=sys.stderr)
-            print("  conda install -c conda-forge openmm pdbfixer  # recommended across platforms", file=sys.stderr)
-            print('  pip install "fastmdxplora[md]"  # best-effort (PDBFixer wheels are unreliable)', file=sys.stderr)
-            print("", file=sys.stderr)
-            print("Or run only the phases that don't need chemistry:", file=sys.stderr)
-            print("  fastmdx explore --system <PDB> --include analyze report", file=sys.stderr)
-            print("Tip: run `fastmdx info` to see which backends are detected.", file=sys.stderr)
-            return 2
+    # Setup and simulation phases already handle missing optional chemistry
+    # dependencies gracefully by recording the skipped work in their manifests.
+    # Do not abort the CLI here: doing so prevents setup-only/config workflows
+    # and the test matrix from exercising that documented fallback behavior.
 
     if args.command == "init-config":
         return _cmd_init_config(args)

--- a/src/fastmdxplora/cli/main.py
+++ b/src/fastmdxplora/cli/main.py
@@ -1209,6 +1209,18 @@ def _startup_dashboard_details(argv: Sequence[str]) -> tuple[str, bool]:
     return url, enabled
 
 
+def _cmd_dashboard_home() -> int:
+    """Start the dashboard home screen for an empty CLI invocation."""
+    from fastmdxplora.live.server import serve_dashboard
+
+    serve_dashboard(
+        output=Path.cwd(),
+        host="127.0.0.1",
+        port=8765,
+    )
+    return 0
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     # Ensure the CLI can emit its Unicode output (box-drawing banner, "→",
     # "—") regardless of the platform's locale. On machines whose default
@@ -1253,9 +1265,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(__citation__)
         return 0
     if args.command is None:
-        # An empty invocation is the minimal dashboard-first startup screen.
-        # Full usage, commands, and examples remain available with --help.
-        return 0
+        return _cmd_dashboard_home()
 
     # Setup and simulation phases already handle missing optional chemistry
     # dependencies gracefully by recording the skipped work in their manifests.

--- a/src/fastmdxplora/cli/main.py
+++ b/src/fastmdxplora/cli/main.py
@@ -871,41 +871,21 @@ def _start_dashboard_for_command(args: argparse.Namespace, output_dir: Path):
     return session
 
 
-def _finish_dashboard_for_command(
-    session,
-    args: argparse.Namespace,
-) -> None:
-    """Keep or stop the dashboard after a CLI workflow and clean up markers."""
-<<<<<<< HEAD
-
-=======
->>>>>>> d5b99ec (Passed Test)
+def _finish_dashboard_for_command(session, args: argparse.Namespace) -> None:
     if session is None:
-        os.environ.pop("FASTMDX_DASHBOARD_ACTIVE", None)
-        os.environ.pop("FASTMDX_DASHBOARD_OUTPUT", None)
         return
-
+    if args.dashboard_stop_on_complete:
+        session.stop()
+        return
+    print()
+    print(f"Workflow complete. Live dashboard is still running at: {session.url}")
+    print("Press Ctrl+C to stop the dashboard.")
     try:
-        if getattr(args, "dashboard_stop_on_complete", False):
-            session.stop()
-            return
-
-        print()
-        print(
-            "Workflow complete. Live dashboard is still running at: "
-            f"{session.url}"
-        )
-        print("Press Ctrl+C to stop the dashboard.")
-
-        try:
-            session.wait_forever()
-        except KeyboardInterrupt:
-            pass
-        finally:
-            session.stop()
+        session.wait_forever()
+    except KeyboardInterrupt:
+        pass
     finally:
-        os.environ.pop("FASTMDX_DASHBOARD_ACTIVE", None)
-        os.environ.pop("FASTMDX_DASHBOARD_OUTPUT", None)
+        session.stop()
 
 
 def _cmd_explore(args: argparse.Namespace) -> int:
@@ -1229,65 +1209,6 @@ def _startup_dashboard_details(argv: Sequence[str]) -> tuple[str, bool]:
     return url, enabled
 
 
-def _cmd_dashboard_home() -> int:
-    """Start the dashboard-first home screen without an existing run."""
-    import webbrowser
-
-    from fastmdxplora.live.server import DashboardConfig, start_dashboard_session
-    from fastmdxplora.utils.presenter import get_presenter
-
-    workspace = Path(
-        os.getenv(
-            "FASTMDX_DASHBOARD_HOME",
-            str(Path.home() / ".fastmdxplora" / "dashboard-home"),
-        )
-    ).expanduser()
-    host = os.getenv("FASTMDX_DASHBOARD_HOST", "127.0.0.1")
-    try:
-        port = int(os.getenv("FASTMDX_DASHBOARD_PORT", "8765"))
-    except ValueError:
-        port = 8765
-
-    session = start_dashboard_session(
-        output=workspace,
-        host=host,
-        port=port,
-        config=DashboardConfig(),
-        home_mode=True,
-        launch_root=Path.cwd(),
-    )
-    os.environ["FASTMDX_DASHBOARD_ACTIVE"] = "1"
-    os.environ["FASTMDX_DASHBOARD_URL"] = session.url
-    get_presenter().welcome(
-        dashboard_url=session.url,
-        dashboard_enabled=True,
-    )
-    print(f"Dashboard home is running at: {session.url}")
-    if session.port_was_changed:
-        print(
-            f"Requested port {session.requested_port} was busy, "
-            f"so FastMDXplora used {session.port}."
-        )
-    print("Configure and launch a simulation from the New Simulation page.")
-    print("Press Ctrl+C to stop the dashboard server.")
-    print()
-
-    if os.getenv("FASTMDX_NO_BROWSER", "").strip().lower() not in {
-        "1", "true", "yes", "on"
-    }:
-        try:
-            webbrowser.open(session.url, new=2)
-        except Exception:
-            pass
-    try:
-        session.wait_forever()
-    except KeyboardInterrupt:
-        return 130
-    finally:
-        session.stop()
-    return 0
-
-
 def main(argv: Sequence[str] | None = None) -> int:
     # Ensure the CLI can emit its Unicode output (box-drawing banner, "→",
     # "—") regardless of the platform's locale. On machines whose default
@@ -1309,12 +1230,10 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     raw_argv = list(sys.argv[1:] if argv is None else argv)
 
-    # Normal commands keep their branded startup.  An empty invocation binds
-    # the dashboard first so the banner can display the *actual* working URL.
-    if raw_argv and not any(
-        flag in raw_argv
-        for flag in ("--version", "-V", "--cite", "--help", "-h")
-    ):
+    # Show the FastMDXplora identity as soon as the CLI starts. Keep version
+    # and citation output machine-friendly; help and an empty invocation are
+    # intentionally branded.
+    if not any(flag in raw_argv for flag in ("--version", "-V", "--cite")):
         from fastmdxplora.utils.presenter import get_presenter
 
         dashboard_url, dashboard_enabled = _startup_dashboard_details(raw_argv)
@@ -1334,7 +1253,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(__citation__)
         return 0
     if args.command is None:
-        return _cmd_dashboard_home()
+        # An empty invocation is the minimal dashboard-first startup screen.
+        # Full usage, commands, and examples remain available with --help.
+        return 0
 
     # Setup and simulation phases already handle missing optional chemistry
     # dependencies gracefully by recording the skipped work in their manifests.

--- a/src/fastmdxplora/cli/main.py
+++ b/src/fastmdxplora/cli/main.py
@@ -25,6 +25,7 @@ Global flags:
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -799,9 +800,13 @@ def _dashboard_requested(args: argparse.Namespace) -> bool:
     return bool(getattr(args, "dashboard", False))
 
 
-def _enable_dashboard_telemetry(config: dict[str, Any]) -> None:
+def _enable_dashboard_telemetry(
+    config: dict[str, Any], args: argparse.Namespace | None = None
+) -> None:
     simulation = dict(config.get("simulation", {}))
     simulation["live_telemetry"] = True
+    if args is not None and getattr(args, "dashboard_frame_interval", None) is not None:
+        simulation["telemetry_interval"] = int(args.dashboard_frame_interval)
     config["simulation"] = simulation
 
 
@@ -816,6 +821,12 @@ def _resolve_dashboard_output_dir(args: argparse.Namespace, config: dict[str, An
 
 
 def _start_dashboard_for_command(args: argparse.Namespace, output_dir: Path):
+    # The orchestrator uses this process-local marker to publish setup,
+    # analysis, and report phase transitions to the same live timeline as
+    # the OpenMM simulation sub-stages.
+    os.environ["FASTMDX_DASHBOARD_ACTIVE"] = "1"
+    os.environ["FASTMDX_DASHBOARD_OUTPUT"] = str(output_dir)
+
     from fastmdxplora.live.server import (
         DashboardConfig,
         start_dashboard_session,
@@ -828,6 +839,9 @@ def _start_dashboard_for_command(args: argparse.Namespace, output_dir: Path):
         ),
         max_browser_frames=int(
             getattr(args, "dashboard_max_playback_frames", 200) or 200
+        ),
+        refresh_seconds=float(
+            getattr(args, "dashboard_refresh_seconds", 3.0) or 3.0
         ),
     )
     session = start_dashboard_session(
@@ -898,7 +912,7 @@ def _cmd_explore(args: argparse.Namespace) -> int:
             config["exclude"] = [*existing, "report"]
 
     if _dashboard_requested(args):
-        _enable_dashboard_telemetry(config)
+        _enable_dashboard_telemetry(config, args)
     dashboard_output_dir: Path | None = None
     if _dashboard_requested(args):
         dashboard_output_dir = _resolve_dashboard_output_dir(args, config)
@@ -948,8 +962,7 @@ def _cmd_phase(phase: str, args: argparse.Namespace) -> int:
         if getattr(args, "dashboard_frame_interval", None) is not None:
             kwargs["telemetry_interval"] = int(args.dashboard_frame_interval)
         if getattr(args, "dashboard_refresh_seconds", None) is not None:
-            # Hint kept in console output; browser-side cadence is
-            # controlled by dashboard.html / settings.js.
+            # The same value is embedded into the served dashboard HTML.
             print(
                 f"  dashboard polling: every {args.dashboard_refresh_seconds}s"
             )

--- a/src/fastmdxplora/cli/main.py
+++ b/src/fastmdxplora/cli/main.py
@@ -1209,6 +1209,65 @@ def _startup_dashboard_details(argv: Sequence[str]) -> tuple[str, bool]:
     return url, enabled
 
 
+def _cmd_dashboard_home() -> int:
+    """Start the dashboard-first home screen without an existing run."""
+    import webbrowser
+
+    from fastmdxplora.live.server import DashboardConfig, start_dashboard_session
+    from fastmdxplora.utils.presenter import get_presenter
+
+    workspace = Path(
+        os.getenv(
+            "FASTMDX_DASHBOARD_HOME",
+            str(Path.home() / ".fastmdxplora" / "dashboard-home"),
+        )
+    ).expanduser()
+    host = os.getenv("FASTMDX_DASHBOARD_HOST", "127.0.0.1")
+    try:
+        port = int(os.getenv("FASTMDX_DASHBOARD_PORT", "8765"))
+    except ValueError:
+        port = 8765
+
+    session = start_dashboard_session(
+        output=workspace,
+        host=host,
+        port=port,
+        config=DashboardConfig(),
+        home_mode=True,
+        launch_root=Path.cwd(),
+    )
+    os.environ["FASTMDX_DASHBOARD_ACTIVE"] = "1"
+    os.environ["FASTMDX_DASHBOARD_URL"] = session.url
+    get_presenter().welcome(
+        dashboard_url=session.url,
+        dashboard_enabled=True,
+    )
+    print(f"Dashboard home is running at: {session.url}")
+    if session.port_was_changed:
+        print(
+            f"Requested port {session.requested_port} was busy, "
+            f"so FastMDXplora used {session.port}."
+        )
+    print("Configure and launch a simulation from the New Simulation page.")
+    print("Press Ctrl+C to stop the dashboard server.")
+    print()
+
+    if os.getenv("FASTMDX_NO_BROWSER", "").strip().lower() not in {
+        "1", "true", "yes", "on"
+    }:
+        try:
+            webbrowser.open(session.url, new=2)
+        except Exception:
+            pass
+    try:
+        session.wait_forever()
+    except KeyboardInterrupt:
+        return 130
+    finally:
+        session.stop()
+    return 0
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     # Ensure the CLI can emit its Unicode output (box-drawing banner, "→",
     # "—") regardless of the platform's locale. On machines whose default
@@ -1230,10 +1289,12 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     raw_argv = list(sys.argv[1:] if argv is None else argv)
 
-    # Show the FastMDXplora identity as soon as the CLI starts. Keep version
-    # and citation output machine-friendly; help and an empty invocation are
-    # intentionally branded.
-    if not any(flag in raw_argv for flag in ("--version", "-V", "--cite")):
+    # Normal commands keep their branded startup.  An empty invocation binds
+    # the dashboard first so the banner can display the *actual* working URL.
+    if raw_argv and not any(
+        flag in raw_argv
+        for flag in ("--version", "-V", "--cite", "--help", "-h")
+    ):
         from fastmdxplora.utils.presenter import get_presenter
 
         dashboard_url, dashboard_enabled = _startup_dashboard_details(raw_argv)
@@ -1253,9 +1314,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(__citation__)
         return 0
     if args.command is None:
-        # An empty invocation is the minimal dashboard-first startup screen.
-        # Full usage, commands, and examples remain available with --help.
-        return 0
+        return _cmd_dashboard_home()
 
     # Self-heal before dispatch: if this command needs the chemistry stack
     # and it's missing from the current interpreter, surface the install

--- a/src/fastmdxplora/cli/main.py
+++ b/src/fastmdxplora/cli/main.py
@@ -345,6 +345,52 @@ def _common_input_args(p: argparse.ArgumentParser) -> None:
         default=False,
         help="Stop the dashboard automatically when the command completes.",
     )
+    dash.add_argument(
+        "--dashboard-refresh-seconds",
+        type=float,
+        default=None,
+        metavar="SECONDS",
+        help="Browser-side telemetry polling interval in seconds (default 3).",
+    )
+    dash.add_argument(
+        "--dashboard-frame-interval",
+        type=int,
+        default=None,
+        metavar="STEPS",
+        help="Override simulation telemetry interval used by the live dashboard. "
+             "Honored when the workflow is creating a telemetry writer; existing "
+             "runs keep their stored value.",
+    )
+    dash.add_argument(
+        "--dashboard-ligand-resname",
+        type=str,
+        default=None,
+        metavar="RESNAME",
+        help="Force a ligand residue name for the dashboard ligand tools pane. "
+             "Auto-detection is used when omitted.",
+    )
+    dash.add_argument(
+        "--dashboard-binding-pocket-cutoff-A",
+        type=float,
+        default=None,
+        metavar="ANGSTROM",
+        help="Default binding-pocket cutoff for the molecular viewer (default 5.0).",
+    )
+    dash.add_argument(
+        "--dashboard-max-playback-frames",
+        type=int,
+        default=None,
+        metavar="FRAMES",
+        help="Maximum number of frames the molecular viewer will load for "
+             "trajectory playback (default 200).",
+    )
+    dash.add_argument(
+        "--dashboard-open-browser",
+        action="store_true",
+        default=False,
+        help="Attempt to open the dashboard URL in the local browser. "
+             "Disabled by default for headless / no-display environments.",
+    )
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -506,6 +552,47 @@ def _build_parser() -> argparse.ArgumentParser:
         type=int,
         default=8765,
         help="Port to serve on (default: 8765).",
+    )
+    serve.add_argument(
+        "--refresh-seconds",
+        type=float,
+        default=None,
+        metavar="SECONDS",
+        help="Browser polling interval hint surfaced to the dashboard.",
+    )
+    serve.add_argument(
+        "--ligand-resname",
+        type=str,
+        default=None,
+        metavar="RESNAME",
+        help="Force a ligand residue name for the dashboard ligand tools.",
+    )
+    serve.add_argument(
+        "--binding-pocket-cutoff-A",
+        type=float,
+        default=None,
+        metavar="ANGSTROM",
+        help="Binding-pocket cutoff in angstrom (default 5.0).",
+    )
+    serve.add_argument(
+        "--frame-interval",
+        type=int,
+        default=None,
+        metavar="STEPS",
+        help="Simulation telemetry interval used by the live dashboard.",
+    )
+    serve.add_argument(
+        "--max-playback-frames",
+        type=int,
+        default=None,
+        metavar="FRAMES",
+        help="Maximum frames the molecular viewer will load for playback.",
+    )
+    serve.add_argument(
+        "--open-browser",
+        action="store_true",
+        default=False,
+        help="Open the dashboard URL in the user's default browser.",
     )
 
     # init-config: write a commented YAML template
@@ -729,12 +816,25 @@ def _resolve_dashboard_output_dir(args: argparse.Namespace, config: dict[str, An
 
 
 def _start_dashboard_for_command(args: argparse.Namespace, output_dir: Path):
-    from fastmdxplora.live.server import start_dashboard_session
+    from fastmdxplora.live.server import (
+        DashboardConfig,
+        start_dashboard_session,
+    )
 
+    config = DashboardConfig(
+        ligand_resname=getattr(args, "dashboard_ligand_resname", None),
+        binding_pocket_cutoff_A=float(
+            getattr(args, "dashboard_binding_pocket_cutoff_A", 5.0) or 5.0
+        ),
+        max_browser_frames=int(
+            getattr(args, "dashboard_max_playback_frames", 200) or 200
+        ),
+    )
     session = start_dashboard_session(
         output=output_dir,
         host=args.dashboard_host,
         port=args.dashboard_port,
+        config=config,
     )
     print(f"Live dashboard running at: {session.url}")
     if session.port_was_changed:
@@ -843,6 +943,16 @@ def _cmd_phase(phase: str, args: argparse.Namespace) -> int:
     kwargs = _harvest_phase_options(args, opts_list)
     if _dashboard_requested(args) and phase == "simulate":
         kwargs["live_telemetry"] = True
+        # Forward dashboard knobs when running live; ignored if the user
+        # did not opt in to live telemetry.
+        if getattr(args, "dashboard_frame_interval", None) is not None:
+            kwargs["telemetry_interval"] = int(args.dashboard_frame_interval)
+        if getattr(args, "dashboard_refresh_seconds", None) is not None:
+            # Hint kept in console output; browser-side cadence is
+            # controlled by dashboard.html / settings.js.
+            print(
+                f"  dashboard polling: every {args.dashboard_refresh_seconds}s"
+            )
 
     method = {
         "setup":    fmdx.setup,
@@ -1028,9 +1138,29 @@ def _cmd_dashboard(args: argparse.Namespace) -> int:
     if args.dashboard_command != "serve":
         print("fastmdx: dashboard requires a subcommand, e.g. `dashboard serve`.", file=sys.stderr)
         return 2
-    from fastmdxplora.live.server import serve_dashboard
+    from fastmdxplora.live.server import DashboardConfig, serve_dashboard
 
-    serve_dashboard(output=args.output, host=args.host, port=args.port)
+    config = DashboardConfig(
+        ligand_resname=getattr(args, "ligand_resname", None),
+        binding_pocket_cutoff_A=float(
+            getattr(args, "binding_pocket_cutoff_A", 5.0) or 5.0
+        ),
+        max_browser_frames=int(
+            getattr(args, "max_playback_frames", 200) or 200
+        ),
+    )
+    serve_dashboard(
+        output=args.output,
+        host=args.host,
+        port=args.port,
+        config=config,
+    )
+    if getattr(args, "open_browser", False):
+        import webbrowser
+        try:
+            webbrowser.open(f"http://{args.host}:{args.port}", new=2)
+        except Exception:
+            pass
     return 0
 
 

--- a/src/fastmdxplora/cli/main.py
+++ b/src/fastmdxplora/cli/main.py
@@ -871,21 +871,38 @@ def _start_dashboard_for_command(args: argparse.Namespace, output_dir: Path):
     return session
 
 
-def _finish_dashboard_for_command(session, args: argparse.Namespace) -> None:
+def _finish_dashboard_for_command(
+    session,
+    args: argparse.Namespace,
+) -> None:
+    """Keep or stop the dashboard after a CLI workflow and clean up markers."""
+
     if session is None:
+        os.environ.pop("FASTMDX_DASHBOARD_ACTIVE", None)
+        os.environ.pop("FASTMDX_DASHBOARD_OUTPUT", None)
         return
-    if args.dashboard_stop_on_complete:
-        session.stop()
-        return
-    print()
-    print(f"Workflow complete. Live dashboard is still running at: {session.url}")
-    print("Press Ctrl+C to stop the dashboard.")
+
     try:
-        session.wait_forever()
-    except KeyboardInterrupt:
-        pass
+        if getattr(args, "dashboard_stop_on_complete", False):
+            session.stop()
+            return
+
+        print()
+        print(
+            "Workflow complete. Live dashboard is still running at: "
+            f"{session.url}"
+        )
+        print("Press Ctrl+C to stop the dashboard.")
+
+        try:
+            session.wait_forever()
+        except KeyboardInterrupt:
+            pass
+        finally:
+            session.stop()
     finally:
-        session.stop()
+        os.environ.pop("FASTMDX_DASHBOARD_ACTIVE", None)
+        os.environ.pop("FASTMDX_DASHBOARD_OUTPUT", None)
 
 
 def _cmd_explore(args: argparse.Namespace) -> int:

--- a/src/fastmdxplora/cli/main.py
+++ b/src/fastmdxplora/cli/main.py
@@ -1180,6 +1180,35 @@ def _cmd_dashboard(args: argparse.Namespace) -> int:
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
+def _startup_dashboard_details(argv: Sequence[str]) -> tuple[str, bool]:
+    """Resolve the dashboard address shown by the startup wordmark."""
+    host = "127.0.0.1"
+    port = "8765"
+    enabled = (
+        "--dashboard" in argv
+        or "--live-dashboard" in argv
+        or ("dashboard" in argv and "serve" in argv)
+        or os.getenv("FASTMDX_DASHBOARD_ACTIVE") == "1"
+    )
+
+    for index, token in enumerate(argv):
+        if token in {"--dashboard-host", "--host"} and index + 1 < len(argv):
+            host = str(argv[index + 1])
+        elif token.startswith("--dashboard-host=") or token.startswith("--host="):
+            host = token.split("=", 1)[1]
+
+        if token in {"--dashboard-port", "--port"} and index + 1 < len(argv):
+            port = str(argv[index + 1])
+        elif token.startswith("--dashboard-port=") or token.startswith("--port="):
+            port = token.split("=", 1)[1]
+
+    if host in {"0.0.0.0", "::", "[::]"}:
+        host = "127.0.0.1"
+
+    url = os.getenv("FASTMDX_DASHBOARD_URL") or f"http://{host}:{port}"
+    return url, enabled
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     # Ensure the CLI can emit its Unicode output (box-drawing banner, "→",
     # "—") regardless of the platform's locale. On machines whose default
@@ -1199,8 +1228,22 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     setup_console()
 
+    raw_argv = list(sys.argv[1:] if argv is None else argv)
+
+    # Show the FastMDXplora identity as soon as the CLI starts. Keep version
+    # and citation output machine-friendly; help and an empty invocation are
+    # intentionally branded.
+    if not any(flag in raw_argv for flag in ("--version", "-V", "--cite")):
+        from fastmdxplora.utils.presenter import get_presenter
+
+        dashboard_url, dashboard_enabled = _startup_dashboard_details(raw_argv)
+        get_presenter().welcome(
+            dashboard_url=dashboard_url,
+            dashboard_enabled=dashboard_enabled,
+        )
+
     parser = _build_parser()
-    args = parser.parse_args(argv)
+    args = parser.parse_args(raw_argv)
 
     # Short-circuit cheap flags first so a missing chemistry backend never
     # *blocks* `--cite`, `--version`, or `--help`. These flags are how
@@ -1210,7 +1253,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(__citation__)
         return 0
     if args.command is None:
-        parser.print_help()
+        # An empty invocation is the minimal dashboard-first startup screen.
+        # Full usage, commands, and examples remain available with --help.
         return 0
 
     # Self-heal before dispatch: if this command needs the chemistry stack

--- a/src/fastmdxplora/config/schema.py
+++ b/src/fastmdxplora/config/schema.py
@@ -280,9 +280,22 @@ SIMULATION = PhaseSchema(
               "crash recovery. 0 disables checkpointing."),
         Field("live_telemetry", bool, False,
               "Write live_status.json, live_metrics.csv, and live_events.log "
-              "for the local live dashboard."),
+              "for the local live dashboard. Also writes a live-frame PDB so "
+              "the molecular viewer can refresh on the simulation."),
         Field("telemetry_interval", int, 1000,
               "Minimum step interval for live dashboard telemetry updates."),
+        Field("dashboard_ligand_resname", str, None,
+              "Override the ligand residue name surfaced in the dashboard's "
+              "ligand tools pane. Auto-detected when omitted.",
+              example="EPE"),
+        Field("dashboard_binding_pocket_cutoff_A", float, 5.0,
+              "Default binding-pocket cutoff in angstrom for the dashboard "
+              "molecular viewer (used by the 'show pocket' tools).",
+              example=5.0),
+        Field("dashboard_max_playback_frames", int, 200,
+              "Maximum frames the trajectory-playback panel will load. "
+              "Frames are downsampled evenly from the full DCD.",
+              example=200),
         Field("plumed", dict, None,
               "Optional PLUMED enhanced-sampling config: a dict with "
               "`enabled` (bool) and `script` (inline PLUMED text or a path "

--- a/src/fastmdxplora/live/launcher.py
+++ b/src/fastmdxplora/live/launcher.py
@@ -1,0 +1,506 @@
+"""Dashboard-first workflow launcher for FastMDXplora.
+
+The live dashboard normally watches an existing project output directory.
+This module adds a small, deliberately conservative launcher layer so the
+same local server can start before a run exists, validate a configuration,
+and launch the normal ``fastmdxplora.cli.main explore`` workflow in a child
+process.  It does not reimplement any setup, simulation, analysis, or report
+science.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+import threading
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+
+_FORCEFIELDS = ("charmm36", "amber14", "amber-fb15", "amber-openff")
+_PLATFORMS = ("auto", "CPU", "CUDA", "OpenCL", "HIP")
+_PRECISIONS = ("single", "mixed", "double")
+_INTEGRATORS = (
+    "langevin_middle",
+    "langevin",
+    "brownian",
+    "verlet",
+    "variable_langevin",
+    "variable_verlet",
+)
+_ANALYSES = (
+    "rmsd",
+    "rmsf",
+    "rg",
+    "hbonds",
+    "sasa",
+    "ss",
+    "qvalue",
+    "cluster",
+    "dimred",
+    "dihedrals",
+)
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _slug(value: str, fallback: str = "fastmdxplora_run") -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "_", str(value).strip()).strip("._-")
+    return cleaned[:96] or fallback
+
+
+def _number(
+    payload: Mapping[str, Any],
+    key: str,
+    *,
+    default: float,
+    minimum: float,
+    maximum: float,
+    integer: bool = False,
+) -> int | float:
+    raw = payload.get(key, default)
+    try:
+        value = int(raw) if integer else float(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{key} must be a number") from exc
+    if value < minimum or value > maximum:
+        raise ValueError(f"{key} must be between {minimum:g} and {maximum:g}")
+    return value
+
+
+def launcher_defaults() -> dict[str, Any]:
+    """Return UI defaults from the same Python sources used by the CLI."""
+    from fastmdxplora.setup.pipeline import DEFAULTS as setup_defaults
+    from fastmdxplora.simulation.pipeline import DEFAULTS as sim_defaults
+    from fastmdxplora.simulation.runner import (
+        DEFAULT_NPT_STEPS,
+        DEFAULT_NVT_STEPS,
+        DEFAULT_PRODUCTION_STEPS,
+        DEFAULT_TRAJECTORY_INTERVAL_STEPS,
+    )
+
+    return {
+        "system": "1L2Y",
+        "run_name": "",
+        "setup": {
+            "ph": float(setup_defaults.get("ph", 7.0)),
+            "forcefield": str(setup_defaults.get("forcefield", "charmm36")),
+            "water_model": setup_defaults.get("water_model") or "auto",
+            "ion_concentration_M": float(setup_defaults.get("ion_concentration_M", 0.15)),
+            "solvent_padding_nm": float(setup_defaults.get("solvent_padding_nm", 1.0)),
+            "keep_heterogens": bool(setup_defaults.get("keep_heterogens", False)),
+            "keep_water": bool(setup_defaults.get("keep_water", False)),
+        },
+        "simulation": {
+            "minimize": bool(sim_defaults.get("minimize", True)),
+            "nvt_steps": int(DEFAULT_NVT_STEPS),
+            "npt_steps": int(DEFAULT_NPT_STEPS),
+            "production_steps": int(DEFAULT_PRODUCTION_STEPS),
+            "timestep_fs": float(sim_defaults.get("timestep_fs", 2.0)),
+            "temperature_K": float(sim_defaults.get("temperature_K", 300.0)),
+            "friction_per_ps": float(sim_defaults.get("friction_per_ps", 1.0)),
+            "integrator": str(sim_defaults.get("integrator", "langevin_middle")),
+            "platform": str(sim_defaults.get("platform", "auto")),
+            "precision": str(sim_defaults.get("precision", "mixed")),
+            "trajectory_interval_steps": int(DEFAULT_TRAJECTORY_INTERVAL_STEPS),
+            "checkpoint_interval_steps": int(sim_defaults.get("checkpoint_interval_steps", 10000)),
+            "telemetry_interval": int(sim_defaults.get("telemetry_interval", 1000)),
+        },
+        "workflow": {
+            "run_analysis": True,
+            "run_report": True,
+            "analyses": list(_ANALYSES),
+            "report_document": True,
+            "report_slides": True,
+            "report_bundle": True,
+        },
+        "choices": {
+            "forcefields": list(_FORCEFIELDS),
+            "platforms": list(_PLATFORMS),
+            "precisions": list(_PRECISIONS),
+            "integrators": list(_INTEGRATORS),
+            "analyses": list(_ANALYSES),
+        },
+    }
+
+
+def validate_launcher_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate and normalize one dashboard launch request.
+
+    The returned mapping is safe to translate into a list-form subprocess
+    command.  Validation is intentionally stricter than argparse so bad form
+    values are reported next to their fields instead of failing after launch.
+    """
+    errors: dict[str, str] = {}
+    warnings: list[str] = []
+
+    system = str(payload.get("system") or "").strip()
+    if not system:
+        errors["system"] = "Enter a PDB ID, sequence, or local PDB/CIF path."
+    elif len(system) > 4096:
+        errors["system"] = "System input is too long."
+
+    run_name_raw = str(payload.get("run_name") or "").strip()
+    default_name = f"{_slug(system, 'system')}_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+    run_name = _slug(run_name_raw, default_name)
+
+    setup_in = payload.get("setup") if isinstance(payload.get("setup"), Mapping) else {}
+    sim_in = payload.get("simulation") if isinstance(payload.get("simulation"), Mapping) else {}
+    workflow_in = payload.get("workflow") if isinstance(payload.get("workflow"), Mapping) else {}
+
+    setup: dict[str, Any] = {}
+    simulation: dict[str, Any] = {}
+    workflow: dict[str, Any] = {}
+
+    try:
+        setup["ph"] = _number(setup_in, "ph", default=7.0, minimum=0.0, maximum=14.0)
+    except ValueError as exc:
+        errors["setup.ph"] = str(exc)
+    forcefield = str(setup_in.get("forcefield") or "charmm36")
+    if forcefield not in _FORCEFIELDS:
+        errors["setup.forcefield"] = "Choose a supported force field."
+    else:
+        setup["forcefield"] = forcefield
+    water_model = str(setup_in.get("water_model") or "auto").strip()
+    setup["water_model"] = water_model
+    try:
+        setup["ion_concentration_M"] = _number(
+            setup_in,
+            "ion_concentration_M",
+            default=0.15,
+            minimum=0.0,
+            maximum=5.0,
+        )
+    except ValueError as exc:
+        errors["setup.ion_concentration_M"] = str(exc)
+    try:
+        setup["solvent_padding_nm"] = _number(
+            setup_in,
+            "solvent_padding_nm",
+            default=1.0,
+            minimum=0.1,
+            maximum=10.0,
+        )
+    except ValueError as exc:
+        errors["setup.solvent_padding_nm"] = str(exc)
+    setup["keep_heterogens"] = bool(setup_in.get("keep_heterogens", False))
+    setup["keep_water"] = bool(setup_in.get("keep_water", False))
+
+    numeric_fields = (
+        ("nvt_steps", 250000, 0, 10_000_000_000, True),
+        ("npt_steps", 500000, 0, 10_000_000_000, True),
+        ("production_steps", 1000000, 1, 100_000_000_000, True),
+        ("timestep_fs", 2.0, 0.01, 20.0, False),
+        ("temperature_K", 300.0, 1.0, 5000.0, False),
+        ("friction_per_ps", 1.0, 0.0, 1000.0, False),
+        ("trajectory_interval_steps", 1000, 1, 10_000_000_000, True),
+        ("checkpoint_interval_steps", 10000, 0, 10_000_000_000, True),
+        ("telemetry_interval", 1000, 1, 10_000_000_000, True),
+    )
+    for key, default, low, high, integer in numeric_fields:
+        try:
+            simulation[key] = _number(
+                sim_in,
+                key,
+                default=default,
+                minimum=low,
+                maximum=high,
+                integer=integer,
+            )
+        except ValueError as exc:
+            errors[f"simulation.{key}"] = str(exc)
+
+    simulation["minimize"] = bool(sim_in.get("minimize", True))
+    integrator = str(sim_in.get("integrator") or "langevin_middle")
+    platform = str(sim_in.get("platform") or "auto")
+    precision = str(sim_in.get("precision") or "mixed")
+    if integrator not in _INTEGRATORS:
+        errors["simulation.integrator"] = "Choose a supported integrator."
+    else:
+        simulation["integrator"] = integrator
+    if platform not in _PLATFORMS:
+        errors["simulation.platform"] = "Choose a supported OpenMM platform."
+    else:
+        simulation["platform"] = platform
+    if precision not in _PRECISIONS:
+        errors["simulation.precision"] = "Choose a supported precision mode."
+    else:
+        simulation["precision"] = precision
+
+    workflow["run_analysis"] = bool(workflow_in.get("run_analysis", True))
+    workflow["run_report"] = bool(workflow_in.get("run_report", True))
+    requested_analyses = workflow_in.get("analyses", list(_ANALYSES))
+    if not isinstance(requested_analyses, list):
+        requested_analyses = list(_ANALYSES)
+    analyses = [str(item) for item in requested_analyses if str(item) in _ANALYSES]
+    workflow["analyses"] = analyses
+    workflow["report_document"] = bool(workflow_in.get("report_document", True))
+    workflow["report_slides"] = bool(workflow_in.get("report_slides", True))
+    workflow["report_bundle"] = bool(workflow_in.get("report_bundle", True))
+
+    if workflow["run_report"] and not workflow["run_analysis"]:
+        warnings.append("Reports can be generated without analysis, but they will contain fewer scientific results.")
+
+    timestep = float(simulation.get("timestep_fs", 2.0))
+    nvt_steps = int(simulation.get("nvt_steps", 0))
+    npt_steps = int(simulation.get("npt_steps", 0))
+    production_steps = int(simulation.get("production_steps", 0))
+    trajectory_interval = int(simulation.get("trajectory_interval_steps", 1))
+    telemetry_interval = int(simulation.get("telemetry_interval", 1))
+
+    durations = {
+        "nvt_ns": nvt_steps * timestep / 1_000_000.0,
+        "npt_ns": npt_steps * timestep / 1_000_000.0,
+        "production_ns": production_steps * timestep / 1_000_000.0,
+        "total_ns": (nvt_steps + npt_steps + production_steps) * timestep / 1_000_000.0,
+        "trajectory_frames": (production_steps + trajectory_interval - 1) // trajectory_interval,
+        "dashboard_frames": (
+            nvt_steps + npt_steps + production_steps + telemetry_interval - 1
+        ) // telemetry_interval,
+    }
+    if durations["production_ns"] < 1.0:
+        warnings.append(
+            f"Production time is {durations['production_ns']:.4g} ns; this is suitable for testing, not strong scientific conclusions."
+        )
+
+    return {
+        "valid": not errors,
+        "errors": errors,
+        "warnings": warnings,
+        "config": {
+            "system": system,
+            "run_name": run_name,
+            "setup": setup,
+            "simulation": simulation,
+            "workflow": workflow,
+        },
+        "summary": durations,
+    }
+
+
+def build_launcher_command(config: Mapping[str, Any], output_dir: Path) -> list[str]:
+    """Translate a normalized launcher config into the canonical CLI."""
+    setup = config["setup"]
+    sim = config["simulation"]
+    workflow = config["workflow"]
+    command = [
+        sys.executable,
+        "-m",
+        "fastmdxplora.cli.main",
+        "explore",
+        "--system",
+        str(config["system"]),
+        "--output",
+        str(output_dir),
+        "--setup-ph",
+        str(setup["ph"]),
+        "--setup-forcefield",
+        str(setup["forcefield"]),
+        "--setup-ion-concentration-M",
+        str(setup["ion_concentration_M"]),
+        "--setup-solvent-padding-nm",
+        str(setup["solvent_padding_nm"]),
+        "--simulate-nvt-steps",
+        str(sim["nvt_steps"]),
+        "--simulate-npt-steps",
+        str(sim["npt_steps"]),
+        "--simulate-production-steps",
+        str(sim["production_steps"]),
+        "--simulate-timestep-fs",
+        str(sim["timestep_fs"]),
+        "--simulate-temperature-K",
+        str(sim["temperature_K"]),
+        "--simulate-friction-per-ps",
+        str(sim["friction_per_ps"]),
+        "--simulate-integrator",
+        str(sim["integrator"]),
+        "--simulate-platform",
+        str(sim["platform"]),
+        "--simulate-precision",
+        str(sim["precision"]),
+        "--simulate-trajectory-interval-steps",
+        str(sim["trajectory_interval_steps"]),
+        "--simulate-checkpoint-interval-steps",
+        str(sim["checkpoint_interval_steps"]),
+        "--simulate-live-telemetry",
+        "--simulate-telemetry-interval",
+        str(sim["telemetry_interval"]),
+    ]
+    if setup.get("water_model") and setup["water_model"] != "auto":
+        command.extend(["--setup-water-model", str(setup["water_model"])])
+    if setup.get("keep_heterogens"):
+        command.append("--setup-keep-heterogens")
+    if setup.get("keep_water"):
+        command.append("--setup-keep-water")
+    if not sim.get("minimize", True):
+        command.append("--simulate-no-minimize")
+
+    phases = ["setup", "simulation"]
+    if workflow.get("run_analysis"):
+        phases.append("analysis")
+    if workflow.get("run_report"):
+        phases.append("report")
+    if phases != ["setup", "simulation", "analysis", "report"]:
+        command.extend(["--include", *phases])
+
+    analyses = list(workflow.get("analyses") or [])
+    if workflow.get("run_analysis") and analyses and set(analyses) != set(_ANALYSES):
+        command.extend(["--analyze-analyses", *analyses])
+    if workflow.get("run_report"):
+        if not workflow.get("report_document", True):
+            command.append("--report-no-document")
+        if not workflow.get("report_slides", True):
+            command.append("--report-no-slides")
+        if not workflow.get("report_bundle", True):
+            command.append("--report-no-bundle")
+        command.extend(["--report-title", str(config.get("run_name") or "FastMDXplora Run")])
+    return command
+
+
+@dataclass
+class DashboardRuntime:
+    """Mutable state shared by all request-handler threads."""
+
+    workspace_root: Path
+    launch_root: Path
+    active_root: Path | None = None
+    process: subprocess.Popen[Any] | None = None
+    process_started_at: str | None = None
+    process_finished_at: str | None = None
+    process_returncode: int | None = None
+    log_path: Path | None = None
+    command: list[str] = field(default_factory=list)
+    lock: threading.RLock = field(default_factory=threading.RLock, repr=False)
+
+    def __post_init__(self) -> None:
+        self.workspace_root = self.workspace_root.expanduser().resolve()
+        self.launch_root = self.launch_root.expanduser().resolve()
+        self.workspace_root.mkdir(parents=True, exist_ok=True)
+        self.launch_root.mkdir(parents=True, exist_ok=True)
+        if self.active_root is not None:
+            self.active_root = self.active_root.expanduser().resolve()
+
+    def data_root(self) -> Path:
+        with self.lock:
+            return self.active_root or self.workspace_root
+
+    def _refresh_process(self) -> None:
+        if self.process is None:
+            return
+        returncode = self.process.poll()
+        if returncode is None:
+            return
+        self.process_returncode = int(returncode)
+        if self.process_finished_at is None:
+            self.process_finished_at = _utc_now()
+
+    def snapshot(self) -> dict[str, Any]:
+        with self.lock:
+            self._refresh_process()
+            running = self.process is not None and self.process.poll() is None
+            status = "idle"
+            if running:
+                status = "running"
+            elif self.process is not None and self.process_returncode == 0:
+                status = "completed"
+            elif self.process is not None and self.process_returncode is not None:
+                status = "failed"
+            return {
+                "mode": "home" if self.active_root is None else "run",
+                "status": status,
+                "active_run": str(self.active_root) if self.active_root else None,
+                "workspace": str(self.workspace_root),
+                "launch_root": str(self.launch_root),
+                "process_running": running,
+                "returncode": self.process_returncode,
+                "started_at": self.process_started_at,
+                "finished_at": self.process_finished_at,
+                "log_path": str(self.log_path) if self.log_path else None,
+                "command": list(self.command),
+                "can_launch": not running,
+            }
+
+    def launch(self, payload: Mapping[str, Any], *, dashboard_url: str | None = None) -> dict[str, Any]:
+        result = validate_launcher_payload(payload)
+        if not result["valid"]:
+            return result
+        config = result["config"]
+        with self.lock:
+            self._refresh_process()
+            if self.process is not None and self.process.poll() is None:
+                return {
+                    **result,
+                    "valid": False,
+                    "errors": {"run": "A FastMDXplora workflow is already running."},
+                }
+
+            run_name = _slug(config["run_name"])
+            output_dir = (self.launch_root / run_name).resolve()
+            try:
+                output_dir.relative_to(self.launch_root)
+            except ValueError:
+                return {
+                    **result,
+                    "valid": False,
+                    "errors": {"run_name": "Run name resolves outside the launch directory."},
+                }
+            if output_dir.exists() and any(output_dir.iterdir()):
+                return {
+                    **result,
+                    "valid": False,
+                    "errors": {"run_name": f"Output folder already exists and is not empty: {output_dir}"},
+                }
+            output_dir.mkdir(parents=True, exist_ok=True)
+            log_path = output_dir / "dashboard_launcher.log"
+            command = build_launcher_command(config, output_dir)
+            env = os.environ.copy()
+            env["FASTMDX_DASHBOARD_ACTIVE"] = "1"
+            env["FASTMDX_DASHBOARD_OUTPUT"] = str(output_dir)
+            if dashboard_url:
+                env["FASTMDX_DASHBOARD_URL"] = dashboard_url
+            log_handle = log_path.open("a", encoding="utf-8", buffering=1)
+            try:
+                process = subprocess.Popen(
+                    command,
+                    cwd=str(self.launch_root),
+                    env=env,
+                    stdout=log_handle,
+                    stderr=subprocess.STDOUT,
+                    stdin=subprocess.DEVNULL,
+                    shell=False,
+                )
+            except Exception:
+                log_handle.close()
+                raise
+            # Popen owns an inherited OS handle. Closing our copy avoids a
+            # long-lived Python file object while the child continues writing.
+            log_handle.close()
+            self.active_root = output_dir
+            self.process = process
+            self.process_started_at = _utc_now()
+            self.process_finished_at = None
+            self.process_returncode = None
+            self.log_path = log_path
+            self.command = command
+            return {
+                **result,
+                "launched": True,
+                "output": str(output_dir),
+                "pid": process.pid,
+                "command": command,
+                "state": self.snapshot(),
+            }
+
+    def stop(self) -> dict[str, Any]:
+        with self.lock:
+            self._refresh_process()
+            if self.process is None or self.process.poll() is not None:
+                return {"stopped": False, "detail": "No workflow is currently running.", "state": self.snapshot()}
+            self.process.terminate()
+            return {"stopped": True, "detail": "Termination requested.", "state": self.snapshot()}

--- a/src/fastmdxplora/live/launcher.py
+++ b/src/fastmdxplora/live/launcher.py
@@ -10,6 +10,8 @@ science.
 
 from __future__ import annotations
 
+import importlib
+import json
 import os
 import re
 import subprocess
@@ -363,6 +365,75 @@ def build_launcher_command(config: Mapping[str, Any], output_dir: Path) -> list[
     return command
 
 
+def launcher_environment_error(config: Mapping[str, Any]) -> str | None:
+    """Return an actionable error when the dashboard cannot run the workflow.
+
+    The normal CLI deliberately imports the chemistry stack lazily and lets
+    phase pipelines write a warning manifest when optional packages are
+    missing.  That behavior is useful for inspecting configuration on light
+    installations, but it is misleading for the dashboard's *Run Simulation*
+    action: the child exits successfully without producing a simulation.
+    """
+    required = [
+        ("OpenMM", "openmm"),
+        ("OpenMM application layer", "openmm.app"),
+        ("PDBFixer", "pdbfixer"),
+    ]
+    workflow = config.get("workflow")
+    if isinstance(workflow, Mapping) and workflow.get("run_analysis"):
+        required.append(("MDTraj", "mdtraj"))
+
+    missing: list[str] = []
+    for label, module_name in required:
+        try:
+            importlib.import_module(module_name)
+        except Exception:  # noqa: BLE001 - broken partial installs also cannot run
+            if label.startswith("OpenMM"):
+                label = "OpenMM"
+            if label not in missing:
+                missing.append(label)
+
+    if not missing:
+        return None
+
+    packages = " ".join(
+        name for name in ("openmm", "pdbfixer", "mdtraj")
+        if name != "mdtraj" or "MDTraj" in missing
+    )
+    return (
+        "Simulation dependencies are unavailable in the Python environment "
+        f"running this dashboard: {', '.join(missing)}. Install them in that "
+        "same environment, restart the dashboard, and launch again. Recommended: "
+        f"conda install -c conda-forge {packages}"
+    )
+
+
+def _json_mapping(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _manifest_note(manifest: Mapping[str, Any]) -> str | None:
+    notes = manifest.get("notes")
+    if not isinstance(notes, list):
+        return None
+    for note in notes:
+        text = str(note or "").strip()
+        if text:
+            return text
+    return None
+
+
+def _is_nonempty_file(path: Path) -> bool:
+    try:
+        return path.is_file() and path.stat().st_size > 0
+    except OSError:
+        return False
+
+
 @dataclass
 class DashboardRuntime:
     """Mutable state shared by all request-handler threads."""
@@ -374,6 +445,7 @@ class DashboardRuntime:
     process_started_at: str | None = None
     process_finished_at: str | None = None
     process_returncode: int | None = None
+    completion_error: str | None = None
     log_path: Path | None = None
     command: list[str] = field(default_factory=list)
     lock: threading.RLock = field(default_factory=threading.RLock, repr=False)
@@ -399,6 +471,91 @@ class DashboardRuntime:
         self.process_returncode = int(returncode)
         if self.process_finished_at is None:
             self.process_finished_at = _utc_now()
+        if self.process_returncode == 0 and self.completion_error is None:
+            self.completion_error = self._completed_run_error()
+            if self.completion_error:
+                self._record_completion_failure(self.completion_error)
+
+    def _completed_run_error(self) -> str | None:
+        """Reject a false-success child that produced no simulation results."""
+        root = self.active_root
+        if root is None or not self.command or "explore" not in self.command:
+            return None
+
+        setup_dir = root / "setup"
+        required_setup = ("system.xml", "state.xml", "topology.pdb")
+        missing_setup = [name for name in required_setup if not (setup_dir / name).is_file()]
+        if missing_setup:
+            setup_manifest = _json_mapping(setup_dir / "setup_parameters.json")
+            detail = _manifest_note(setup_manifest)
+            suffix = f" Details: {detail}" if detail else ""
+            return (
+                "Setup did not produce the files required for simulation "
+                f"({', '.join(missing_setup)}).{suffix} See "
+                f"{self.log_path or root / 'dashboard_launcher.log'} for the full log."
+            )
+
+        simulation_dir = root / "simulation"
+        simulation_manifest = _json_mapping(
+            simulation_dir / "simulation_parameters.json"
+        )
+        final_state = simulation_dir / "state_final.xml"
+        simulated = (
+            _is_nonempty_file(final_state)
+            and simulation_manifest.get("platform_used") not in (None, "")
+            and simulation_manifest.get("duration_ns_actual") is not None
+        )
+        if not simulated:
+            detail = _manifest_note(simulation_manifest)
+            suffix = f" Details: {detail}" if detail else ""
+            return (
+                "The workflow exited without producing a completed molecular "
+                f"dynamics simulation.{suffix} See "
+                f"{self.log_path or root / 'dashboard_launcher.log'} for the full log."
+            )
+        return None
+
+    def _record_completion_failure(self, detail: str) -> None:
+        """Make the overview and health panels reflect post-run validation."""
+        if self.active_root is None:
+            return
+        try:
+            from fastmdxplora.live.telemetry import TelemetryWriter, read_status
+
+            status = read_status(self.active_root)
+            states = status.get("stage_states")
+            states = dict(states) if isinstance(states, dict) else {}
+            setup_ready = all(
+                (self.active_root / "setup" / name).is_file()
+                for name in ("system.xml", "state.xml", "topology.pdb")
+            )
+            if setup_ready:
+                stage = "production"
+                states["production"] = "failed"
+                states["analysis"] = "skipped"
+                states["report"] = "skipped"
+            else:
+                stage = "setup"
+                states["setup"] = "failed"
+                for name in (
+                    "minimization",
+                    "nvt",
+                    "npt",
+                    "production",
+                    "analysis",
+                    "report",
+                ):
+                    states[name] = "skipped"
+            writer = TelemetryWriter(self.active_root / "simulation", enabled=True)
+            writer.write_status(
+                stage=stage,
+                status="failed",
+                latest_error=detail,
+                stage_states=states,
+            )
+            writer.event(detail, level="error")
+        except Exception:  # noqa: BLE001 - status reporting must not mask the result
+            return
 
     def snapshot(self) -> dict[str, Any]:
         with self.lock:
@@ -407,6 +564,8 @@ class DashboardRuntime:
             status = "idle"
             if running:
                 status = "running"
+            elif self.completion_error:
+                status = "failed"
             elif self.process is not None and self.process_returncode == 0:
                 status = "completed"
             elif self.process is not None and self.process_returncode is not None:
@@ -419,6 +578,7 @@ class DashboardRuntime:
                 "launch_root": str(self.launch_root),
                 "process_running": running,
                 "returncode": self.process_returncode,
+                "error": self.completion_error,
                 "started_at": self.process_started_at,
                 "finished_at": self.process_finished_at,
                 "log_path": str(self.log_path) if self.log_path else None,
@@ -438,6 +598,15 @@ class DashboardRuntime:
                     **result,
                     "valid": False,
                     "errors": {"run": "A FastMDXplora workflow is already running."},
+                }
+
+            environment_error = launcher_environment_error(config)
+            if environment_error:
+                return {
+                    **result,
+                    "valid": False,
+                    "error": environment_error,
+                    "errors": {"run": environment_error},
                 }
 
             run_name = _slug(config["run_name"])
@@ -486,6 +655,7 @@ class DashboardRuntime:
             self.process_started_at = _utc_now()
             self.process_finished_at = None
             self.process_returncode = None
+            self.completion_error = None
             self.log_path = log_path
             self.command = command
             return {

--- a/src/fastmdxplora/live/ligand_detection.py
+++ b/src/fastmdxplora/live/ligand_detection.py
@@ -1,0 +1,179 @@
+"""Detect likely non-protein ligands from a PDB structure.
+
+Separates biologically meaningful ligands (drugs, cofactors) from
+crystallographic water and free ions that don't need the dashboard's
+ligand tools. Never assumes the ligand is named "LIG" – the detection
+is residue-name driven and accepts an explicit CLI override.
+
+The water/ion residue sets live here (where they semantically belong)
+and are re-exported from :mod:`fastmdxplora.live.structure_info` so
+that :func:`structure_info.count_structure` can re-use them.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any, Iterable
+
+WATER_RESNAMES = frozenset({
+    "HOH", "WAT", "TIP", "TIP3", "SOL", "H2O",
+})
+
+ION_RESNAMES = frozenset({
+    "NA", "K", "CL", "BR", "I", "F", "MG", "CA", "ZN", "MN", "FE", "CU",
+    "NI", "CO", "CD", "HG", "PB", "CS", "RB", "LI", "BA", "SR", "AU", "AG",
+    "AL", "CR", "SN", "PT",
+    "NA+", "K+", "CL-", "MG2+", "CA2+", "ZN2+",
+})
+
+# Public so structure_info can re-use without importing this file's
+# internals; previously exposed only with a leading underscore, but
+# structure_info shares the canonical copy.
+AMINO_ACID_RESNAMES = frozenset({
+    "ALA", "ARG", "ASN", "ASP", "CYS", "GLN", "GLU", "GLY", "HIS",
+    "HID", "HIE", "HIP", "ILE", "LEU", "LYS", "MET", "PHE", "PRO",
+    "SER", "THR", "TRP", "TYR", "VAL",
+    # Modified residues PDBFixer commonly produces
+    "MSE", "SEC", "PYL",
+})
+
+# Legacy private alias kept for backwards compatibility within the package.
+_AMINO_ACID_RESNAMES = AMINO_ACID_RESNAMES
+
+# Cofactors / crystallographic additives that are typically retained but
+# aren't interesting "ligands" for the dashboard ligand panel. Filtered
+# by default to avoid clutter.
+COMMON_COFACTORS = frozenset({
+    "NAG", "MAN", "BMA", "FUC", "GLC", "GAL", "NDG",  # glycans
+    "SO4", "PO4", "GOL", "EDO", "PEG", "DMS", "ACT",  # buffers / cryoprotectants
+})
+
+
+def _residue_sort_key(resi: str) -> tuple[int, str]:
+    """Numeric-then-string fallback sort key for residue IDs.
+
+    PDB residue IDs are integers with optional insertion-code suffixes
+    (e.g. ``"10A"``). Sorting by raw strings produces ``"10" < "2"``,
+    so we coerce to int when possible and otherwise sort by the raw
+    value to keep stable ordering for insertion-code variants.
+    """
+    try:
+        return (int(resi), "")
+    except (TypeError, ValueError):
+        return (0, str(resi))
+
+
+def detect_ligands(
+    residue_keys: Iterable[tuple[str, str, str]],
+    *,
+    explicit: Iterable[str] | None = None,
+    include_cofactors: bool = False,
+) -> dict[str, Any]:
+    """Identify likely ligand residues.
+
+    Parameters
+    ----------
+    residue_keys
+        Iterable of (chain, resname, resi) tuples. Typically produced by
+        :mod:`fastmdxplora.live.structure_info` walking the PDB.
+    explicit
+        Optional iterable of residue names that should always be treated
+        as ligands, even if they would otherwise be filtered out
+        (e.g. ``{"LIG"}`` from ``--setup-ligand-name``). Explicit names
+        *override* the water/ion/amino-acid filters.
+    include_cofactors
+        When True, common cofactors (NAG, GOL, SO4, ...) are also
+        surfaced. Defaults to False so the ligand panel focuses on the
+        chemistry-of-interest ligand.
+
+    Returns
+    -------
+    dict with keys ``instances`` (a list of dicts), ``resnames`` (sorted
+    unique residue names), and ``cofactors`` (filtered list of cofactor
+    names found).
+    """
+    explicit_set = {name.upper() for name in (explicit or ())}
+    by_resname: Counter[str] = Counter()
+    instances: list[dict[str, Any]] = []
+    cofactors_found: set[str] = set()
+
+    for chain, resname, resi in residue_keys:
+        rn = resname.upper()
+        if not rn:
+            continue
+        # Explicit ligands win over the water/ion/amino-acid filters so
+        # users can name a residue of interest even if its residue code
+        # overlaps with water or an ion (rare but possible).
+        if rn not in explicit_set:
+            if rn in WATER_RESNAMES or rn in ION_RESNAMES:
+                continue
+            if rn in _AMINO_ACID_RESNAMES:
+                continue
+        is_cofactor = rn in COMMON_COFACTORS and rn not in explicit_set
+        if is_cofactor:
+            # Track cofactor-tagged residue names regardless of whether
+            # they're included as ligands — the UI uses this list to
+            # label instances that may not be the ligand of interest.
+            cofactors_found.add(rn)
+            if not include_cofactors:
+                continue
+        by_resname[rn] += 1
+        instances.append(
+            {
+                "chain": chain or "A",
+                "resname": rn,
+                "resi": resi,
+                "explicit": rn in explicit_set,
+                "cofactor": is_cofactor,
+            }
+        )
+
+    return {
+        "instances": sorted(
+            instances,
+            key=lambda inst: (
+                inst["chain"],
+                inst["resname"],
+                _residue_sort_key(inst["resi"]),
+            ),
+        ),
+        "resnames": sorted(by_resname.keys()),
+        "resname_counts": dict(by_resname),
+        "cofactors": sorted(cofactors_found),
+    }
+
+
+def normalise_ligand_resname(value: str | None) -> str | None:
+    """Return the residue name to focus the ligand panel on.
+
+    Accepts ``"EPE"``, ``"epe"``, ``"LIG"``. Returns uppercase or ``None``
+    on empty/None input so callers can safely drop it from options dicts.
+    """
+    if value is None:
+        return None
+    cleaned = value.strip().upper()
+    return cleaned or None
+
+
+def filter_pdb_to_ligand(
+    pdb_text: str, ligand_resname: str
+) -> str:
+    """Return PDB text containing only the ligand atoms + END.
+
+    Used by the binding-pocket / ligand-tools features that want just the
+    ligand string for the 3Dmol viewer. Caller is responsible for
+    cross-origin / size validation; this helper does no IO.
+    """
+    if not ligand_resname:
+        return pdb_text
+    target = ligand_resname.upper()
+    out_lines: list[str] = []
+    for line in pdb_text.splitlines():
+        if not (line.startswith("ATOM") or line.startswith("HETATM")):
+            out_lines.append(line)
+            continue
+        rn = line[17:20].strip().upper()
+        if rn == target:
+            out_lines.append(line)
+    out_lines.append("END")
+    return "\n".join(out_lines)

--- a/src/fastmdxplora/live/live_frames.py
+++ b/src/fastmdxplora/live/live_frames.py
@@ -1,33 +1,56 @@
-"""Atomic, fail-safe writing of live simulation frames for the dashboard.
+"""Atomic live-coordinate snapshots and rolling browser playback history.
 
-The dashboard polls ``/structure/live-frame.pdb`` so the molecular viewer
-can track the simulation as it runs. We never want this side-channel to
-crash or even pause the OpenMM loop, so every operation here:
-
-  - is bounded by a try/except (returns ``False`` on any failure);
-  - writes to a temp file and then uses ``os.replace`` for an atomic
-    rename — the dashboard cannot read a half-written PDB;
-  - records the frame index and mtime in ``live_frame_index.json`` so
-    the browser can cheaply detect "something changed" without parsing
-    the PDB header.
-
-The simulation runner calls :func:`write_live_frame` once per telemetry
-interval. The dashboard never reads coordinates from in-process state —
-it always asks the server, which reads from disk. This keeps cross-thread
-state-sharing simple and lets the dashboard work even after the
-simulation has exited (it just stops updating).
+These files are a read-only dashboard side channel.  They never feed values
+back into OpenMM and failures are swallowed so visualization cannot stop or
+change a scientific simulation.
 """
 
 from __future__ import annotations
 
 import json
 import os
+import re
 import time
 from pathlib import Path
 from typing import Any
 
 LIVE_FRAME_FILE = "live_frame.pdb"
 LIVE_FRAME_INDEX_FILE = "live_frame_index.json"
+LIVE_FRAME_HISTORY_DIR = "live_frames"
+LIVE_FRAME_HISTORY_FILE = "live_frame_history.json"
+DEFAULT_MAX_HISTORY_FRAMES = 200
+
+_WATER_RESNAMES = {"HOH", "WAT", "TIP", "TIP3", "TIP3P", "SOL", "H2O"}
+_ION_RESNAMES = {
+    "NA", "K", "CL", "BR", "I", "F", "MG", "CA", "ZN", "MN", "FE",
+    "CU", "NI", "CO", "CD", "HG", "PB", "CS", "RB", "LI", "BA", "SR",
+}
+
+
+def dashboard_display_pdb(pdb_text: str) -> str:
+    """Return a browser-friendly PDB with bulk solvent and ions removed.
+
+    The simulation topology and DCD remain untouched.  Filtering only the
+    dashboard copy keeps 3Dmol responsive while preserving protein and ligand
+    coordinates.  Bonds are inferred by 3Dmol from the displayed atoms.
+    """
+    output: list[str] = []
+    atom_written = False
+    for line in str(pdb_text or "").splitlines():
+        record = line[:6].strip().upper()
+        if record in {"ATOM", "HETATM"}:
+            resname = line[17:20].strip().upper()
+            if resname in _WATER_RESNAMES or resname in _ION_RESNAMES:
+                continue
+            output.append(line)
+            atom_written = True
+        elif record == "CRYST1":
+            output.append(line)
+        elif record in {"TER"} and atom_written:
+            output.append(line)
+    if atom_written:
+        output.append("END")
+    return "\n".join(output) + ("\n" if output else "")
 
 
 def write_live_frame(
@@ -35,38 +58,64 @@ def write_live_frame(
     *,
     pdb_text: str,
     frame_index: int | None = None,
+    stage: str | None = None,
+    simulation_time_ns: float | None = None,
+    archive: bool = False,
+    max_history_frames: int = DEFAULT_MAX_HISTORY_FRAMES,
 ) -> dict[str, Any]:
-    """Atomically write ``pdb_text`` as ``live_frame.pdb``.
+    """Atomically write the newest frame and optionally archive it.
 
-    Returns a small status dict; failures are swallowed (the simulation
-    continues) but recorded with ``ok=False`` for telemetry purposes.
+    ``archive=True`` maintains a bounded rolling history used by the playback
+    controls even while NVT/NPT/production are still running.
     """
     out = Path(output_dir)
-    frames_path = out / LIVE_FRAME_FILE
+    frame_path = out / LIVE_FRAME_FILE
     index_path = out / LIVE_FRAME_INDEX_FILE
 
     try:
         out.mkdir(parents=True, exist_ok=True)
-        tmp = frames_path.with_suffix(".pdb.tmp")
+        tmp = frame_path.with_suffix(".pdb.tmp")
         tmp.write_text(pdb_text, encoding="utf-8")
-        os.replace(tmp, frames_path)
+        os.replace(tmp, frame_path)
     except OSError as exc:
         return {"ok": False, "error": f"write-error: {exc}", "frame_index": frame_index}
 
-    mtime = frames_path.stat().st_mtime if frames_path.exists() else time.time()
+    history_count = 0
+    history_sequence = None
+    if archive:
+        history = _archive_frame(
+            out,
+            pdb_text=pdb_text,
+            frame_index=frame_index,
+            stage=stage,
+            simulation_time_ns=simulation_time_ns,
+            max_history_frames=max_history_frames,
+        )
+        history_count = int(history.get("count", 0) or 0)
+        history_sequence = history.get("sequence")
+
+    try:
+        stat = frame_path.stat()
+        mtime = stat.st_mtime
+        size = stat.st_size
+    except OSError:
+        mtime = time.time()
+        size = len(pdb_text.encode("utf-8"))
+
     index_payload = {
         "live_frame_available": True,
         "live_frame_index": int(frame_index) if frame_index is not None else None,
         "live_frame_updated_at": _iso_now(time.time()),
         "live_frame_mtime": mtime,
-        "live_frame_size": frames_path.stat().st_size,
+        "live_frame_size": size,
+        "simulation_stage": str(stage or "").lower() or None,
+        "simulation_time_ns": float(simulation_time_ns) if simulation_time_ns is not None else None,
+        "history_frame_count": history_count,
+        "history_sequence": history_sequence,
     }
     try:
-        tmp_idx = index_path.with_suffix(".json.tmp")
-        tmp_idx.write_text(json.dumps(index_payload), encoding="utf-8")
-        os.replace(tmp_idx, index_path)
+        _atomic_json(index_path, index_payload)
     except OSError:
-        # Best-effort; the frame itself succeeded and that's what matters.
         pass
     return {"ok": True, **index_payload}
 
@@ -78,27 +127,105 @@ def write_openmm_live_frame(
     topology: Any,
     positions: Any,
     frame_index: int | None = None,
+    stage: str | None = None,
+    simulation_time_ns: float | None = None,
+    archive: bool = True,
+    max_history_frames: int = DEFAULT_MAX_HISTORY_FRAMES,
 ) -> dict[str, Any]:
-    """Convenience wrapper around :func:`write_live_frame` for OpenMM.
-
-    ``pdbfile_writer`` is typically ``openmm.app.PDBFile.writeFile``;
-    accepting it as a callable lets this module stay free of any direct
-    OpenMM import (the rest of the live module already imports openmm
-    lazily only when telemetry is on).
-    """
+    """Write an OpenMM state as a solvent-stripped dashboard snapshot."""
     try:
         from io import StringIO
 
         buf = StringIO()
-        pdbfile_writer(topology, positions, buf)
-        text = buf.getvalue()
+        try:
+            pdbfile_writer(topology, positions, buf, keepIds=True)
+        except TypeError:
+            pdbfile_writer(topology, positions, buf)
+        text = dashboard_display_pdb(buf.getvalue())
+        if "ATOM" not in text and "HETATM" not in text:
+            return {"ok": False, "error": "openmm-snapshot: no display atoms", "frame_index": frame_index}
     except Exception as exc:  # noqa: BLE001 - dashboard writes must never crash sim
         return {"ok": False, "error": f"openmm-snapshot: {exc}", "frame_index": frame_index}
-    return write_live_frame(output_dir, pdb_text=text, frame_index=frame_index)
+    return write_live_frame(
+        output_dir,
+        pdb_text=text,
+        frame_index=frame_index,
+        stage=stage,
+        simulation_time_ns=simulation_time_ns,
+        archive=archive,
+        max_history_frames=max_history_frames,
+    )
+
+
+def _archive_frame(
+    output_dir: Path,
+    *,
+    pdb_text: str,
+    frame_index: int | None,
+    stage: str | None,
+    simulation_time_ns: float | None,
+    max_history_frames: int,
+) -> dict[str, Any]:
+    history_dir = output_dir / LIVE_FRAME_HISTORY_DIR
+    history_path = output_dir / LIVE_FRAME_HISTORY_FILE
+    try:
+        history_dir.mkdir(parents=True, exist_ok=True)
+        payload = read_live_frame_history(output_dir)
+        records = payload.get("frames") if isinstance(payload, dict) else []
+        records = list(records) if isinstance(records, list) else []
+        last_sequence = max(
+            (int(item.get("sequence", -1)) for item in records if isinstance(item, dict)),
+            default=-1,
+        )
+        sequence = last_sequence + 1
+        stage_token = re.sub(r"[^a-z0-9_-]+", "-", str(stage or "frame").lower()).strip("-") or "frame"
+        step_token = int(frame_index) if frame_index is not None else sequence
+        filename = f"frame_{sequence:06d}_{stage_token}_{step_token:012d}.pdb"
+        destination = history_dir / filename
+        tmp = destination.with_suffix(".pdb.tmp")
+        tmp.write_text(pdb_text, encoding="utf-8")
+        os.replace(tmp, destination)
+        records.append({
+            "sequence": sequence,
+            "frame_index": int(frame_index) if frame_index is not None else None,
+            "stage": str(stage or "").lower() or None,
+            "simulation_time_ns": float(simulation_time_ns) if simulation_time_ns is not None else None,
+            "path": f"{LIVE_FRAME_HISTORY_DIR}/{filename}",
+            "updated_at": _iso_now(time.time()),
+            "mtime_ns": destination.stat().st_mtime_ns,
+        })
+        cap = max(2, int(max_history_frames or DEFAULT_MAX_HISTORY_FRAMES))
+        while len(records) > cap:
+            removed = records.pop(0)
+            if isinstance(removed, dict):
+                old_path = output_dir / str(removed.get("path") or "")
+                try:
+                    old_path.unlink(missing_ok=True)
+                except OSError:
+                    pass
+        manifest = {
+            "version": 1,
+            "count": len(records),
+            "max_frames": cap,
+            "frames": records,
+            "updated_at": _iso_now(time.time()),
+        }
+        _atomic_json(history_path, manifest)
+        return {"count": len(records), "sequence": sequence}
+    except Exception:  # noqa: BLE001 - visualization history is best effort
+        return {"count": 0, "sequence": None}
+
+
+def read_live_frame_history(output_dir: str | Path) -> dict[str, Any]:
+    path = Path(output_dir) / LIVE_FRAME_HISTORY_FILE
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {"frames": [], "count": 0}
+    except (OSError, json.JSONDecodeError):
+        return {"frames": [], "count": 0}
 
 
 def read_live_frame_index(output_dir: str | Path) -> dict[str, Any]:
-    """Read the latest frame companion JSON, defaulting to ``available=False``."""
     out = Path(output_dir)
     idx_path = out / LIVE_FRAME_INDEX_FILE
     if not idx_path.is_file():
@@ -114,8 +241,13 @@ def live_frame_pdb_path(output_dir: str | Path) -> Path:
 
 
 def live_frame_exists(output_dir: str | Path) -> bool:
-    """Cheap existence check used by the route handler."""
     return live_frame_pdb_path(output_dir).is_file()
+
+
+def _atomic_json(path: Path, payload: dict[str, Any]) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    os.replace(tmp, path)
 
 
 def _iso_now(timestamp: float) -> str:

--- a/src/fastmdxplora/live/live_frames.py
+++ b/src/fastmdxplora/live/live_frames.py
@@ -1,0 +1,124 @@
+"""Atomic, fail-safe writing of live simulation frames for the dashboard.
+
+The dashboard polls ``/structure/live-frame.pdb`` so the molecular viewer
+can track the simulation as it runs. We never want this side-channel to
+crash or even pause the OpenMM loop, so every operation here:
+
+  - is bounded by a try/except (returns ``False`` on any failure);
+  - writes to a temp file and then uses ``os.replace`` for an atomic
+    rename — the dashboard cannot read a half-written PDB;
+  - records the frame index and mtime in ``live_frame_index.json`` so
+    the browser can cheaply detect "something changed" without parsing
+    the PDB header.
+
+The simulation runner calls :func:`write_live_frame` once per telemetry
+interval. The dashboard never reads coordinates from in-process state —
+it always asks the server, which reads from disk. This keeps cross-thread
+state-sharing simple and lets the dashboard work even after the
+simulation has exited (it just stops updating).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+LIVE_FRAME_FILE = "live_frame.pdb"
+LIVE_FRAME_INDEX_FILE = "live_frame_index.json"
+
+
+def write_live_frame(
+    output_dir: str | Path,
+    *,
+    pdb_text: str,
+    frame_index: int | None = None,
+) -> dict[str, Any]:
+    """Atomically write ``pdb_text`` as ``live_frame.pdb``.
+
+    Returns a small status dict; failures are swallowed (the simulation
+    continues) but recorded with ``ok=False`` for telemetry purposes.
+    """
+    out = Path(output_dir)
+    frames_path = out / LIVE_FRAME_FILE
+    index_path = out / LIVE_FRAME_INDEX_FILE
+
+    try:
+        out.mkdir(parents=True, exist_ok=True)
+        tmp = frames_path.with_suffix(".pdb.tmp")
+        tmp.write_text(pdb_text, encoding="utf-8")
+        os.replace(tmp, frames_path)
+    except OSError as exc:
+        return {"ok": False, "error": f"write-error: {exc}", "frame_index": frame_index}
+
+    mtime = frames_path.stat().st_mtime if frames_path.exists() else time.time()
+    index_payload = {
+        "live_frame_available": True,
+        "live_frame_index": int(frame_index) if frame_index is not None else None,
+        "live_frame_updated_at": _iso_now(time.time()),
+        "live_frame_mtime": mtime,
+        "live_frame_size": frames_path.stat().st_size,
+    }
+    try:
+        tmp_idx = index_path.with_suffix(".json.tmp")
+        tmp_idx.write_text(json.dumps(index_payload), encoding="utf-8")
+        os.replace(tmp_idx, index_path)
+    except OSError:
+        # Best-effort; the frame itself succeeded and that's what matters.
+        pass
+    return {"ok": True, **index_payload}
+
+
+def write_openmm_live_frame(
+    output_dir: str | Path,
+    *,
+    pdbfile_writer: Any,
+    topology: Any,
+    positions: Any,
+    frame_index: int | None = None,
+) -> dict[str, Any]:
+    """Convenience wrapper around :func:`write_live_frame` for OpenMM.
+
+    ``pdbfile_writer`` is typically ``openmm.app.PDBFile.writeFile``;
+    accepting it as a callable lets this module stay free of any direct
+    OpenMM import (the rest of the live module already imports openmm
+    lazily only when telemetry is on).
+    """
+    try:
+        from io import StringIO
+
+        buf = StringIO()
+        pdbfile_writer(topology, positions, buf)
+        text = buf.getvalue()
+    except Exception as exc:  # noqa: BLE001 - dashboard writes must never crash sim
+        return {"ok": False, "error": f"openmm-snapshot: {exc}", "frame_index": frame_index}
+    return write_live_frame(output_dir, pdb_text=text, frame_index=frame_index)
+
+
+def read_live_frame_index(output_dir: str | Path) -> dict[str, Any]:
+    """Read the latest frame companion JSON, defaulting to ``available=False``."""
+    out = Path(output_dir)
+    idx_path = out / LIVE_FRAME_INDEX_FILE
+    if not idx_path.is_file():
+        return {"live_frame_available": False}
+    try:
+        return json.loads(idx_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {"live_frame_available": False}
+
+
+def live_frame_pdb_path(output_dir: str | Path) -> Path:
+    return Path(output_dir) / LIVE_FRAME_FILE
+
+
+def live_frame_exists(output_dir: str | Path) -> bool:
+    """Cheap existence check used by the route handler."""
+    return live_frame_pdb_path(output_dir).is_file()
+
+
+def _iso_now(timestamp: float) -> str:
+    from datetime import datetime, timezone
+
+    return datetime.fromtimestamp(timestamp, tz=timezone.utc).isoformat()

--- a/src/fastmdxplora/live/protein_preview.py
+++ b/src/fastmdxplora/live/protein_preview.py
@@ -15,11 +15,17 @@ PREVIEW_CANDIDATES = (
     "simulation/protein_preview.png",
 )
 
+# Prefer the prepared solute for browser rendering.  The simulation topology
+# normally contains the entire solvent box and can easily be tens of megabytes,
+# which makes a browser viewer slow and also obscures the protein/ligand.  Live
+# frames and trajectory playback still use the full simulation topology where
+# atom-for-atom correspondence is required.
 STRUCTURE_CANDIDATES = (
+    "setup/prepared.pdb",
+    "simulation/final.pdb",
     "simulation/topology.pdb",
     "setup/topology.pdb",
     "setup/solvated.pdb",
-    "simulation/final.pdb",
 )
 
 AMINO_ACID_RESNAMES = {

--- a/src/fastmdxplora/live/server.py
+++ b/src/fastmdxplora/live/server.py
@@ -1,8 +1,15 @@
-"""Dependency-free localhost dashboard server."""
+"""Dependency-free localhost dashboard server.
+
+The HTML shell, CSS, and JavaScript live in
+:mod:`fastmdxplora.live.templates` and :mod:`fastmdxplora.live.static`.
+``_dashboard_shell`` reads ``dashboard.html`` from disk on first request
+and caches the result.
+"""
 
 from __future__ import annotations
 
 import json
+import logging
 import mimetypes
 import threading
 import time
@@ -12,8 +19,14 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import unquote, urlparse
 
+from fastmdxplora.live.ligand_detection import detect_ligands, normalise_ligand_resname
+from fastmdxplora.live.live_frames import live_frame_exists, read_live_frame_index
 from fastmdxplora.live.protein_preview import find_structure, protein_preview_payload
+from fastmdxplora.live.structure_info import count_structure, ligand_atom_counts
 from fastmdxplora.live.telemetry import analyze_health, read_events, read_metrics, read_status
+from fastmdxplora.live.trajectory_playback import playback_info
+
+logger = logging.getLogger("fastmdxplora.live.server")
 
 PLOT_TITLE_ALIASES = {
     "rmsd": "RMSD",
@@ -96,6 +109,22 @@ PLOT_CATEGORY_BY_TITLE = {
 
 KEY_PLOT_TITLES = {"RMSD", "RMSF", "Radius of gyration", "Hydrogen bonds", "PCA", "SASA"}
 
+DASHBOARD_TEMPLATE_PATH = Path(__file__).with_name("templates") / "dashboard.html"
+
+
+@dataclass
+class DashboardConfig:
+    """Per-dashboard-server knobs supplied by the CLI."""
+
+    ligand_resname: str | None = None
+    include_cofactors: bool = False
+    binding_pocket_cutoff_A: float = 5.0
+    max_browser_frames: int = 200
+
+    @property
+    def binding_pocket_cutoff_m(self) -> float:
+        return float(self.binding_pocket_cutoff_A)
+
 
 @dataclass
 class DashboardSession:
@@ -107,6 +136,7 @@ class DashboardSession:
     host: str
     port: int
     requested_port: int
+    config: DashboardConfig | None = None
 
     @property
     def url(self) -> str:
@@ -126,22 +156,39 @@ class DashboardSession:
             time.sleep(0.2)
 
 
-def make_handler(project_root: str | Path) -> type[BaseHTTPRequestHandler]:
+
+def make_handler(
+    project_root: str | Path,
+    config: DashboardConfig | None = None,
+    template_html: str | None = None,
+) -> type[BaseHTTPRequestHandler]:
     root = Path(project_root).resolve()
+    cfg = config or DashboardConfig()
+    html = template_html if template_html is not None else _load_template()
 
     class LiveDashboardHandler(BaseHTTPRequestHandler):
         server_version = "FastMDXLive/1.0"
 
         def do_GET(self) -> None:  # noqa: N802 - stdlib API
+            try:
+                self._dispatch()
+            except Exception as exc:  # noqa: BLE001 — dashboard must never crash the sim
+                logger.warning("dashboard route failed: %s", exc)
+                self.send_error(500, "Dashboard internal error")
+
+        def _dispatch(self) -> None:
             parsed = urlparse(self.path)
             path = parsed.path
-            if path in {"/", "/results", "/live"}:
-                self._send_html(_dashboard_shell(root))
+            if path in {"/", "/index", "/results", "/live"}:
+                self._send_html(html)
                 return
             if path == "/api/status":
                 status = read_status(root)
                 metrics = read_metrics(root)
-                payload = {"status": status, "health": analyze_health(status, metrics)}
+                payload = {
+                    "status": status,
+                    "health": analyze_health(status, metrics),
+                }
                 self._send_json(payload)
                 return
             if path == "/api/metrics":
@@ -150,18 +197,56 @@ def make_handler(project_root: str | Path) -> type[BaseHTTPRequestHandler]:
             if path == "/api/events":
                 self._send_json({"events": read_events(root)})
                 return
-            if path == "/api/artifacts":
+            if path == "/api/artifacts" or path == "/api/files":
                 self._send_json({"artifacts": _artifact_records(root)})
                 return
-            if path == "/api/results":
+            if path == "/api/results" or path == "/api/analyses":
                 self._send_json(_results_payload(root))
                 return
             if path == "/api/protein-preview":
                 regenerate = parsed.query == "regenerate=1"
                 self._send_json(protein_preview_payload(root, regenerate=regenerate))
                 return
+            if path == "/api/structure-info":
+                self._send_json(_structure_info_payload(root, cfg))
+                return
+            if path == "/api/ligands":
+                self._send_json(_ligands_payload(root, cfg))
+                return
+            if path == "/api/live-frame-index":
+                sim_dir = root / "simulation"
+                self._send_json(read_live_frame_index(sim_dir))
+                return
+            if path == "/api/live-coordinates":
+                self._send_json(_live_coordinates_payload(root))
+                return
+            if path == "/api/playback-info":
+                max_frames = cfg.max_browser_frames
+                if "max=" in parsed.query:
+                    try:
+                        max_frames = int(parsed.query.split("max=", 1)[1].split("&")[0])
+                    except ValueError:
+                        pass
+                force = "force=1" in parsed.query
+                manifest = _load_json(root / "manifest.json")
+                duration_ns = (manifest.get("simulation") or {}).get(
+                    "duration_ns_actual"
+                )
+                self._send_json(playback_info(
+                    root,
+                    max_browser_frames=max_frames,
+                    simulation_time_ns_total=duration_ns,
+                    force=force,
+                ))
+                return
             if path == "/structure/topology.pdb":
                 self._send_structure(root)
+                return
+            if path == "/structure/live-frame.pdb":
+                self._send_live_frame(root)
+                return
+            if path == "/structure/playback.pdb":
+                self._send_playback(root)
                 return
             if path.startswith("/static/"):
                 self._send_static_asset(path.removeprefix("/static/"))
@@ -174,6 +259,7 @@ def make_handler(project_root: str | Path) -> type[BaseHTTPRequestHandler]:
         def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
             return
 
+        # ---- Generic response helpers ----
         def _send_json(self, payload: dict[str, Any]) -> None:
             body = json.dumps(payload, default=str).encode("utf-8")
             self.send_response(200)
@@ -183,8 +269,8 @@ def make_handler(project_root: str | Path) -> type[BaseHTTPRequestHandler]:
             self.end_headers()
             self.wfile.write(body)
 
-        def _send_html(self, html: str) -> None:
-            body = html.encode("utf-8")
+        def _send_html(self, html_text: str) -> None:
+            body = html_text.encode("utf-8")
             self.send_response(200)
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.send_header("Cache-Control", "no-store")
@@ -224,6 +310,46 @@ def make_handler(project_root: str | Path) -> type[BaseHTTPRequestHandler]:
             self.end_headers()
             self.wfile.write(data)
 
+        def _send_live_frame(self, root: Path) -> None:
+            sim_dir = root / "simulation"
+            live_path = sim_dir / "live_frame.pdb"
+            if not live_path.is_file():
+                self.send_error(404, "Live frame not available")
+                return
+            try:
+                data = live_path.read_bytes()
+            except OSError:
+                self.send_error(404, "Live frame not available")
+                return
+            self.send_response(200)
+            self.send_header("Content-Type", "chemical/x-pdb; charset=utf-8")
+            self.send_header("Cache-Control", "no-store")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+        def _send_playback(self, root: Path) -> None:
+            sim_dir = root / "simulation"
+            playback_path = sim_dir / "playback.pdb"
+            if not playback_path.is_file():
+                # Auto-generate on demand so the dashboard never needs
+                # to know whether the simulation phase has finished.
+                playback_info(root, max_browser_frames=cfg.max_browser_frames)
+            if not playback_path.is_file():
+                self.send_error(404, "Playback not available")
+                return
+            try:
+                data = playback_path.read_bytes()
+            except OSError:
+                self.send_error(404, "Playback not available")
+                return
+            self.send_response(200)
+            self.send_header("Content-Type", "chemical/x-pdb; charset=utf-8")
+            self.send_header("Cache-Control", "no-store")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
         def _send_static_asset(self, raw_name: str) -> None:
             name = Path(unquote(raw_name)).name
             static_root = Path(__file__).with_name("static")
@@ -248,13 +374,28 @@ def make_handler(project_root: str | Path) -> type[BaseHTTPRequestHandler]:
     return LiveDashboardHandler
 
 
+def _load_template() -> str:
+    try:
+        return DASHBOARD_TEMPLATE_PATH.read_text(encoding="utf-8")
+    except OSError:
+        return (
+            "<!doctype html><html><head><meta charset=\"utf-8\"><title>"
+            "FastMDXplora Live Dashboard</title></head><body>"
+            "<h1>Dashboard template unavailable</h1>"
+            "<p>The dashboard HTML template could not be loaded. "
+            "Reinstall the fastmdxplora package or run from the editable checkout.</p>"
+            "</body></html>"
+        )
+
+
 def serve_dashboard(
     *,
     output: str | Path,
     host: str = "127.0.0.1",
     port: int = 8765,
+    config: DashboardConfig | None = None,
 ) -> None:
-    session = start_dashboard_session(output=output, host=host, port=port)
+    session = start_dashboard_session(output=output, host=host, port=port, config=config)
     print(f"Live dashboard running at {session.url}")
     if session.port_was_changed:
         print(
@@ -277,15 +418,16 @@ def start_dashboard_session(
     host: str = "127.0.0.1",
     port: int = 8765,
     max_port_tries: int = 50,
+    config: DashboardConfig | None = None,
 ) -> DashboardSession:
     """Start the local dashboard server in a background thread."""
     root = Path(output).resolve()
-    handler = make_handler(root)
     requested_port = int(port)
     candidates = [0] if requested_port == 0 else range(requested_port, requested_port + max_port_tries)
     last_error: OSError | None = None
     for candidate in candidates:
         try:
+            handler = make_handler(root, config=config)
             server = ThreadingHTTPServer((host, int(candidate)), handler)
         except OSError as exc:
             last_error = exc
@@ -304,14 +446,19 @@ def start_dashboard_session(
             host=host,
             port=actual_port,
             requested_port=requested_port,
+            config=config,
         )
     if last_error is not None:
         raise last_error
     raise OSError("No dashboard ports were available")
 
 
-def start_test_server(project_root: str | Path) -> tuple[ThreadingHTTPServer, str]:
-    handler = make_handler(project_root)
+def start_test_server(
+    project_root: str | Path,
+    *,
+    config: DashboardConfig | None = None,
+) -> tuple[ThreadingHTTPServer, str]:
+    handler = make_handler(project_root, config=config)
     server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
@@ -365,11 +512,12 @@ def _results_payload(root: Path) -> dict[str, Any]:
     ]
     reports = [by_path[path] for path in report_paths if path in by_path]
     dashboard = by_path.get("report/dashboard.html")
+    summary = _summary_records(root, manifest, analysis_manifest, sim_manifest)
     return {
         "refreshed_at": _iso_now(),
         "has_analysis": any(record["path"].startswith("analysis/") for record in artifacts),
         "has_report": any(record["path"].startswith("report/") for record in artifacts),
-        "summary": _summary_records(root, manifest, analysis_manifest, sim_manifest),
+        "summary": summary,
         "system": _system_info(root, manifest, analysis_manifest, sim_manifest),
         "phases": _phase_records(manifest),
         "dashboard": dashboard,
@@ -377,6 +525,75 @@ def _results_payload(root: Path) -> dict[str, Any]:
         "key_plots": [plot for plot in plots if plot["title"] in KEY_PLOT_TITLES][:6],
         "reports": reports,
         "artifacts": artifacts,
+    }
+
+
+def _structure_info_payload(
+    root: Path, config: DashboardConfig
+) -> dict[str, Any]:
+    structure_path = find_structure(root)
+    if structure_path is None:
+        return {
+            "valid": False,
+            "reason": "missing",
+            "ligand_resnames": [],
+            "ligand_instances": [],
+        }
+    info = count_structure(structure_path)
+    if not info.get("valid"):
+        return dict(info, ligand_resnames=[], ligand_instances=[])
+    info["atoms_by_resname"] = ligand_atom_counts(structure_path)
+    info["explicit_ligand"] = config.ligand_resname
+    return info
+
+
+def _ligands_payload(
+    root: Path, config: DashboardConfig
+) -> dict[str, Any]:
+    structure_path = find_structure(root)
+    if structure_path is None or not structure_path.is_file():
+        return {"ligands": [], "explicit": normalise_ligand_resname(config.ligand_resname), "valid": False}
+    info = count_structure(structure_path)
+    instances = []
+    if info.get("valid"):
+        explicit = [config.ligand_resname] if config.ligand_resname else None
+        detected = detect_ligands(
+            # Reconstruct (chain, resname, resi) keys from info — we
+            # already collected them in count_structure. To avoid a
+            # second PDB walk we accept that callers that want full
+            # ligand IDs receive them via /api/structure-info.
+            (
+                (ins.chain, ins.resname, ins.resi)
+                for ins in info.get("ligand_instances", [])
+            ),
+            explicit=explicit,
+            include_cofactors=config.include_cofactors,
+        )
+        instances = [
+            {
+                "chain": inst["chain"],
+                "resname": inst["resname"],
+                "resi": inst["resi"],
+                "explicit": inst["explicit"],
+            }
+            for inst in detected["instances"]
+        ]
+    return {
+        "ligands": instances,
+        "resnames": sorted({inst["resname"] for inst in instances}),
+        "explicit": normalise_ligand_resname(config.ligand_resname),
+        "include_cofactors": config.include_cofactors,
+        "valid": True,
+    }
+
+
+def _live_coordinates_payload(root: Path) -> dict[str, Any]:
+    sim_dir = root / "simulation"
+    index = read_live_frame_index(sim_dir)
+    return {
+        "live_frame_exists": live_frame_exists(sim_dir),
+        "index": index,
+        "available": bool(index.get("live_frame_available")),
     }
 
 
@@ -522,787 +739,3 @@ def _iso_now() -> str:
     from datetime import datetime, timezone
 
     return datetime.now(timezone.utc).isoformat()
-
-
-def _dashboard_shell(root: Path) -> str:
-    output_label = root.as_posix()
-    return f"""<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>FastMDXplora Live Dashboard</title>
-  <style>
-    :root {{ color-scheme: dark; --bg:#07101b; --panel:#101a28; --line:#22364b; --text:#edf4fb; --muted:#a7b5c6; --accent:#39b7c9; --ok:#7cc66a; --warn:#efb35e; --bad:#e35d6a; }}
-    * {{ box-sizing: border-box; }}
-    body {{ margin:0; background:var(--bg); color:var(--text); font-family:Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }}
-    .layout {{ display:grid; grid-template-columns:260px minmax(0,1fr); min-height:100vh; }}
-    aside {{ border-right:1px solid var(--line); background:#071321; padding:22px 16px; }}
-    main {{ padding:24px; width:min(1480px, 100%); }}
-    .brand {{ font-weight:800; font-size:1.1rem; margin-bottom:4px; }}
-    .subtle, .muted {{ color:var(--muted); }}
-    .nav-heading {{ color:#7d8da2; font-size:.72rem; font-weight:800; letter-spacing:.07em; text-transform:uppercase; margin:20px 0 8px; }}
-    .nav-link {{ display:flex; gap:9px; align-items:center; padding:8px 10px; border-radius:8px; color:#d4deea; text-decoration:none; }}
-    .nav-link.active, .nav-link:hover {{ background:rgba(57,183,201,.14); color:white; }}
-    .view {{ display:none; }}
-    .view.active {{ display:block; }}
-    .header {{ display:flex; justify-content:space-between; gap:18px; align-items:flex-end; border-bottom:1px solid var(--line); padding-bottom:18px; margin-bottom:22px; }}
-    h1 {{ margin:0 0 6px; font-size:2rem; letter-spacing:0; }}
-    .badge {{ display:inline-flex; align-items:center; gap:8px; padding:7px 10px; border:1px solid var(--line); border-radius:999px; background:rgba(255,255,255,.04); }}
-    .dot {{ width:9px; height:9px; border-radius:99px; background:var(--warn); }}
-    .dot.ok {{ background:var(--ok); }} .dot.warning {{ background:var(--warn); }} .dot.failed {{ background:var(--bad); }}
-    .cards {{ display:grid; grid-template-columns:repeat(auto-fit,minmax(190px,1fr)); gap:14px; margin-bottom:18px; }}
-    .card, .panel {{ border:1px solid var(--line); border-radius:8px; background:linear-gradient(180deg,rgba(19,35,56,.92),rgba(16,27,41,.96)); padding:16px; }}
-    .card .label {{ color:var(--muted); font-size:.82rem; margin-bottom:8px; }} .card .value {{ font-size:1.25rem; font-weight:760; overflow-wrap:anywhere; }}
-    .progress-track {{ height:13px; border-radius:99px; background:#0b1626; border:1px solid rgba(148,163,184,.2); overflow:hidden; }}
-    .progress-fill {{ height:100%; width:0%; background:linear-gradient(90deg,var(--accent),var(--ok)); transition:width .3s ease; }}
-    .grid {{ display:grid; grid-template-columns:minmax(0,1.1fr) minmax(280px,.9fr); gap:14px; align-items:start; }}
-    .live-grid {{
-      display:grid;
-      grid-template-columns:minmax(0,2fr) minmax(320px,1fr);
-      gap:18px;
-      align-items:start;
-    }}
-    .live-main-column {{ display:grid; gap:14px; min-width:0; }}
-    .live-bottom-grid {{
-      display:grid;
-      grid-template-columns:minmax(0,1fr) minmax(300px,.8fr);
-      gap:14px;
-      align-items:start;
-      margin-top:14px;
-    }}
-    canvas {{ width:100%; height:230px; background:#0b1626; border:1px solid rgba(148,163,184,.18); border-radius:8px; }}
-    .events {{ max-height:320px; overflow:auto; display:grid; gap:8px; }}
-    .event {{ padding:8px 10px; border:1px solid rgba(148,163,184,.16); border-radius:7px; background:#0b1626; }}
-    .artifact-list {{ display:grid; grid-template-columns:repeat(auto-fit,minmax(240px,1fr)); gap:10px; }}
-    .artifact {{ color:inherit; text-decoration:none; border:1px solid var(--line); border-radius:8px; padding:10px; background:#0b1626; min-width:0; max-width:100%; overflow:hidden; display:grid; gap:3px; }}
-    .artifact-title, .artifact-subtitle, .artifact-path, .plot-meta, .plot-path, .card-subtitle {{
-      min-width:0;
-      max-width:100%;
-      overflow-wrap:anywhere;
-      word-break:break-word;
-      line-height:1.35;
-    }}
-    .artifact-title {{ font-weight:700; color:var(--text); }}
-    .artifact-subtitle, .artifact-path, .card-subtitle {{ color:var(--muted); font-size:.82rem; }}
-    .artifact-path, .plot-path {{
-      display:-webkit-box;
-      -webkit-line-clamp:2;
-      -webkit-box-orient:vertical;
-      overflow:hidden;
-    }}
-    .toolbar {{ display:flex; gap:10px; align-items:center; flex-wrap:wrap; }}
-    .button {{ border:1px solid rgba(148,163,184,.28); border-radius:7px; background:#0b1626; color:var(--text); padding:8px 11px; cursor:pointer; }}
-    .button:hover {{ border-color:rgba(57,183,201,.7); background:rgba(57,183,201,.14); }}
-    .result-state {{ margin-bottom:14px; }}
-    .plot-grid {{ display:grid; grid-template-columns:repeat(auto-fill,minmax(260px,1fr)); gap:14px; }}
-    .plot-card {{ border:1px solid var(--line); border-radius:8px; padding:12px; background:#0b1626; min-width:0; max-width:100%; overflow:hidden; display:flex; flex-direction:column; gap:10px; }}
-    .plot-card.card-sm {{ grid-column:span 1; }}
-    .plot-card.card-md {{ grid-column:span 1; }}
-    .plot-card.card-lg {{ grid-column:span 2; }}
-    .plot-card.card-wide {{ grid-column:span 2; }}
-    .plot-card h3, .plot-title {{ margin:0 0 8px; font-size:1rem; overflow-wrap:anywhere; line-height:1.15; }}
-    .plot-title-row {{ display:flex; gap:8px; justify-content:space-between; align-items:flex-start; }}
-    .size-controls {{ display:flex; gap:4px; flex-wrap:wrap; }}
-    .size-button {{ border:1px solid rgba(148,163,184,.25); background:#071321; color:var(--muted); border-radius:5px; padding:2px 5px; font-size:.68rem; cursor:pointer; }}
-    .size-button:hover, .size-button.active {{ color:white; border-color:rgba(57,183,201,.7); }}
-    .plot-frame {{ height:210px; display:flex; align-items:center; justify-content:center; border:1px solid rgba(148,163,184,.16); border-radius:8px; background:#071321; overflow:hidden; }}
-    .plot-card.card-lg .plot-frame {{ height:390px; }}
-    .plot-card.card-wide .plot-frame {{ height:260px; }}
-    .plot-frame img {{ width:100%; height:100%; object-fit:contain; display:block; }}
-    .preview-toolbar {{ display:flex; gap:7px; align-items:center; flex-wrap:wrap; margin-top:10px; }}
-    .preview-button {{ border:1px solid rgba(148,163,184,.28); border-radius:7px; background:#0b1626; color:var(--text); padding:6px 9px; cursor:pointer; font-size:.84rem; }}
-    .preview-button:hover, .preview-button.active {{ border-color:rgba(57,183,201,.7); background:rgba(57,183,201,.14); }}
-    .preview-button:disabled {{ opacity:.45; cursor:not-allowed; }}
-    .preview-note {{ margin-top:8px; color:var(--muted); font-size:.86rem; }}
-    .protein-preview-card .plot-title-row,
-    .protein-preview-card .preview-toolbar,
-    .protein-preview-card .preview-note {{
-      position:relative;
-      z-index:2;
-    }}
-    .protein-preview-card {{
-      max-height:520px;
-      overflow:hidden;
-      min-width:0;
-    }}
-    .protein-preview-frame {{
-      height:340px;
-      max-height:340px;
-      position:relative;
-      z-index:1;
-      display:flex;
-      align-items:center;
-      justify-content:center;
-      overflow:hidden;
-      border:1px solid rgba(148,163,184,.16);
-      border-radius:8px;
-      background:#071321;
-      margin-top:12px;
-    }}
-    .protein-preview-frame img {{
-      width:100%;
-      height:100%;
-      object-fit:contain;
-      display:block;
-    }}
-    .protein-view {{ width:100%; height:340px; max-height:340px; }}
-    .protein-view.hidden {{ display:none; }}
-    #proteinViewer, #protein-viewer, #protein-3dmol-viewer {{ width:100%; height:340px; max-height:340px; }}
-    .viewer-3dmol {{ width:100%; height:340px; max-height:340px; display:block; background:#08111f; }}
-    .viewer-canvas {{ width:100%; height:340px; max-height:340px; display:block; cursor:grab; background:radial-gradient(circle at 50% 42%, #162a42, #071321 70%); }}
-    .viewer-canvas.dragging {{ cursor:grabbing; }}
-    .protein-preview-card.expanded {{
-      position:fixed;
-      inset:24px;
-      z-index:30;
-      max-height:none;
-      overflow:auto;
-      box-shadow:0 26px 80px rgba(0,0,0,.55);
-    }}
-    .protein-preview-card.expanded .protein-preview-frame {{
-      height:min(72vh,720px);
-      max-height:min(72vh,720px);
-    }}
-    .protein-preview-card.expanded .protein-view,
-    .protein-preview-card.expanded #protein-viewer,
-    .protein-preview-card.expanded #protein-3dmol-viewer,
-    .protein-preview-card.expanded .viewer-3dmol,
-    .protein-preview-card.expanded .viewer-canvas {{
-      height:100%;
-      max-height:none;
-    }}
-    .protein-preview-card:not(.expanded) #protein-collapse {{ display:none; }}
-    body.protein-preview-expanded {{ overflow:hidden; }}
-    .plot-footer {{
-      margin-top:auto;
-      display:grid;
-      gap:4px;
-      min-width:0;
-      max-width:100%;
-      color:var(--muted);
-      font-size:.82rem;
-      line-height:1.35;
-    }}
-    .plot-summary, .plot-category {{
-      min-width:0;
-      max-width:100%;
-      overflow-wrap:anywhere;
-    }}
-    .plot-card.card-sm .plot-summary,
-    .plot-card.card-sm .plot-category {{
-      display:none;
-    }}
-    .phase-list {{ display:grid; gap:10px; }}
-    .phase-row {{ display:grid; grid-template-columns:1fr auto; gap:12px; align-items:center; padding:10px 12px; border:1px solid rgba(148,163,184,.16); border-radius:8px; background:#0b1626; }}
-    .table {{ display:grid; gap:8px; }}
-    .table-row {{ display:grid; grid-template-columns:minmax(130px,.35fr) minmax(0,1fr); gap:12px; padding:9px 0; border-bottom:1px solid rgba(148,163,184,.12); }}
-    .category-heading {{ margin:18px 0 10px; color:var(--muted); font-size:.82rem; text-transform:uppercase; letter-spacing:.06em; }}
-    .quick-links {{ display:grid; grid-template-columns:repeat(auto-fit,minmax(190px,1fr)); gap:10px; }}
-    @media (max-width: 1000px) {{
-      .live-grid {{ grid-template-columns:1fr; }}
-      .live-bottom-grid {{ grid-template-columns:1fr; }}
-      .protein-preview-card {{ max-height:500px; }}
-      .protein-preview-frame {{ height:320px; max-height:320px; }}
-      .protein-view, #proteinViewer, #protein-viewer, #protein-3dmol-viewer, .viewer-3dmol, .viewer-canvas {{ height:320px; max-height:320px; }}
-    }}
-    @media (max-width: 800px) {{ .layout {{ grid-template-columns:1fr; }} aside {{ border-right:0; border-bottom:1px solid var(--line); }} .grid {{ grid-template-columns:1fr; }} .header {{ display:block; }} }}
-  </style>
-</head>
-<body>
-<div class="layout">
-  <aside>
-    <div class="brand">FastMDXplora</div>
-    <div class="subtle">Local live dashboard</div>
-    <div class="nav-heading">Overview</div>
-    <a href="#dashboard" class="nav-link active" data-view-link="dashboard">Dashboard</a>
-    <a href="#live" class="nav-link" data-view-link="live">Live Simulation</a>
-    <a href="#analysis-plots" class="nav-link" data-view-link="analysis-plots">Analysis Plots</a>
-    <a href="#generated-files" class="nav-link" data-view-link="generated-files">Generated Files</a>
-    <a href="#system-info" class="nav-link" data-view-link="system-info">System Info</a>
-    <a href="#run-status" class="nav-link" data-view-link="run-status">Run Status</a>
-  </aside>
-  <main>
-    <section id="dashboard" class="view active">
-      <div class="header">
-        <div><h1>Dashboard</h1><div class="subtle">Completed results and generated files</div></div>
-        <div class="toolbar">
-          <button class="button" type="button" id="refresh-results">Refresh</button>
-          <span class="muted">Last refreshed: <span id="results-refreshed">not available</span></span>
-        </div>
-      </div>
-      <div class="panel result-state" id="results-state">Analysis outputs not available yet. They will appear here after analysis/report finishes.</div>
-      <div class="cards" id="summary-cards"></div>
-      <div class="grid">
-        <div class="panel"><h2>Phase Summary</h2><div id="dashboard-phase-list" class="phase-list"></div></div>
-        <div class="panel"><h2>Live Status Summary</h2><div id="dashboard-live-summary" class="table"></div></div>
-      </div>
-      <div class="panel" style="margin-top:14px">
-        <h2>Quick Actions</h2>
-        <div id="overview-links" class="quick-links"></div>
-      </div>
-    </section>
-    <section id="live" class="view">
-      <div class="header">
-        <div><h1>Live Simulation</h1><div class="subtle">Watching {output_label}</div></div>
-        <div class="badge"><span id="status-dot" class="dot"></span><span id="status-text">not available</span></div>
-      </div>
-      <div class="cards">
-        <div class="card"><div class="label">Current stage</div><div class="value" id="stage">not available</div></div>
-        <div class="card"><div class="label">Current step</div><div class="value" id="step">not available</div></div>
-        <div class="card"><div class="label">Frames</div><div class="value" id="frames">not available</div></div>
-        <div class="card"><div class="label">Simulation time</div><div class="value" id="sim-time">not available</div></div>
-        <div class="card"><div class="label">Elapsed wall time</div><div class="value" id="elapsed">not available</div></div>
-        <div class="card"><div class="label">Platform</div><div class="value" id="platform">not available</div></div>
-      </div>
-      <div class="live-grid">
-        <div class="live-main-column">
-          <div class="panel">
-            <h2>Progress</h2><div class="progress-track"><div id="progress-fill" class="progress-fill"></div></div>
-            <div class="muted" id="progress-label">not available</div>
-          </div>
-          <div class="panel"><h2>Energy / Temperature Trends</h2><canvas id="metrics-chart" width="900" height="260"></canvas><div class="muted" id="chart-empty">not available yet</div></div>
-        </div>
-        <div class="panel protein-preview-card" id="protein-preview-card">
-        <div class="plot-title-row">
-          <div><h2>Protein Preview</h2><span class="badge" id="protein-preview-mode">not available</span></div>
-          <div class="toolbar">
-            <button class="button" type="button" id="protein-expand" onclick="setProteinPreviewExpanded(true)">Expand</button>
-            <button class="button" type="button" id="protein-collapse" onclick="setProteinPreviewExpanded(false)">Close</button>
-          </div>
-        </div>
-        <div class="preview-toolbar" aria-label="Protein preview controls">
-          <button class="preview-button active" type="button" id="protein-view-static">PyMOL Preview</button>
-          <button class="preview-button" type="button" id="protein-view-3d">Interactive 3D</button>
-          <button class="preview-button" type="button" id="protein-spin">Spin</button>
-          <button class="preview-button" type="button" id="protein-reset">Reset view</button>
-          <button class="preview-button" type="button" id="regenerate-preview">Regenerate preview</button>
-        </div>
-        <div class="preview-note" id="protein-preview-note">Interactive 3Dmol viewer will appear when a structure is available.</div>
-        <div class="protein-preview-frame" id="protein-preview-frame">
-          <div class="protein-view" id="protein-viewer-wrap">
-            <div class="viewer-3dmol" id="protein-3dmol-viewer" aria-label="Interactive 3Dmol protein viewer"></div>
-          </div>
-          <div class="protein-view hidden" id="protein-fallback-wrap">
-            <canvas class="viewer-canvas" id="protein-viewer" width="900" height="520" aria-label="Interactive protein viewer"></canvas>
-          </div>
-          <div class="protein-view hidden" id="protein-static-wrap">
-            <p class="muted" id="protein-preview-message">No topology/PDB found yet.</p>
-          </div>
-        </div>
-        </div>
-      </div>
-      <div class="live-bottom-grid">
-        <div class="panel"><h2>Health</h2><p id="health-message">not available</p><p class="muted" id="health-explanation">not available</p></div>
-        <div class="panel"><h2>Recent events</h2><div id="events" class="events"></div></div>
-      </div>
-    </section>
-    <section id="analysis-plots" class="view">
-      <div class="header"><div><h1>Analysis Plots</h1><div class="subtle">Dashboard-native assets are used when available.</div></div></div>
-      <div id="analysis-plot-groups"></div>
-    </section>
-    <section id="generated-files" class="view">
-      <div class="header"><div><h1>Generated Files</h1><div class="subtle">Report outputs, manifests, and important artifacts</div></div></div>
-      <div class="panel" style="margin-bottom:14px"><h2>Report Artifacts</h2><div id="report-artifact-list" class="artifact-list"></div></div>
-      <div class="panel"><h2>All Generated Files</h2><div id="artifact-list" class="artifact-list"></div></div>
-    </section>
-    <section id="system-info" class="view">
-      <div class="header"><h1>System Info</h1></div>
-      <div class="panel"><div class="table" id="system-info-panel"></div></div>
-    </section>
-    <section id="run-status" class="view">
-      <div class="header"><h1>Run Status</h1></div>
-      <div class="panel"><h2>Manifest Phases</h2><div id="run-status-panel" class="phase-list"></div></div>
-      <div class="panel" style="margin-top:14px"><h2>Live Telemetry Status</h2><div id="live-status-panel" class="table"></div></div>
-    </section>
-  </main>
-</div>
-<script src="/static/3Dmol-min.js"></script>
-<script>
-const fmt = (v, fallback="not available") => (v === null || v === undefined || v === "" ? fallback : String(v));
-const setText = (id, value) => {{ document.getElementById(id).textContent = fmt(value); }};
-function showView(name) {{
-  document.querySelectorAll(".view").forEach(el => el.classList.toggle("active", el.id === name));
-  document.querySelectorAll("[data-view-link]").forEach(el => el.classList.toggle("active", el.dataset.viewLink === name));
-}}
-document.querySelectorAll("[data-view-link]").forEach(el => el.addEventListener("click", event => {{ event.preventDefault(); showView(el.dataset.viewLink); }}));
-async function fetchJson(url) {{ const res = await fetch(url, {{cache:"no-store"}}); return await res.json(); }}
-function progressFrom(status, metrics) {{
-  const latest = metrics.length ? metrics[metrics.length - 1] : {{}};
-  let pct = Number(latest.progress_percent ?? status.progress_percent);
-  if (!Number.isFinite(pct) && status.current_step && status.total_planned_steps) pct = Number(status.current_step) / Number(status.total_planned_steps) * 100;
-  return Number.isFinite(pct) ? Math.max(0, Math.min(100, pct)) : null;
-}}
-function updateCards(status, health, metrics) {{
-  const dot = document.getElementById("status-dot");
-  dot.className = "dot " + fmt(health.state, "unknown");
-  setText("status-text", health.state || status.status);
-  setText("stage", status.stage);
-  setText("step", status.current_step && status.total_planned_steps ? `${{status.current_step}} / ${{status.total_planned_steps}}` : status.current_step);
-  setText("frames", status.current_frame_count && status.planned_frame_count ? `${{status.current_frame_count}} / ${{status.planned_frame_count}}` : status.current_frame_count);
-  setText("sim-time", status.simulation_time_completed_ns ? `${{status.simulation_time_completed_ns}} ns` : null);
-  setText("elapsed", status.elapsed_wall_time_s ? `${{status.elapsed_wall_time_s}} s` : null);
-  setText("platform", status.platform);
-  const pct = progressFrom(status, metrics);
-  document.getElementById("progress-fill").style.width = pct === null ? "0%" : pct.toFixed(1) + "%";
-  setText("progress-label", pct === null ? null : pct.toFixed(1) + "% complete");
-  setText("health-message", health.message);
-  setText("health-explanation", health.explanation);
-  document.getElementById("live-status-panel").innerHTML = tableRows({{
-    status: status.status,
-    stage: status.stage,
-    platform: status.platform,
-    current_step: status.current_step,
-    checkpoint: status.current_checkpoint_path,
-    last_update: status.last_update_timestamp
-  }});
-  document.getElementById("dashboard-live-summary").innerHTML = tableRows({{
-    status: status.status,
-    stage: status.stage,
-    current_step: status.current_step,
-    platform: status.platform,
-    health: health.state
-  }});
-}}
-function drawChart(metrics) {{
-  const canvas = document.getElementById("metrics-chart");
-  const ctx = canvas.getContext("2d");
-  ctx.clearRect(0, 0, canvas.width, canvas.height);
-  if (!metrics.length) {{ document.getElementById("chart-empty").style.display = "block"; return; }}
-  document.getElementById("chart-empty").style.display = "none";
-  const series = [
-    {{field:"total_energy", color:"#39b7c9"}},
-    {{field:"temperature", color:"#efb35e"}}
-  ].map(spec => ({{...spec, values: metrics.map(r => Number(r[spec.field])).filter(Number.isFinite)}})).filter(s => s.values.length);
-  if (!series.length) {{ document.getElementById("chart-empty").style.display = "block"; return; }}
-  const all = series.flatMap(s => s.values);
-  const min = Math.min(...all), max = Math.max(...all), span = max === min ? 1 : max - min;
-  ctx.strokeStyle = "rgba(148,163,184,.25)"; ctx.lineWidth = 1;
-  for (let y=30; y<canvas.height-25; y+=45) {{ ctx.beginPath(); ctx.moveTo(42,y); ctx.lineTo(canvas.width-16,y); ctx.stroke(); }}
-  for (const s of series) {{
-    ctx.strokeStyle = s.color; ctx.lineWidth = 2; ctx.beginPath();
-    s.values.forEach((v, i) => {{
-      const x = 42 + (canvas.width - 64) * (i / Math.max(1, s.values.length - 1));
-      const y = 18 + (canvas.height - 46) * (1 - ((v - min) / span));
-      if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-    }});
-    ctx.stroke();
-  }}
-}}
-async function poll() {{
-  try {{
-    const [statusPayload, metricsPayload, eventsPayload] = await Promise.all([
-      fetchJson("/api/status"), fetchJson("/api/metrics"), fetchJson("/api/events")
-    ]);
-    const status = statusPayload.status || {{}};
-    const metrics = metricsPayload.metrics || [];
-    updateCards(status, statusPayload.health || {{}}, metrics);
-    drawChart(metrics);
-    document.getElementById("events").innerHTML = (eventsPayload.events || []).slice(-20).reverse().map(e => `<div class="event"><strong>${{e.level}}</strong> ${{e.message}}<div class="muted">${{e.timestamp}}</div></div>`).join("") || '<p class="muted">not available</p>';
-  }} catch (err) {{
-    setText("health-message", "Could not read live dashboard data");
-    setText("health-explanation", String(err));
-  }}
-}}
-async function refreshProteinPreview(regenerate = false) {{
-  const payload = await fetchJson("/api/protein-preview" + (regenerate ? "?regenerate=1" : ""));
-  proteinPayload = payload || {{}};
-  const staticWrap = document.getElementById("protein-static-wrap");
-  const viewerButton = document.getElementById("protein-view-3d");
-  const staticButton = document.getElementById("protein-view-static");
-  const imageUrl = payload.static_image_url || payload.image_url || payload.href;
-  if (payload.static_available && imageUrl) {{
-    staticButton.disabled = false;
-    staticWrap.innerHTML = '<a href="' + imageUrl + '"><img src="' + imageUrl + '" alt="PyMOL protein preview"></a>';
-  }} else {{
-    staticButton.disabled = true;
-    staticWrap.innerHTML = '<p class="muted" id="protein-preview-message">' + (payload.message || "PyMOL preview unavailable. Showing schematic fallback.") + '</p>';
-  }}
-  if (payload.viewer_available && payload.viewer_mode === "3dmol" && payload.structure_url) {{
-    viewerButton.disabled = false;
-    await load3DmolViewer(payload.structure_url);
-  }} else if (payload.fallback_available && payload.structure_url) {{
-    viewerButton.disabled = false;
-    await loadSchematicViewer(payload.structure_url);
-  }} else {{
-    viewerButton.disabled = true;
-  }}
-  const activeMode = currentProteinPreviewMode();
-  if (payload.viewer_available && payload.viewer_mode === "3dmol" && (activeMode === "empty" || regenerate)) {{
-    showProteinPreviewMode("viewer");
-  }} else if (payload.static_available && imageUrl && (activeMode === "empty" || regenerate)) {{
-    showProteinPreviewMode("static");
-  }} else if (!payload.static_available && payload.fallback_available) {{
-    showProteinPreviewMode("fallback");
-  }} else {{
-    showProteinPreviewMode(activeMode === "empty" ? "static" : activeMode);
-  }}
-}}
-function currentProteinPreviewMode() {{
-  if (!document.getElementById("protein-viewer-wrap").classList.contains("hidden")) return "viewer";
-  if (!document.getElementById("protein-fallback-wrap").classList.contains("hidden")) return "fallback";
-  if (!document.getElementById("protein-static-wrap").classList.contains("hidden")) return "static";
-  return "empty";
-}}
-function proteinPreviewLabel(mode) {{
-  if (mode === "viewer") {{
-    if (proteinPayload.viewer_mode === "3dmol") return "Interactive 3Dmol viewer";
-    if (proteinPayload.viewer_mode === "ngl") return "NGL viewer";
-    return "interactive viewer";
-  }}
-  if (mode === "fallback") {{
-    return "schematic fallback";
-  }}
-  if (proteinPayload.static_available) {{
-    return proteinPayload.static_mode === "pymol" ? "PyMOL render" : "static preview";
-  }}
-  return "not available";
-}}
-function proteinPreviewNote(mode) {{
-  if (mode === "viewer") {{
-    return proteinPayload.viewer_mode === "3dmol"
-      ? "Interactive 3Dmol cartoon viewer. Drag to rotate, scroll to zoom, or use Spin."
-      : "Interactive molecular viewer.";
-  }}
-  if (mode === "fallback") {{
-    return "Schematic fallback CA/backbone trace. This is not a PyMOL render or full molecular viewer.";
-  }}
-  if (proteinPayload.static_available) {{
-    return proteinPayload.static_mode === "pymol"
-      ? "Showing the PyMOL-rendered cartoon/ribbon PNG."
-      : "Showing the available static protein preview image.";
-  }}
-  return proteinPayload.message || "PyMOL preview unavailable. Showing schematic fallback.";
-}}
-function showProteinPreviewMode(mode) {{
-  const viewerWrap = document.getElementById("protein-viewer-wrap");
-  const fallbackWrap = document.getElementById("protein-fallback-wrap");
-  const staticWrap = document.getElementById("protein-static-wrap");
-  const view3d = document.getElementById("protein-view-3d");
-  const viewStatic = document.getElementById("protein-view-static");
-  const requestedViewer = mode === "viewer";
-  const requestedFallback = mode === "fallback";
-  const useViewer = requestedViewer && !view3d.disabled && proteinPayload.viewer_mode === "3dmol";
-  const useFallback = (requestedFallback || requestedViewer) && !useViewer && !view3d.disabled && proteinPayload.fallback_available;
-  const useStatic = !useViewer && !useFallback;
-  viewerWrap.classList.toggle("hidden", !useViewer);
-  fallbackWrap.classList.toggle("hidden", !useFallback);
-  staticWrap.classList.toggle("hidden", !useStatic);
-  view3d.classList.toggle("active", useViewer || useFallback);
-  viewStatic.classList.toggle("active", useStatic);
-  const active = useViewer ? "viewer" : useFallback ? "fallback" : "static";
-  setText("protein-preview-mode", proteinPreviewLabel(active));
-  setText("protein-preview-note", proteinPreviewNote(active));
-  if (useViewer) {{
-    render3DmolViewer();
-  }} else if (useFallback) {{
-    drawSchematicViewer();
-  }}
-}}
-let proteinPayload = {{}};
-let proteinViewerSource = "";
-let proteinViewer3Dmol = null;
-let proteinViewer3DmolSource = "";
-let proteinViewer3DmolPdb = "";
-let proteinViewerSpinning = false;
-const proteinFallbackViewer = {{
-  points: [],
-  angleX: -0.4,
-  angleY: 0.7,
-  zoom: 1,
-  dragging: false,
-  lastX: 0,
-  lastY: 0,
-  animation: null
-}};
-async function load3DmolViewer(url) {{
-  if (proteinViewer3DmolSource === url && proteinViewer3Dmol) {{
-    render3DmolViewer();
-    return;
-  }}
-  const res = await fetch(url, {{cache:"no-store"}});
-  proteinViewer3DmolPdb = await res.text();
-  proteinViewer3DmolSource = url;
-  if (!window.$3Dmol || !proteinViewer3DmolPdb.trim()) {{
-    proteinPayload.viewer_available = false;
-    proteinPayload.viewer_mode = null;
-    if (proteinPayload.fallback_available) await loadSchematicViewer(url);
-    return;
-  }}
-  const element = document.getElementById("protein-3dmol-viewer");
-  element.innerHTML = "";
-  proteinViewer3Dmol = $3Dmol.createViewer(element, {{backgroundColor:"#08111f"}});
-  proteinViewer3Dmol.addModel(proteinViewer3DmolPdb, "pdb");
-  proteinViewer3Dmol.setStyle({{}}, {{cartoon: {{color:"spectrum"}}}});
-  proteinViewer3Dmol.zoomTo();
-  proteinViewer3Dmol.render();
-}}
-function render3DmolViewer() {{
-  if (!proteinViewer3Dmol) return;
-  proteinViewer3Dmol.resize();
-  proteinViewer3Dmol.zoomTo();
-  proteinViewer3Dmol.render();
-}}
-async function loadSchematicViewer(url) {{
-  if (proteinViewerSource === url && proteinFallbackViewer.points.length) {{
-    drawSchematicViewer();
-    return;
-  }}
-  const res = await fetch(url, {{cache:"no-store"}});
-  const text = await res.text();
-  const points = parsePdbTrace(text);
-  proteinViewerSource = url;
-  proteinFallbackViewer.points = points;
-  if (!points.length) {{
-    document.getElementById("protein-view-3d").disabled = true;
-    if (!proteinPayload.static_available) {{
-      document.getElementById("protein-static-wrap").innerHTML = '<p class="muted">Structure loaded, but no CA atoms were found for the schematic viewer.</p>';
-    }}
-    return;
-  }}
-  drawSchematicViewer();
-}}
-function parsePdbTrace(text) {{
-  const points = [];
-  for (const line of text.split(/\\r?\\n/)) {{
-    if (!line.startsWith("ATOM") && !line.startsWith("HETATM")) continue;
-    const atom = line.slice(12, 16).trim();
-    if (atom !== "CA") continue;
-    const x = Number(line.slice(30, 38));
-    const y = Number(line.slice(38, 46));
-    const z = Number(line.slice(46, 54));
-    if (Number.isFinite(x) && Number.isFinite(y) && Number.isFinite(z)) points.push({{x, y, z}});
-  }}
-  return points;
-}}
-function drawSchematicViewer() {{
-  const canvas = document.getElementById("protein-viewer");
-  if (!canvas || !proteinFallbackViewer.points.length) return;
-  const rect = canvas.getBoundingClientRect();
-  const dpr = window.devicePixelRatio || 1;
-  canvas.width = Math.max(1, Math.floor(rect.width * dpr));
-  canvas.height = Math.max(1, Math.floor(rect.height * dpr));
-  const ctx = canvas.getContext("2d");
-  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-  const width = rect.width;
-  const height = rect.height;
-  ctx.clearRect(0, 0, width, height);
-  const projected = projectProteinPoints(width, height);
-  ctx.lineWidth = 3;
-  ctx.lineJoin = "round";
-  ctx.lineCap = "round";
-  for (let i = 1; i < projected.length; i += 1) {{
-    const prev = projected[i - 1];
-    const curr = projected[i];
-    ctx.strokeStyle = residueColor(i, projected.length);
-    ctx.beginPath();
-    ctx.moveTo(prev.x, prev.y);
-    ctx.lineTo(curr.x, curr.y);
-    ctx.stroke();
-  }}
-  for (let i = 0; i < projected.length; i += 1) {{
-    const point = projected[i];
-    ctx.fillStyle = residueColor(i, projected.length);
-    ctx.beginPath();
-    ctx.arc(point.x, point.y, Math.max(2.2, 4.5 * point.depth), 0, Math.PI * 2);
-    ctx.fill();
-  }}
-}}
-function projectProteinPoints(width, height) {{
-  const pts = proteinFallbackViewer.points;
-  const center = pts.reduce((acc, p) => ({{x: acc.x + p.x, y: acc.y + p.y, z: acc.z + p.z}}), {{x:0, y:0, z:0}});
-  center.x /= pts.length; center.y /= pts.length; center.z /= pts.length;
-  const sinX = Math.sin(proteinFallbackViewer.angleX), cosX = Math.cos(proteinFallbackViewer.angleX);
-  const sinY = Math.sin(proteinFallbackViewer.angleY), cosY = Math.cos(proteinFallbackViewer.angleY);
-  const rotated = pts.map(p => {{
-    const x0 = p.x - center.x, y0 = p.y - center.y, z0 = p.z - center.z;
-    const x1 = x0 * cosY + z0 * sinY;
-    const z1 = -x0 * sinY + z0 * cosY;
-    const y1 = y0 * cosX - z1 * sinX;
-    const z2 = y0 * sinX + z1 * cosX;
-    return {{x:x1, y:y1, z:z2}};
-  }});
-  const maxRadius = Math.max(1, ...rotated.map(p => Math.hypot(p.x, p.y)));
-  const scale = Math.min(width, height) * 0.38 * proteinFallbackViewer.zoom / maxRadius;
-  const zMin = Math.min(...rotated.map(p => p.z));
-  const zMax = Math.max(...rotated.map(p => p.z));
-  const zSpan = zMax === zMin ? 1 : zMax - zMin;
-  return rotated.map(p => ({{
-    x: width / 2 + p.x * scale,
-    y: height / 2 - p.y * scale,
-    depth: 0.55 + 0.45 * ((p.z - zMin) / zSpan)
-  }}));
-}}
-function residueColor(index, total) {{
-  const hue = Math.round(210 + (index / Math.max(1, total - 1)) * 130);
-  return `hsl(${{hue}}, 84%, 62%)`;
-}}
-function animateProteinSpin() {{
-  if (!proteinViewerSpinning) return;
-  proteinFallbackViewer.angleY += 0.012;
-  drawSchematicViewer();
-  proteinFallbackViewer.animation = requestAnimationFrame(animateProteinSpin);
-}}
-function setProteinSpin(active) {{
-  proteinViewerSpinning = active;
-  document.getElementById("protein-spin").classList.toggle("active", active);
-  if (proteinViewer3Dmol && currentProteinPreviewMode() === "viewer") {{
-    proteinViewer3Dmol.spin(active);
-    proteinViewer3Dmol.render();
-    return;
-  }}
-  if (active) animateProteinSpin();
-  else if (proteinFallbackViewer.animation) cancelAnimationFrame(proteinFallbackViewer.animation);
-}}
-function resetProteinViewer() {{
-  if (proteinViewer3Dmol && currentProteinPreviewMode() === "viewer") {{
-    proteinViewer3Dmol.spin(false);
-    proteinViewerSpinning = false;
-    document.getElementById("protein-spin").classList.remove("active");
-    proteinViewer3Dmol.zoomTo();
-    proteinViewer3Dmol.render();
-    return;
-  }}
-  proteinFallbackViewer.angleX = -0.4;
-  proteinFallbackViewer.angleY = 0.7;
-  proteinFallbackViewer.zoom = 1;
-  drawSchematicViewer();
-}}
-function bindProteinViewerControls() {{
-  const canvas = document.getElementById("protein-viewer");
-  canvas.addEventListener("mousedown", event => {{
-    proteinFallbackViewer.dragging = true;
-    proteinFallbackViewer.lastX = event.clientX;
-    proteinFallbackViewer.lastY = event.clientY;
-    canvas.classList.add("dragging");
-  }});
-  window.addEventListener("mouseup", () => {{ proteinFallbackViewer.dragging = false; canvas.classList.remove("dragging"); }});
-  window.addEventListener("mousemove", event => {{
-    if (!proteinFallbackViewer.dragging) return;
-    proteinFallbackViewer.angleY += (event.clientX - proteinFallbackViewer.lastX) * 0.01;
-    proteinFallbackViewer.angleX += (event.clientY - proteinFallbackViewer.lastY) * 0.01;
-    proteinFallbackViewer.lastX = event.clientX;
-    proteinFallbackViewer.lastY = event.clientY;
-    drawSchematicViewer();
-  }});
-  canvas.addEventListener("wheel", event => {{
-    event.preventDefault();
-    proteinFallbackViewer.zoom = Math.max(0.45, Math.min(3, proteinFallbackViewer.zoom + (event.deltaY < 0 ? 0.08 : -0.08)));
-    drawSchematicViewer();
-  }}, {{passive:false}});
-  document.getElementById("protein-view-3d").addEventListener("click", () => showProteinPreviewMode("viewer"));
-  document.getElementById("protein-view-static").addEventListener("click", () => showProteinPreviewMode("static"));
-  document.getElementById("protein-spin").addEventListener("click", () => setProteinSpin(!proteinViewerSpinning));
-  document.getElementById("protein-reset").addEventListener("click", resetProteinViewer);
-  document.getElementById("protein-expand").addEventListener("click", () => setProteinPreviewExpanded(true));
-  document.getElementById("protein-collapse").addEventListener("click", () => setProteinPreviewExpanded(false));
-}}
-function setProteinPreviewExpanded(expanded) {{
-  const card = document.getElementById("protein-preview-card");
-  card.classList.toggle("expanded", expanded);
-  document.body.classList.toggle("protein-preview-expanded", expanded);
-  document.getElementById("protein-expand").textContent = expanded ? "Expanded" : "Expand";
-  window.setTimeout(() => {{
-    if (currentProteinPreviewMode() === "viewer") render3DmolViewer();
-    if (currentProteinPreviewMode() === "fallback") drawSchematicViewer();
-  }}, 50);
-}}
-function artifactLink(a) {{
-  return `<a class="artifact" href="${{a.href}}" title="${{a.path}}"><span class="artifact-title">${{a.name}}</span><span class="artifact-path">${{a.display_path || a.path}}</span></a>`;
-}}
-function plotCard(p) {{
-  return `<article class="plot-card card-md" data-card-key="${{p.path}}"><div class="plot-title-row"><div><h3 class="plot-title">${{p.title}}</h3><span class="badge">${{p.mode}}</span></div><div class="size-controls" aria-label="Card size"><button type="button" class="size-button" data-card-size="sm">S</button><button type="button" class="size-button active" data-card-size="md">M</button><button type="button" class="size-button" data-card-size="lg">L</button><button type="button" class="size-button" data-card-size="wide">Wide</button></div></div><div class="plot-frame"><a href="${{p.href}}"><img src="${{p.href}}" alt="${{p.title}}"></a></div><div class="plot-footer"><div class="plot-summary">${{p.mode}}</div><div class="plot-category">${{p.category}}</div><a class="artifact-path plot-path" href="${{p.href}}" title="${{p.path}}">${{p.display_path || p.path}}</a></div></article>`;
-}}
-function summaryCard(card) {{
-  return `<article class="card"><div class="label">${{card.label}}</div><div class="value">${{card.value}}</div></article>`;
-}}
-function phaseRow(row) {{
-  return `<div class="phase-row"><strong>${{row.name}}</strong><span class="badge">${{row.status}}</span></div>`;
-}}
-function tableRows(obj) {{
-  return Object.entries(obj || {{}}).map(([key, value]) => `<div class="table-row"><strong>${{key.replaceAll("_", " ")}}</strong><span class="muted">${{fmt(value)}}</span></div>`).join("") || '<p class="muted">not available</p>';
-}}
-function groupedPlotSections(plots) {{
-  if (!plots.length) return '<div class="panel">Analysis outputs not available yet. They will appear here after analysis/report finishes.</div>';
-  const groups = {{}};
-  for (const plot of plots) {{
-    const category = plot.category || "Other";
-    if (!groups[category]) groups[category] = [];
-    groups[category].push(plot);
-  }}
-  return Object.entries(groups).map(([category, items]) => `<section><h2 class="category-heading">${{category}}</h2><div class="plot-grid">${{items.map(plotCard).join("")}}</div></section>`).join("");
-}}
-function bindPlotSizing() {{
-  const key = "fastmdx-live-card-layout:" + window.location.pathname;
-  let saved = {{}};
-  try {{ saved = JSON.parse(localStorage.getItem(key) || "{{}}"); }} catch (_) {{ saved = {{}}; }}
-  for (const card of document.querySelectorAll(".plot-card[data-card-key]")) {{
-    const stored = saved[card.dataset.cardKey] || "md";
-    applyCardSize(card, stored, false);
-    for (const button of card.querySelectorAll("[data-card-size]")) {{
-      button.onclick = () => applyCardSize(card, button.dataset.cardSize, true);
-    }}
-  }}
-  function applyCardSize(card, size, persist) {{
-    for (const name of ["sm", "md", "lg", "wide"]) card.classList.remove("card-" + name);
-    card.classList.add("card-" + (size || "md"));
-    for (const button of card.querySelectorAll("[data-card-size]")) {{
-      button.classList.toggle("active", button.dataset.cardSize === size);
-    }}
-    if (persist) {{
-      saved[card.dataset.cardKey] = size;
-      try {{ localStorage.setItem(key, JSON.stringify(saved)); }} catch (_) {{}}
-    }}
-  }}
-}}
-function overviewLinks(reports) {{
-  const byPath = Object.fromEntries((reports || []).map(item => [item.path, item]));
-  const internal = [
-    {{label:"Live Simulation", href:"#live", view:"live"}},
-    {{label:"Analysis Plots", href:"#analysis-plots", view:"analysis-plots"}},
-    {{label:"Generated Files", href:"#generated-files", view:"generated-files"}},
-  ];
-  const outputLinks = [
-    ["Static Dashboard HTML", "report/dashboard.html"],
-    ["Markdown Report", "report/report.md"],
-    ["Slides PPTX", "report/slides.pptx"],
-    ["Bundle", "report/project_bundle.zip"],
-  ].map(([label, path]) => byPath[path] ? {{label, href: byPath[path].href, path}} : null).filter(Boolean);
-  return [...internal, ...outputLinks].map(link => `<a class="artifact" href="${{link.href}}" data-view-target="${{link.view || ""}}" title="${{link.path || link.label}}"><span class="artifact-title">${{link.label}}</span><span class="artifact-subtitle">${{link.path || "Open tab"}}</span></a>`).join("");
-}}
-async function refreshResults() {{
-  const payload = await fetchJson("/api/results");
-  const artifacts = payload.artifacts || [];
-  const plots = payload.plots || [];
-  const reports = payload.reports || [];
-  setText("results-refreshed", payload.refreshed_at);
-  const state = document.getElementById("results-state");
-  if (!payload.has_analysis && !payload.has_report) {{
-    state.style.display = "block";
-    state.textContent = "Analysis outputs not available yet. They will appear here after analysis/report finishes.";
-  }} else {{
-    state.style.display = "none";
-  }}
-  document.getElementById("summary-cards").innerHTML = (payload.summary || []).map(summaryCard).join("");
-  document.getElementById("dashboard-phase-list").innerHTML = (payload.phases || []).map(phaseRow).join("");
-  document.getElementById("analysis-plot-groups").innerHTML = groupedPlotSections(plots);
-  bindPlotSizing();
-  document.getElementById("overview-links").innerHTML = overviewLinks(reports);
-  for (const link of document.querySelectorAll("[data-view-target]")) {{
-    if (link.dataset.viewTarget) link.onclick = (event) => {{ event.preventDefault(); showView(link.dataset.viewTarget); }};
-  }}
-  document.getElementById("report-artifact-list").innerHTML = reports.map(artifactLink).join("") || '<p class="muted">Report artifacts not available yet.</p>';
-  document.getElementById("artifact-list").innerHTML = artifacts.map(artifactLink).join("") || '<p class="muted">No generated files found yet.</p>';
-  document.getElementById("system-info-panel").innerHTML = tableRows(payload.system || {{}});
-  document.getElementById("run-status-panel").innerHTML = (payload.phases || []).map(phaseRow).join("") || '<p class="muted">not available</p>';
-}}
-document.getElementById("refresh-results").addEventListener("click", () => refreshResults().catch(err => setText("results-state", String(err))));
-document.getElementById("regenerate-preview").addEventListener("click", () => refreshProteinPreview(true).catch(err => setText("protein-preview-message", String(err))));
-bindProteinViewerControls();
-poll(); refreshResults(); refreshProteinPreview();
-setInterval(poll, 3000);
-setInterval(() => refreshResults().catch(() => {{}}), 5000);
-setInterval(() => refreshProteinPreview().catch(() => {{}}), 5000);
-</script>
-</body>
-</html>"""

--- a/src/fastmdxplora/live/server.py
+++ b/src/fastmdxplora/live/server.py
@@ -24,6 +24,12 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import unquote, urlparse
 
+from fastmdxplora.live.launcher import (
+    DashboardRuntime,
+    build_launcher_command,
+    launcher_defaults,
+    validate_launcher_payload,
+)
 from fastmdxplora.live.ligand_detection import detect_ligands, normalise_ligand_resname
 from fastmdxplora.live.live_frames import live_frame_exists, read_live_frame_index
 from fastmdxplora.live.protein_preview import find_structure, protein_preview_payload
@@ -143,6 +149,7 @@ class DashboardSession:
     port: int
     requested_port: int
     config: DashboardConfig | None = None
+    runtime: DashboardRuntime | None = None
 
     @property
     def url(self) -> str:
@@ -150,7 +157,10 @@ class DashboardSession:
 
     @property
     def port_was_changed(self) -> bool:
-        return self.port != self.requested_port
+        # Port 0 explicitly asks the operating system for any free port; that
+        # is not a fallback caused by a conflict and should not be reported as
+        # one to the user.
+        return self.requested_port != 0 and self.port != self.requested_port
 
     def stop(self) -> None:
         self.server.shutdown()
@@ -167,8 +177,14 @@ def make_handler(
     project_root: str | Path,
     config: DashboardConfig | None = None,
     template_html: str | None = None,
+    runtime: DashboardRuntime | None = None,
 ) -> type[BaseHTTPRequestHandler]:
     root = Path(project_root).resolve()
+    app_runtime = runtime or DashboardRuntime(
+        workspace_root=root,
+        launch_root=root.parent,
+        active_root=root,
+    )
     cfg = config or DashboardConfig()
     html = template_html if template_html is not None else _load_template()
     refresh_seconds = min(60.0, max(1.0, float(cfg.refresh_seconds or 3.0)))
@@ -184,11 +200,28 @@ def make_handler(
                 logger.warning("dashboard route failed: %s", exc)
                 self.send_error(500, "Dashboard internal error")
 
+        def do_POST(self) -> None:  # noqa: N802 - stdlib API
+            try:
+                self._dispatch_post()
+            except Exception as exc:  # noqa: BLE001 — launcher errors stay local
+                logger.warning("dashboard POST route failed: %s", exc)
+                self._send_json(
+                    {"ok": False, "error": "Dashboard request failed."},
+                    status=500,
+                )
+
         def _dispatch(self) -> None:
             parsed = urlparse(self.path)
             path = parsed.path
+            root = app_runtime.data_root()
             if path in {"/", "/index", "/results", "/live"}:
                 self._send_html(html)
+                return
+            if path == "/api/app-state" or path == "/api/launcher/state":
+                self._send_json(app_runtime.snapshot())
+                return
+            if path == "/api/launcher/defaults":
+                self._send_json(launcher_defaults())
                 return
             if path == "/api/status":
                 status = read_status(root)
@@ -277,13 +310,51 @@ def make_handler(
                 return
             self.send_error(404, "Not found")
 
+        def _dispatch_post(self) -> None:
+            parsed = urlparse(self.path)
+            path = parsed.path
+            payload = self._read_json_body()
+            if path == "/api/launcher/validate":
+                result = validate_launcher_payload(payload)
+                if result.get("valid"):
+                    config_payload = result["config"]
+                    output_dir = app_runtime.launch_root / str(config_payload["run_name"])
+                    result["output"] = str(output_dir)
+                    result["command"] = build_launcher_command(config_payload, output_dir)
+                self._send_json(result, status=200 if result.get("valid") else 422)
+                return
+            if path == "/api/launcher/launch":
+                dashboard_url = self.headers.get("Origin")
+                result = app_runtime.launch(payload, dashboard_url=dashboard_url)
+                self._send_json(result, status=201 if result.get("launched") else 422)
+                return
+            if path == "/api/launcher/stop":
+                self._send_json(app_runtime.stop())
+                return
+            self.send_error(404, "Not found")
+
         def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
             return
 
         # ---- Generic response helpers ----
-        def _send_json(self, payload: dict[str, Any]) -> None:
+        def _read_json_body(self) -> dict[str, Any]:
+            try:
+                length = int(self.headers.get("Content-Length", "0") or 0)
+            except ValueError:
+                length = 0
+            if length <= 0:
+                return {}
+            if length > 1_000_000:
+                raise ValueError("Request body is too large")
+            raw = self.rfile.read(length)
+            data = json.loads(raw.decode("utf-8"))
+            if not isinstance(data, dict):
+                raise ValueError("JSON body must be an object")
+            return data
+
+        def _send_json(self, payload: dict[str, Any], *, status: int = 200) -> None:
             body = json.dumps(payload, default=str).encode("utf-8")
-            self.send_response(200)
+            self.send_response(status)
             self.send_header("Content-Type", "application/json; charset=utf-8")
             self.send_header("Cache-Control", "no-store")
             self.send_header("Content-Length", str(len(body)))
@@ -452,8 +523,17 @@ def serve_dashboard(
     host: str = "127.0.0.1",
     port: int = 8765,
     config: DashboardConfig | None = None,
+    home_mode: bool = False,
+    launch_root: str | Path | None = None,
 ) -> None:
-    session = start_dashboard_session(output=output, host=host, port=port, config=config)
+    session = start_dashboard_session(
+        output=output,
+        host=host,
+        port=port,
+        config=config,
+        home_mode=home_mode,
+        launch_root=launch_root,
+    )
     print(f"Live dashboard running at {session.url}")
     if session.port_was_changed:
         print(
@@ -477,15 +557,23 @@ def start_dashboard_session(
     port: int = 8765,
     max_port_tries: int = 50,
     config: DashboardConfig | None = None,
+    home_mode: bool = False,
+    launch_root: str | Path | None = None,
 ) -> DashboardSession:
     """Start the local dashboard server in a background thread."""
     root = Path(output).resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    runtime = DashboardRuntime(
+        workspace_root=root,
+        launch_root=Path(launch_root).resolve() if launch_root is not None else root.parent,
+        active_root=None if home_mode else root,
+    )
     requested_port = int(port)
     candidates = [0] if requested_port == 0 else range(requested_port, requested_port + max_port_tries)
     last_error: OSError | None = None
     for candidate in candidates:
         try:
-            handler = make_handler(root, config=config)
+            handler = make_handler(root, config=config, runtime=runtime)
             server = ThreadingHTTPServer((host, int(candidate)), handler)
         except OSError as exc:
             last_error = exc
@@ -505,6 +593,7 @@ def start_dashboard_session(
             port=actual_port,
             requested_port=requested_port,
             config=config,
+            runtime=runtime,
         )
     if last_error is not None:
         raise last_error
@@ -515,8 +604,15 @@ def start_test_server(
     project_root: str | Path,
     *,
     config: DashboardConfig | None = None,
+    home_mode: bool = False,
 ) -> tuple[ThreadingHTTPServer, str]:
-    handler = make_handler(project_root, config=config)
+    root = Path(project_root).resolve()
+    runtime = DashboardRuntime(
+        workspace_root=root,
+        launch_root=root.parent,
+        active_root=None if home_mode else root,
+    )
+    handler = make_handler(root, config=config, runtime=runtime)
     server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()

--- a/src/fastmdxplora/live/server.py
+++ b/src/fastmdxplora/live/server.py
@@ -8,11 +8,16 @@ and caches the result.
 
 from __future__ import annotations
 
+import io
 import json
 import logging
 import mimetypes
+import os
+import subprocess
+import sys
 import threading
 import time
+import zipfile
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -120,6 +125,7 @@ class DashboardConfig:
     include_cofactors: bool = False
     binding_pocket_cutoff_A: float = 5.0
     max_browser_frames: int = 200
+    refresh_seconds: float = 3.0
 
     @property
     def binding_pocket_cutoff_m(self) -> float:
@@ -165,6 +171,8 @@ def make_handler(
     root = Path(project_root).resolve()
     cfg = config or DashboardConfig()
     html = template_html if template_html is not None else _load_template()
+    refresh_seconds = min(60.0, max(1.0, float(cfg.refresh_seconds or 3.0)))
+    html = html.replace("__FASTMDX_REFRESH_SECONDS__", f"{refresh_seconds:g}")
 
     class LiveDashboardHandler(BaseHTTPRequestHandler):
         server_version = "FastMDXLive/1.0"
@@ -228,16 +236,25 @@ def make_handler(
                     except ValueError:
                         pass
                 force = "force=1" in parsed.query
-                manifest = _load_json(root / "manifest.json")
-                duration_ns = (manifest.get("simulation") or {}).get(
-                    "duration_ns_actual"
-                )
+                sim_manifest = _load_json(root / "simulation" / "simulation_parameters.json")
+                duration_ns = sim_manifest.get("duration_ns_actual")
                 self._send_json(playback_info(
                     root,
                     max_browser_frames=max_frames,
                     simulation_time_ns_total=duration_ns,
                     force=force,
                 ))
+                return
+            if path == "/api/open-output":
+                opened, detail = _open_local_path(root)
+                self._send_json({
+                    "opened": opened,
+                    "path": str(root),
+                    "detail": detail,
+                })
+                return
+            if path == "/analysis-figures-svg.zip":
+                self._send_svg_bundle(root)
                 return
             if path == "/structure/topology.pdb":
                 self._send_structure(root)
@@ -252,7 +269,11 @@ def make_handler(
                 self._send_static_asset(path.removeprefix("/static/"))
                 return
             if path.startswith("/artifacts/"):
-                self._send_artifact(root, path.removeprefix("/artifacts/"))
+                self._send_artifact(
+                    root,
+                    path.removeprefix("/artifacts/"),
+                    download="download=1" in parsed.query,
+                )
                 return
             self.send_error(404, "Not found")
 
@@ -278,7 +299,13 @@ def make_handler(
             self.end_headers()
             self.wfile.write(body)
 
-        def _send_artifact(self, root: Path, raw_rel: str) -> None:
+        def _send_artifact(
+            self,
+            root: Path,
+            raw_rel: str,
+            *,
+            download: bool = False,
+        ) -> None:
             try:
                 target = (root / unquote(raw_rel)).resolve()
                 target.relative_to(root)
@@ -293,6 +320,38 @@ def make_handler(
             self.send_response(200)
             self.send_header("Content-Type", content_type)
             self.send_header("Cache-Control", "no-store")
+            if download:
+                safe_name = target.name.replace('"', "")
+                self.send_header(
+                    "Content-Disposition",
+                    f'attachment; filename="{safe_name}"',
+                )
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+        def _send_svg_bundle(self, root: Path) -> None:
+            """Download every generated SVG analysis/report figure as one ZIP."""
+            svg_paths = _svg_figure_paths(root)
+            if not svg_paths:
+                self.send_error(404, "No SVG figures are available yet")
+                return
+            buffer = io.BytesIO()
+            with zipfile.ZipFile(buffer, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
+                for source in svg_paths:
+                    try:
+                        relative = source.relative_to(root).as_posix()
+                        archive.write(source, arcname=relative)
+                    except (OSError, ValueError):
+                        continue
+            data = buffer.getvalue()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/zip")
+            self.send_header("Cache-Control", "no-store")
+            self.send_header(
+                "Content-Disposition",
+                'attachment; filename="fastmdxplora_svg_figures.zip"',
+            )
             self.send_header("Content-Length", str(len(data)))
             self.end_headers()
             self.wfile.write(data)
@@ -351,13 +410,12 @@ def make_handler(
             self.wfile.write(data)
 
         def _send_static_asset(self, raw_name: str) -> None:
-            name = Path(unquote(raw_name)).name
             static_root = Path(__file__).with_name("static")
-            target = (static_root / name).resolve()
+            target = (static_root / unquote(raw_name)).resolve()
             try:
                 target.relative_to(static_root.resolve())
             except ValueError:
-                self.send_error(403, "Static asset path is outside the asset directory")
+                self.send_error(404, "Static asset not found")
                 return
             if not target.is_file():
                 self.send_error(404, "Static asset not found")
@@ -481,9 +539,13 @@ def _artifact_records(root: Path) -> list[dict[str, str]]:
                 "path": rel,
                 "name": path.name,
                 "href": f"/artifacts/{rel}?v={int(path.stat().st_mtime)}",
+                "download_href": (
+                    f"/artifacts/{rel}?download=1&v={int(path.stat().st_mtime)}"
+                ),
                 "size": str(path.stat().st_size),
                 "mtime": str(path.stat().st_mtime),
                 "display_path": _compact_path(rel),
+                "absolute_path": str(path.resolve()),
             }
         )
     return records
@@ -503,26 +565,36 @@ def _results_payload(root: Path) -> dict[str, Any]:
     analysis_manifest = _load_json(root / "analysis" / "analysis_manifest.json")
     sim_manifest = _load_json(root / "simulation" / "simulation_parameters.json")
     plots = _plot_records(artifacts)
-    report_paths = [
-        "report/report.md",
-        "report/slides.pptx",
-        "report/project_bundle.zip",
-        "report/dashboard.html",
-        "analysis/analysis_manifest.json",
+    report_suffixes = {".md", ".html", ".htm", ".pdf", ".pptx", ".zip"}
+    reports = [
+        record
+        for record in artifacts
+        if record["path"].startswith("report/")
+        and len(Path(record["path"]).parts) == 2
+        and Path(record["path"]).suffix.lower() in report_suffixes
     ]
-    reports = [by_path[path] for path in report_paths if path in by_path]
+    reports.sort(key=lambda record: _report_order(record["path"]))
     dashboard = by_path.get("report/dashboard.html")
     summary = _summary_records(root, manifest, analysis_manifest, sim_manifest)
+    setup_manifest = _load_json(root / "setup" / "setup_parameters.json")
+    system = _system_info(root, manifest, analysis_manifest, sim_manifest)
     return {
         "refreshed_at": _iso_now(),
         "has_analysis": any(record["path"].startswith("analysis/") for record in artifacts),
         "has_report": any(record["path"].startswith("report/") for record in artifacts),
+        "output_dir": str(root),
+        "run_title": _run_title(root, manifest),
         "summary": summary,
-        "system": _system_info(root, manifest, analysis_manifest, sim_manifest),
+        "system": system,
+        "setup": _setup_details(setup_manifest),
+        "simulation": _simulation_details(sim_manifest, read_status(root)),
         "phases": _phase_records(manifest),
+        "analyses": _analysis_records(analysis_manifest, artifacts, plots),
         "dashboard": dashboard,
         "plots": plots,
         "key_plots": [plot for plot in plots if plot["title"] in KEY_PLOT_TITLES][:6],
+        "svg_figure_count": len(_svg_figure_paths(root)),
+        "svg_bundle_href": "/analysis-figures-svg.zip",
         "reports": reports,
         "artifacts": artifacts,
     }
@@ -541,9 +613,23 @@ def _structure_info_payload(
         }
     info = count_structure(structure_path)
     if not info.get("valid"):
-        return dict(info, ligand_resnames=[], ligand_instances=[])
+        return dict(
+            info,
+            structure_available=True,
+            structure_url="/structure/topology.pdb",
+            ligand_resnames=[],
+            ligand_instances=[],
+        )
     info["atoms_by_resname"] = ligand_atom_counts(structure_path)
     info["explicit_ligand"] = config.ligand_resname
+    try:
+        info["structure_path"] = structure_path.relative_to(root).as_posix()
+    except ValueError:
+        info["structure_path"] = structure_path.as_posix()
+    info["structure_url"] = (
+        f"/structure/topology.pdb?v={int(structure_path.stat().st_mtime_ns)}"
+    )
+    info["structure_available"] = True
     return info
 
 
@@ -563,8 +649,9 @@ def _ligands_payload(
             # second PDB walk we accept that callers that want full
             # ligand IDs receive them via /api/structure-info.
             (
-                (ins.chain, ins.resname, ins.resi)
+                (str(ins.get("chain", "A")), str(ins.get("resname", "")), str(ins.get("resi", "")))
                 for ins in info.get("ligand_instances", [])
+                if isinstance(ins, dict)
             ),
             explicit=explicit,
             include_cofactors=config.include_cofactors,
@@ -611,20 +698,44 @@ def _summary_records(
     analysis_manifest: dict[str, Any],
     sim_manifest: dict[str, Any],
 ) -> list[dict[str, str]]:
-    status = str(manifest.get("status") or "not available")
-    frames = analysis_manifest.get("n_frames") or sim_manifest.get("n_production_frames")
+    phase_statuses = [
+        str(item.get("status") or "unknown").lower()
+        for item in manifest.get("phases", [])
+        if isinstance(item, dict)
+    ]
+    if phase_statuses and all(value in {"ok", "completed", "skipped"} for value in phase_statuses):
+        status = "completed"
+    elif any(value in {"error", "failed"} for value in phase_statuses):
+        status = "failed"
+    elif phase_statuses:
+        status = "in progress"
+    else:
+        status = "not available"
+    frames = _first_present(
+        analysis_manifest.get("n_frames"),
+        sim_manifest.get("n_production_frames"),
+    )
     atoms = analysis_manifest.get("n_atoms")
     sim_time = sim_manifest.get("duration_ns_actual")
     live_status = read_status(root)
-    temperature = live_status.get("target_temperature_K") or _last_metric_value(root, "temperature")
-    latest = live_status.get("status") or status
+    temperature = _first_present(
+        live_status.get("target_temperature_K"),
+        _last_metric_value(root, "temperature"),
+    )
+    latest = _first_present(live_status.get("status"), status)
     return [
         {"label": "Project status", "value": status},
         {"label": "Latest status", "value": str(latest or "not available")},
-        {"label": "Frames", "value": str(frames or "not available")},
-        {"label": "Atoms", "value": str(atoms or "not available")},
-        {"label": "Simulation time", "value": f"{sim_time} ns" if sim_time is not None else "not available"},
-        {"label": "Temperature", "value": f"{temperature} K" if temperature not in (None, "") else "not available"},
+        {"label": "Frames", "value": _display_value(frames)},
+        {"label": "Atoms", "value": _display_value(atoms)},
+        {
+            "label": "Simulation time",
+            "value": f"{sim_time} ns" if sim_time is not None else "not available",
+        },
+        {
+            "label": "Temperature",
+            "value": f"{temperature} K" if temperature not in (None, "") else "not available",
+        },
     ]
 
 
@@ -643,15 +754,197 @@ def _system_info(
     sim_manifest: dict[str, Any],
 ) -> dict[str, str]:
     live_status = read_status(root)
+    params = sim_manifest.get("parameters")
+    if not isinstance(params, dict):
+        params = sim_manifest
     return {
-        "system": str(manifest.get("system") or "not available"),
+        "system": _display_value(manifest.get("system")),
         "output_folder": root.as_posix(),
-        "atoms": str(analysis_manifest.get("n_atoms") or "not available"),
-        "frames": str(analysis_manifest.get("n_frames") or "not available"),
-        "platform": str(live_status.get("platform") or sim_manifest.get("platform_used") or "not available"),
-        "timestep_fs": str(live_status.get("timestep_fs") or "not available"),
-        "checkpoint": str(live_status.get("current_checkpoint_path") or "not available"),
+        "atoms": _display_value(analysis_manifest.get("n_atoms")),
+        "frames": _display_value(
+            _first_present(
+                analysis_manifest.get("n_frames"),
+                sim_manifest.get("n_production_frames"),
+            )
+        ),
+        "platform": _display_value(
+            _first_present(
+                live_status.get("platform"),
+                sim_manifest.get("platform_used"),
+                sim_manifest.get("platform"),
+                params.get("platform"),
+            )
+        ),
+        "timestep_fs": _display_value(
+            _first_present(live_status.get("timestep_fs"), params.get("timestep_fs"))
+        ),
+        "checkpoint": _display_value(
+            _first_present(
+                live_status.get("current_checkpoint_path"),
+                live_status.get("checkpoint_path"),
+            )
+        ),
     }
+
+
+def _run_title(root: Path, manifest: dict[str, Any]) -> str:
+    options = manifest.get("options") if isinstance(manifest.get("options"), dict) else {}
+    report_options = options.get("report") if isinstance(options.get("report"), dict) else {}
+    title = (
+        report_options.get("title")
+        or report_options.get("report_title")
+        or manifest.get("title")
+    )
+    if title:
+        return str(title)
+    system = manifest.get("system")
+    if system:
+        return f"{Path(str(system)).stem} · FastMDXplora"
+    return root.name or "FastMDXplora Live"
+
+
+def _setup_details(setup_manifest: dict[str, Any]) -> dict[str, Any]:
+    params = setup_manifest.get("parameters")
+    if not isinstance(params, dict):
+        params = setup_manifest
+    forcefield = setup_manifest.get("resolved_forcefield")
+    if not isinstance(forcefield, dict):
+        forcefield = {}
+    ligand = forcefield.get("ligand") or params.get("ligand")
+    if isinstance(ligand, dict):
+        ligand = ligand.get("name") or ligand.get("files")
+    return {
+        "ph": _first_present(params.get("ph"), params.get("pH")),
+        "ion_concentration_M": _first_present(
+            params.get("ion_concentration_M"),
+            params.get("ion_concentration_m"),
+        ),
+        "force_field": _first_present(
+            forcefield.get("name"),
+            forcefield.get("protein_forcefield"),
+            forcefield.get("forcefield"),
+            params.get("forcefield"),
+            params.get("force_field"),
+        ),
+        "water_model": _first_present(
+            forcefield.get("water_model"),
+            params.get("water_model"),
+        ),
+        "ligand": ligand,
+    }
+
+
+def _simulation_details(
+    sim_manifest: dict[str, Any],
+    live_status: dict[str, Any],
+) -> dict[str, Any]:
+    params = sim_manifest.get("parameters")
+    if not isinstance(params, dict):
+        params = sim_manifest
+    return {
+        "platform": _first_present(
+            live_status.get("platform"),
+            sim_manifest.get("platform_used"),
+            sim_manifest.get("platform"),
+            params.get("platform"),
+        ),
+        "precision": _first_present(
+            live_status.get("precision"),
+            params.get("precision"),
+        ),
+        "temperature_K": _first_present(
+            live_status.get("target_temperature_K"),
+            params.get("temperature_K"),
+        ),
+        "timestep_fs": _first_present(
+            live_status.get("timestep_fs"),
+            params.get("timestep_fs"),
+        ),
+        "friction_per_ps": params.get("friction_per_ps"),
+        "pressure_bar": _first_present(
+            params.get("pressure_bar"),
+            params.get("pressure_atm"),
+        ),
+        "duration_ns_actual": _first_present(
+            sim_manifest.get("duration_ns_actual"),
+            params.get("duration_ns"),
+        ),
+        "n_production_frames": _first_present(
+            sim_manifest.get("n_production_frames"),
+            live_status.get("current_frame_count"),
+        ),
+    }
+
+
+def _analysis_records(
+    analysis_manifest: dict[str, Any],
+    artifacts: list[dict[str, str]],
+    plots: list[dict[str, str]],
+) -> list[dict[str, Any]]:
+    results = analysis_manifest.get("results")
+    if not isinstance(results, dict):
+        if analysis_manifest.get("status"):
+            return [
+                {
+                    "name": "analysis",
+                    "title": "Analysis",
+                    "status": str(analysis_manifest.get("status")),
+                    "message": str(analysis_manifest.get("note") or ""),
+                    "artifacts": [],
+                    "plot": None,
+                }
+            ]
+        return []
+
+    records: list[dict[str, Any]] = []
+    for name, raw in results.items():
+        data = raw if isinstance(raw, dict) else {}
+        prefix = f"analysis/{name}/"
+        related = [record for record in artifacts if record["path"].startswith(prefix)]
+        plot = next(
+            (
+                item
+                for item in plots
+                if item["path"].startswith(prefix)
+                or _normalise_analysis_name(item["title"]) == _normalise_analysis_name(str(name))
+            ),
+            None,
+        )
+        records.append(
+            {
+                "name": str(name),
+                "title": PLOT_TITLE_ALIASES.get(str(name).lower(), _humanize_stem(str(name))),
+                "status": str(data.get("status") or "unknown"),
+                "message": str(data.get("message") or ""),
+                "started_at": data.get("started_at"),
+                "finished_at": data.get("finished_at"),
+                "artifacts": related,
+                "plot": plot,
+            }
+        )
+    return records
+
+
+def _normalise_analysis_name(value: str) -> str:
+    return "".join(ch for ch in value.lower() if ch.isalnum())
+
+
+def _report_order(path: str) -> tuple[int, str]:
+    preferred = {
+        "report/dashboard.html": 0,
+        "report/report.md": 1,
+        "report/slides.pptx": 2,
+        "report/project_bundle.zip": 3,
+    }
+    return preferred.get(path, 99), path
+
+
+def _first_present(*values: Any) -> Any:
+    return next((value for value in values if value not in (None, "")), None)
+
+
+def _display_value(value: Any) -> str:
+    return "not available" if value in (None, "") else str(value)
 
 
 def _phase_records(manifest: dict[str, Any]) -> list[dict[str, str]]:
@@ -669,6 +962,12 @@ def _phase_records(manifest: dict[str, Any]) -> list[dict[str, str]]:
 
 
 def _plot_records(artifacts: list[dict[str, str]]) -> list[dict[str, str]]:
+    """Return one display record per scientific figure, paired with SVG.
+
+    PNG is preferred for fast browser previews while a matching true-vector
+    SVG is exposed for publication download.  Pairing by normalized title also
+    handles report/dashboard_assets copies and per-analysis artifact names.
+    """
     image_suffixes = {".png", ".jpg", ".jpeg", ".gif", ".svg"}
     candidates = [
         record for record in artifacts
@@ -678,24 +977,42 @@ def _plot_records(artifacts: list[dict[str, str]]) -> list[dict[str, str]]:
             or record["path"].startswith("analysis/")
         )
     ]
-    chosen: dict[str, dict[str, str]] = {}
+    grouped: dict[str, list[dict[str, str]]] = {}
     for record in candidates:
         title = _plot_title(record["path"])
-        if not title:
-            continue
-        current = chosen.get(title)
-        if current is None or _plot_priority(record["path"]) < _plot_priority(current["path"]):
-            mode = "dashboard view" if record["path"].startswith("report/dashboard_assets/") else "artifact fallback"
-            enriched = dict(record)
+        if title:
+            grouped.setdefault(title, []).append(record)
+
+    results: list[dict[str, str]] = []
+    for title, records in grouped.items():
+        display = min(records, key=lambda item: _plot_record_priority(item["path"]))
+        svg_candidates = [item for item in records if Path(item["path"]).suffix.lower() == ".svg"]
+        svg = min(svg_candidates, key=lambda item: _plot_priority(item["path"])) if svg_candidates else None
+        mode = "dashboard view" if display["path"].startswith("report/dashboard_assets/") else "artifact fallback"
+        enriched = dict(display)
+        enriched.update(
+            {
+                "title": title,
+                "category": PLOT_CATEGORY_BY_TITLE.get(title, _plot_category(display["path"])),
+                "mode": mode,
+            }
+        )
+        if svg is not None:
             enriched.update(
                 {
-                    "title": title,
-                    "category": PLOT_CATEGORY_BY_TITLE.get(title, _plot_category(record["path"])),
-                    "mode": mode,
+                    "svg_path": svg["path"],
+                    "svg_href": svg["href"],
+                    "svg_download_href": svg["download_href"],
                 }
             )
-            chosen[title] = enriched
-    return sorted(chosen.values(), key=lambda item: (_category_order(item["category"]), item["title"]))
+        results.append(enriched)
+    return sorted(results, key=lambda item: (_category_order(item["category"]), item["title"]))
+
+
+def _plot_record_priority(path: str) -> tuple[int, int]:
+    suffix = Path(path).suffix.lower()
+    suffix_priority = {".png": 0, ".jpg": 1, ".jpeg": 1, ".gif": 2, ".svg": 3}
+    return _plot_priority(path), suffix_priority.get(suffix, 9)
 
 
 def _plot_priority(path: str) -> int:
@@ -735,7 +1052,34 @@ def _category_order(category: str) -> int:
     return order.get(category, 99)
 
 
+def _svg_figure_paths(root: Path) -> list[Path]:
+    """Return generated SVG figures, excluding branding/static assets."""
+    paths: list[Path] = []
+    for base in (root / "analysis", root / "report" / "dashboard_assets", root / "report"):
+        if not base.is_dir():
+            continue
+        for path in base.rglob("*.svg"):
+            if path.is_file() and path not in paths:
+                paths.append(path)
+    return sorted(paths)
+
+
 def _iso_now() -> str:
     from datetime import datetime, timezone
 
     return datetime.now(timezone.utc).isoformat()
+
+
+def _open_local_path(path: Path) -> tuple[bool, str]:
+    """Open ``path`` in the host file manager on a best-effort basis."""
+
+    try:
+        if os.name == "nt":
+            os.startfile(str(path))  # type: ignore[attr-defined]
+        elif sys.platform == "darwin":
+            subprocess.Popen(["open", str(path)])
+        else:
+            subprocess.Popen(["xdg-open", str(path)])
+    except Exception as exc:  # noqa: BLE001 - dashboard helper only
+        return False, str(exc)
+    return True, "opened"

--- a/src/fastmdxplora/live/static/aai-research-logo.svg
+++ b/src/fastmdxplora/live/static/aai-research-logo.svg
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 96" fill="none" role="img" aria-label="AAI Research Lab logo">
+  <title>AAI Research Lab</title>
+  <desc>Three-node molecular mark with the AAI Research Lab wordmark.</desc>
+  <!-- Molecular mark: three nodes around a central atom, with restrained accents -->
+  <g transform="translate(8,4)">
+    <!-- Bounding hex outline, thin graphite -->
+    <polygon points="44,4 78,24 78,64 44,84 10,64 10,24"
+             stroke="rgba(245,245,247,0.18)" stroke-width="1.2" fill="rgba(255,255,255,0.02)"/>
+    <!-- Bonds -->
+    <line x1="44" y1="44" x2="78" y2="24" stroke="rgba(99,230,255,0.55)" stroke-width="1.6"/>
+    <line x1="44" y1="44" x2="78" y2="64" stroke="rgba(167,139,250,0.55)" stroke-width="1.6"/>
+    <line x1="44" y1="44" x2="10" y2="24" stroke="rgba(167,139,250,0.55)" stroke-width="1.6"/>
+    <line x1="44" y1="44" x2="10" y2="64" stroke="rgba(99,230,255,0.55)" stroke-width="1.6"/>
+    <line x1="44" y1="44" x2="44" y2="6" stroke="rgba(245,245,247,0.35)" stroke-width="1.4"/>
+    <!-- Central atom -->
+    <circle cx="44" cy="44" r="5.5" fill="#ffffff" stroke="rgba(0,0,0,0.2)" stroke-width="0.6"/>
+    <!-- Surrounding atoms -->
+    <circle cx="78" cy="24" r="4.0" fill="#63e6ff"/>
+    <circle cx="78" cy="64" r="4.0" fill="#a78bfa"/>
+    <circle cx="10" cy="24" r="4.0" fill="#a78bfa"/>
+    <circle cx="10" cy="64" r="4.0" fill="#63e6ff"/>
+    <circle cx="44" cy="6" r="2.6" fill="#d8d8dd"/>
+    <!-- Orbit ellipse, very faint -->
+    <ellipse cx="44" cy="44" rx="40" ry="14"
+             stroke="rgba(245,245,247,0.10)" stroke-width="1"
+             fill="none" transform="rotate(-22 44 44)"/>
+  </g>
+  <!-- Wordmark -->
+  <g font-family="'Inter', 'Segoe UI', system-ui, sans-serif" fill="#f5f5f7">
+    <text x="108" y="44" font-size="22" font-weight="700" letter-spacing="0.4">AAI</text>
+    <text x="156" y="44" font-size="22" font-weight="300" letter-spacing="0.6">Research Lab</text>
+    <text x="108" y="68" font-size="10" font-weight="500" letter-spacing="3.2"
+          fill="#b5b5bb" text-transform="uppercase">MOLECULAR DYNAMICS</text>
+  </g>
+</svg>

--- a/src/fastmdxplora/live/static/aai-research-mark.svg
+++ b/src/fastmdxplora/live/static/aai-research-mark.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" role="img" aria-label="AAI Research Lab mark">
+  <title>AAI Research Lab mark</title>
+  <polygon points="32,4 56,18 56,46 32,60 8,46 8,18"
+           stroke="rgba(245,245,247,0.20)" stroke-width="1.6" fill="rgba(255,255,255,0.025)"/>
+  <line x1="32" y1="32" x2="56" y2="18" stroke="rgba(99,230,255,0.6)" stroke-width="1.8"/>
+  <line x1="32" y1="32" x2="56" y2="46" stroke="rgba(99,230,255,0.6)" stroke-width="1.8"/>
+  <line x1="32" y1="32" x2="8" y2="18" stroke="rgba(167,139,250,0.6)" stroke-width="1.8"/>
+  <line x1="32" y1="32" x2="8" y2="46" stroke="rgba(167,139,250,0.6)" stroke-width="1.8"/>
+  <line x1="32" y1="32" x2="32" y2="6" stroke="rgba(245,245,247,0.4)" stroke-width="1.6"/>
+  <circle cx="32" cy="32" r="6" fill="#ffffff"/>
+  <circle cx="56" cy="18" r="4.2" fill="#63e6ff"/>
+  <circle cx="56" cy="46" r="4.2" fill="#63e6ff"/>
+  <circle cx="8" cy="18" r="4.2" fill="#a78bfa"/>
+  <circle cx="8" cy="46" r="4.2" fill="#a78bfa"/>
+  <circle cx="32" cy="6" r="2.6" fill="#d8d8dd"/>
+</svg>

--- a/src/fastmdxplora/live/static/charts.js
+++ b/src/fastmdxplora/live/static/charts.js
@@ -1,14 +1,4 @@
-/* FastMDXplora Live Dashboard — charts
- *
- * Lightweight canvas charts for the Live Simulation page. We rebuild
- * each chart's data buffer in place (no full canvas redraw) so updates
- * feel smooth even at high polling cadence. The set of canvases is
- * declared in dashboard.html as <canvas class="chart-canvas"
- * data-chart="...">; we discover them on load.
-
- * No chart library is used — keeping the offline mandate simple and
- * the footprint small.
- */
+/* FastMDXplora Live Dashboard — dependency-free canvas charts. */
 
 (function () {
   "use strict";
@@ -19,176 +9,281 @@
     violet: "#a78bfa",
     silver: "#d8d8dd",
     green: "#67e8a3",
-    red: "#ff7272",
   };
-
   const GRID = "rgba(255, 255, 255, 0.06)";
   const AXIS = "#777780";
 
-  /* chart configurations */
-  const CHARTS = [
-    {key: "potential_energy", color: COLORS.cyan,   label: "Potential energy",      unit: "kJ/mol"},
-    {key: "temperature",      color: COLORS.orange, label: "Temperature",          unit: "K"},
-    {key: "density",          color: COLORS.violet, label: "Density",              unit: "g/mL"},
-    {key: "speed",            color: COLORS.silver, label: "Simulation speed",     unit: "ns/day"},
+  const CONFIG = [
+    {key: "potential_energy", label: "Potential energy", unit: "kJ/mol", color: COLORS.cyan},
+    {key: "temperature", label: "Temperature", unit: "K", color: COLORS.orange},
+    {key: "density", label: "Density", unit: "g/mL", color: COLORS.violet},
+    {key: "speed", label: "Simulation speed", unit: "ns/day", color: COLORS.silver},
   ];
 
-  /** chart key -> {canvas, ctx, lastSeries, lastBounds} */
-  const chartState = new Map();
+  const states = new Map();
+  let lastMetrics = [];
+  let resizeObserver = null;
+
+  document.addEventListener("DOMContentLoaded", init);
 
   function init() {
     document.querySelectorAll(".chart-canvas").forEach((canvas) => {
       const key = canvas.getAttribute("data-chart");
-      const colorName = canvas.getAttribute("data-color") || "cyan";
-      chartState.set(key, {
+      const ctx = canvas.getContext("2d");
+      if (!key || !ctx) return;
+      states.set(key, {
         canvas,
-        ctx: canvas.getContext("2d"),
-        lastSeries: null,
-        lastBounds: null,
-        color: COLORS[colorName] || COLORS.cyan,
+        ctx,
+        points: [],
+        needsDraw: true,
       });
     });
-    window.addEventListener("resize", () => draw());
-    window.FastMDXDashboard &&
-      window.FastMDXDashboard.on("playback-ready", () => draw());
+
+    if (window.ResizeObserver) {
+      resizeObserver = new ResizeObserver(() => drawAll());
+      states.forEach((entry) => resizeObserver.observe(entry.canvas));
+    }
+    window.addEventListener("resize", drawAll);
+    window.addEventListener("dashboard:live-page-opened", () => {
+      requestAnimationFrame(() => requestAnimationFrame(drawAll));
+    });
+    wireChartControls();
   }
 
-  /** @param {Array<{step:number, [key]:string}>} metrics */
+  function wireChartControls() {
+    const select = document.getElementById("chart-metric-select");
+    if (select && !select.options.length) {
+      const all = document.createElement("option");
+      all.value = "all";
+      all.textContent = "All metrics";
+      select.appendChild(all);
+      CONFIG.forEach((config) => {
+        const option = document.createElement("option");
+        option.value = config.key;
+        option.textContent = config.label;
+        select.appendChild(option);
+      });
+    }
+    select?.addEventListener("change", () => {
+      const selected = select.value;
+      document.querySelectorAll(".chart-row").forEach((row) => {
+        const key = row.querySelector(".chart-canvas")?.getAttribute("data-chart");
+        row.hidden = selected !== "all" && key !== selected;
+      });
+      requestAnimationFrame(drawAll);
+    });
+    document.getElementById("chart-reset")?.addEventListener("click", () => {
+      if (select) select.value = "all";
+      document.querySelectorAll(".chart-row").forEach((row) => { row.hidden = false; });
+      requestAnimationFrame(drawAll);
+    });
+  }
+
   function update(metrics) {
-    for (const chart of CHARTS) {
-      const state = chartState.get(chart.key);
-      if (!state) continue;
-      const values = metrics
-        .map((row) => parseFloat(row[chart.key]))
-        .filter((v) => Number.isFinite(v));
-      state.lastSeries = values;
-      drawChart(state, chart, values);
-    }
+    lastMetrics = Array.isArray(metrics) ? metrics : [];
+    CONFIG.forEach((config) => {
+      const entry = states.get(config.key);
+      if (!entry) return;
+      entry.points = lastMetrics
+        .map((row, index) => {
+          const value = Number(row[config.key]);
+          const step = Number(row.step);
+          return {
+            x: Number.isFinite(step) ? step : index,
+            y: value,
+          };
+        })
+        .filter((point) => Number.isFinite(point.y));
+      entry.needsDraw = true;
+    });
+    updateEmptyState();
+    drawAll();
+  }
+
+  function updateEmptyState() {
     const empty = document.getElementById("chart-empty");
-    if (empty) {
-      const any = Array.from(chartState.values()).some((s) => s.lastSeries && s.lastSeries.length);
-      empty.style.display = any ? "none" : "block";
+    if (!empty) return;
+    const anyData = Array.from(states.values()).some((entry) => entry.points.length > 0);
+    empty.style.display = anyData ? "none" : "block";
+    if (!anyData) {
+      empty.textContent = lastMetrics.length
+        ? "Telemetry samples exist, but none contain chartable values."
+        : "Live telemetry will appear after the first sample.";
     }
   }
 
-  function draw() {
-    for (const chart of CHARTS) {
-      const state = chartState.get(chart.key);
-      if (!state || !state.lastSeries) continue;
-      drawChart(state, chart, state.lastSeries);
-    }
+  function drawAll() {
+    CONFIG.forEach((config) => {
+      const entry = states.get(config.key);
+      if (entry) drawChart(entry, config);
+    });
   }
 
-  function drawChart(state, chart, values) {
-    const canvas = state.canvas;
-    if (!canvas) return;
+  function drawChart(entry, config) {
+    const canvas = entry.canvas;
+    if (!canvas.isConnected || canvas.closest("[hidden]")) {
+      entry.needsDraw = true;
+      return;
+    }
     const rect = canvas.getBoundingClientRect();
-    const dpr = window.devicePixelRatio || 1;
-    canvas.width = Math.max(1, Math.floor(rect.width * dpr));
-    canvas.height = Math.max(1, Math.floor(rect.height * dpr));
-    const ctx = state.ctx;
-    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-    ctx.clearRect(0, 0, rect.width, rect.height);
-
-    /* Background gradient */
-    const grad = ctx.createLinearGradient(0, 0, 0, rect.height);
-    grad.addColorStop(0, "rgba(99,230,255,0.04)");
-    grad.addColorStop(1, "rgba(99,230,255,0)");
-    ctx.fillStyle = grad;
-    ctx.fillRect(0, 0, rect.width, rect.height);
-
-    /* Threshold markers */
-    drawThresholds(ctx, chart, rect);
-
-    /* Grid */
-    ctx.strokeStyle = GRID;
-    ctx.lineWidth = 1;
-    for (let y = 20; y < rect.height - 18; y += 36) {
-      ctx.beginPath(); ctx.moveTo(40, y); ctx.lineTo(rect.width - 12, y); ctx.stroke();
-    }
-
-    if (!values || !values.length) {
-      ctx.fillStyle = AXIS;
-      ctx.font = "12px " + monoFont();
-      ctx.fillText("no data yet", rect.width / 2 - 36, rect.height / 2);
+    if (rect.width < 40 || rect.height < 40) {
+      entry.needsDraw = true;
       return;
     }
 
-    const min = Math.min(...values);
-    const max = Math.max(...values);
-    const span = max === min ? 1 : max - min;
-    const padding = 18;
-    const plotWidth = rect.width - 52;
-    const plotHeight = rect.height - 30;
+    const dpr = Math.max(1, window.devicePixelRatio || 1);
+    const pixelWidth = Math.max(1, Math.round(rect.width * dpr));
+    const pixelHeight = Math.max(1, Math.round(rect.height * dpr));
+    if (canvas.width !== pixelWidth || canvas.height !== pixelHeight) {
+      canvas.width = pixelWidth;
+      canvas.height = pixelHeight;
+    }
 
-    /* Series line */
-    ctx.strokeStyle = chart.color;
-    ctx.lineWidth = 2;
+    const ctx = entry.ctx;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, rect.width, rect.height);
+    drawBackground(ctx, rect);
+
+    const points = entry.points;
+    if (!points.length) {
+      drawGrid(ctx, rect);
+      ctx.fillStyle = AXIS;
+      ctx.font = `12px ${monoFont()}`;
+      ctx.textAlign = "center";
+      ctx.fillText("no data yet", rect.width / 2, rect.height / 2);
+      entry.needsDraw = false;
+      return;
+    }
+
+    const yValues = points.map((point) => point.y);
+    let minY = Math.min(...yValues);
+    let maxY = Math.max(...yValues);
+    if (minY === maxY) {
+      const padding = Math.max(Math.abs(minY) * 0.02, 1e-6);
+      minY -= padding;
+      maxY += padding;
+    } else {
+      const padding = (maxY - minY) * 0.08;
+      minY -= padding;
+      maxY += padding;
+    }
+    const minX = Math.min(...points.map((point) => point.x));
+    const maxX = Math.max(...points.map((point) => point.x));
+    const bounds = {minY, maxY, minX, maxX};
+
+    drawThresholds(ctx, config, rect, bounds);
+    drawGrid(ctx, rect);
+    drawSeries(ctx, rect, bounds, points, config.color);
+    drawLabels(ctx, rect, bounds, points.length, config.unit);
+    entry.needsDraw = false;
+  }
+
+  function drawBackground(ctx, rect) {
+    const gradient = ctx.createLinearGradient(0, 0, 0, rect.height);
+    gradient.addColorStop(0, "rgba(99,230,255,0.035)");
+    gradient.addColorStop(1, "rgba(99,230,255,0)");
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, rect.width, rect.height);
+  }
+
+  function drawGrid(ctx, rect) {
+    const area = plotArea(rect);
+    ctx.strokeStyle = GRID;
+    ctx.lineWidth = 1;
+    for (let row = 0; row <= 4; row += 1) {
+      const y = area.top + (area.height * row / 4);
+      ctx.beginPath();
+      ctx.moveTo(area.left, y);
+      ctx.lineTo(area.right, y);
+      ctx.stroke();
+    }
+  }
+
+  function drawSeries(ctx, rect, bounds, points, color) {
+    const area = plotArea(rect);
+    const spanX = bounds.maxX - bounds.minX || 1;
+    const spanY = bounds.maxY - bounds.minY || 1;
+    const coords = points.map((point, index) => ({
+      x: area.left + area.width * (
+        points.length === 1 ? 0.5 : (point.x - bounds.minX) / spanX
+      ),
+      y: area.bottom - area.height * ((point.y - bounds.minY) / spanY),
+      index,
+    }));
+
     ctx.beginPath();
-    values.forEach((v, i) => {
-      const x = 40 + plotWidth * (i / Math.max(1, values.length - 1));
-      const y = padding + plotHeight * (1 - ((v - min) / span));
-      if (i === 0) ctx.moveTo(x, y);
-      else ctx.lineTo(x, y);
+    coords.forEach((point, index) => {
+      if (index === 0) ctx.moveTo(point.x, point.y);
+      else ctx.lineTo(point.x, point.y);
     });
+    ctx.lineWidth = 2;
+    ctx.strokeStyle = color;
     ctx.stroke();
 
-    /* Soft area under the curve */
-    ctx.lineTo(40 + plotWidth, padding + plotHeight);
-    ctx.lineTo(40, padding + plotHeight);
-    ctx.closePath();
-    ctx.fillStyle = hexToRgba(chart.color, 0.08);
-    ctx.fill();
+    if (coords.length > 1) {
+      ctx.lineTo(coords[coords.length - 1].x, area.bottom);
+      ctx.lineTo(coords[0].x, area.bottom);
+      ctx.closePath();
+      ctx.fillStyle = hexToRgba(color, 0.075);
+      ctx.fill();
+    } else {
+      ctx.beginPath();
+      ctx.arc(coords[0].x, coords[0].y, 3, 0, Math.PI * 2);
+      ctx.fillStyle = color;
+      ctx.fill();
+    }
+  }
 
-    /* Min / max labels */
+  function drawLabels(ctx, rect, bounds, samples, unit) {
+    const area = plotArea(rect);
     ctx.fillStyle = AXIS;
-    ctx.font = "10px " + monoFont();
+    ctx.font = `10px ${monoFont()}`;
     ctx.textAlign = "left";
-    ctx.fillText(min.toFixed(2), 6, padding + 4);
-    ctx.fillText(max.toFixed(2), 6, padding + plotHeight - 4);
+    ctx.fillText(formatAxis(bounds.maxY), 6, area.top + 4);
+    ctx.fillText(formatAxis(bounds.minY), 6, area.bottom);
     ctx.textAlign = "right";
-    ctx.fillText(`${values.length} samples`, rect.width - 14, padding + 4);
-    ctx.fillText(chart.unit, rect.width - 14, padding + plotHeight - 4);
+    ctx.fillText(`${samples} sample${samples === 1 ? "" : "s"}`, rect.width - 12, area.top + 4);
+    ctx.fillText(unit, rect.width - 12, area.bottom);
   }
 
-  function drawThresholds(ctx, chart, rect) {
-    if (chart.key === "temperature") {
-      /* Standard MD operating band: 270K..330K (broad OK). */
-      drawBand(ctx, 270, 330, COLORS.green, rect, 0.06);
-    }
-    if (chart.key === "density") {
-      drawBand(ctx, 0.98, 1.04, COLORS.green, rect, 0.06);
-    }
-    if (chart.key === "potential_energy") {
-      /* "Healthy" range is trajectory-specific; we draw nothing by
-         default. NaN / Inf values are screened out upstream. */
-    }
+  function drawThresholds(ctx, config, rect, bounds) {
+    if (config.key === "temperature") drawBand(ctx, rect, bounds, 270, 330, COLORS.green);
+    if (config.key === "density") drawBand(ctx, rect, bounds, 0.98, 1.04, COLORS.green);
   }
 
-  function drawBand(ctx, lo, hi, color, rect, alpha) {
-    const padding = 18;
-    const plotHeight = rect.height - 30;
-    const range = ctx.canvas.__lastRange;
-    if (!range) return;
-    const yLo = padding + plotHeight * (1 - (lo - range.min) / (range.max - range.min || 1));
-    const yHi = padding + plotHeight * (1 - (hi - range.min) / (range.max - range.min || 1));
-    ctx.fillStyle = hexToRgba(color, alpha);
-    ctx.fillRect(40, Math.min(yLo, yHi), rect.width - 52, Math.abs(yHi - yLo));
+  function drawBand(ctx, rect, bounds, low, high, color) {
+    const area = plotArea(rect);
+    if (high < bounds.minY || low > bounds.maxY) return;
+    const span = bounds.maxY - bounds.minY || 1;
+    const yLow = area.bottom - area.height * ((Math.max(low, bounds.minY) - bounds.minY) / span);
+    const yHigh = area.bottom - area.height * ((Math.min(high, bounds.maxY) - bounds.minY) / span);
+    ctx.fillStyle = hexToRgba(color, 0.055);
+    ctx.fillRect(area.left, Math.min(yLow, yHigh), area.width, Math.abs(yLow - yHigh));
   }
 
-  function hexToRgba(hex, a) {
-    const m = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
-    if (!m) return hex;
-    return `rgba(${parseInt(m[1], 16)}, ${parseInt(m[2], 16)}, ${parseInt(m[3], 16)}, ${a})`;
+  function plotArea(rect) {
+    const left = 46;
+    const right = rect.width - 12;
+    const top = 22;
+    const bottom = rect.height - 18;
+    return {left, right, top, bottom, width: Math.max(1, right - left), height: Math.max(1, bottom - top)};
+  }
+
+  function formatAxis(value) {
+    const magnitude = Math.abs(value);
+    if ((magnitude > 0 && magnitude < 0.001) || magnitude >= 1e6) return value.toExponential(2);
+    return value.toFixed(magnitude < 10 ? 3 : 2);
+  }
+
+  function hexToRgba(hex, alpha) {
+    const match = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
+    if (!match) return hex;
+    return `rgba(${parseInt(match[1], 16)}, ${parseInt(match[2], 16)}, ${parseInt(match[3], 16)}, ${alpha})`;
   }
 
   function monoFont() {
     return "JetBrains Mono, SFMono-Regular, IBM Plex Mono, Consolas, Menlo, monospace";
   }
 
-  document.addEventListener("DOMContentLoaded", init);
-  document.addEventListener("dashboard:metrics-updated", () => {
-    /* No-op; dashboard.js calls update() directly after polling. */
-  });
-  window.FastMDXCharts = { update, draw };
-})();
+  window.FastMDXCharts = {update, draw: drawAll};
+}());

--- a/src/fastmdxplora/live/static/charts.js
+++ b/src/fastmdxplora/live/static/charts.js
@@ -1,0 +1,194 @@
+/* FastMDXplora Live Dashboard — charts
+ *
+ * Lightweight canvas charts for the Live Simulation page. We rebuild
+ * each chart's data buffer in place (no full canvas redraw) so updates
+ * feel smooth even at high polling cadence. The set of canvases is
+ * declared in dashboard.html as <canvas class="chart-canvas"
+ * data-chart="...">; we discover them on load.
+
+ * No chart library is used — keeping the offline mandate simple and
+ * the footprint small.
+ */
+
+(function () {
+  "use strict";
+
+  const COLORS = {
+    cyan: "#63e6ff",
+    orange: "#ffb86b",
+    violet: "#a78bfa",
+    silver: "#d8d8dd",
+    green: "#67e8a3",
+    red: "#ff7272",
+  };
+
+  const GRID = "rgba(255, 255, 255, 0.06)";
+  const AXIS = "#777780";
+
+  /* chart configurations */
+  const CHARTS = [
+    {key: "potential_energy", color: COLORS.cyan,   label: "Potential energy",      unit: "kJ/mol"},
+    {key: "temperature",      color: COLORS.orange, label: "Temperature",          unit: "K"},
+    {key: "density",          color: COLORS.violet, label: "Density",              unit: "g/mL"},
+    {key: "speed",            color: COLORS.silver, label: "Simulation speed",     unit: "ns/day"},
+  ];
+
+  /** chart key -> {canvas, ctx, lastSeries, lastBounds} */
+  const chartState = new Map();
+
+  function init() {
+    document.querySelectorAll(".chart-canvas").forEach((canvas) => {
+      const key = canvas.getAttribute("data-chart");
+      const colorName = canvas.getAttribute("data-color") || "cyan";
+      chartState.set(key, {
+        canvas,
+        ctx: canvas.getContext("2d"),
+        lastSeries: null,
+        lastBounds: null,
+        color: COLORS[colorName] || COLORS.cyan,
+      });
+    });
+    window.addEventListener("resize", () => draw());
+    window.FastMDXDashboard &&
+      window.FastMDXDashboard.on("playback-ready", () => draw());
+  }
+
+  /** @param {Array<{step:number, [key]:string}>} metrics */
+  function update(metrics) {
+    for (const chart of CHARTS) {
+      const state = chartState.get(chart.key);
+      if (!state) continue;
+      const values = metrics
+        .map((row) => parseFloat(row[chart.key]))
+        .filter((v) => Number.isFinite(v));
+      state.lastSeries = values;
+      drawChart(state, chart, values);
+    }
+    const empty = document.getElementById("chart-empty");
+    if (empty) {
+      const any = Array.from(chartState.values()).some((s) => s.lastSeries && s.lastSeries.length);
+      empty.style.display = any ? "none" : "block";
+    }
+  }
+
+  function draw() {
+    for (const chart of CHARTS) {
+      const state = chartState.get(chart.key);
+      if (!state || !state.lastSeries) continue;
+      drawChart(state, chart, state.lastSeries);
+    }
+  }
+
+  function drawChart(state, chart, values) {
+    const canvas = state.canvas;
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = Math.max(1, Math.floor(rect.width * dpr));
+    canvas.height = Math.max(1, Math.floor(rect.height * dpr));
+    const ctx = state.ctx;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, rect.width, rect.height);
+
+    /* Background gradient */
+    const grad = ctx.createLinearGradient(0, 0, 0, rect.height);
+    grad.addColorStop(0, "rgba(99,230,255,0.04)");
+    grad.addColorStop(1, "rgba(99,230,255,0)");
+    ctx.fillStyle = grad;
+    ctx.fillRect(0, 0, rect.width, rect.height);
+
+    /* Threshold markers */
+    drawThresholds(ctx, chart, rect);
+
+    /* Grid */
+    ctx.strokeStyle = GRID;
+    ctx.lineWidth = 1;
+    for (let y = 20; y < rect.height - 18; y += 36) {
+      ctx.beginPath(); ctx.moveTo(40, y); ctx.lineTo(rect.width - 12, y); ctx.stroke();
+    }
+
+    if (!values || !values.length) {
+      ctx.fillStyle = AXIS;
+      ctx.font = "12px " + monoFont();
+      ctx.fillText("no data yet", rect.width / 2 - 36, rect.height / 2);
+      return;
+    }
+
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    const span = max === min ? 1 : max - min;
+    const padding = 18;
+    const plotWidth = rect.width - 52;
+    const plotHeight = rect.height - 30;
+
+    /* Series line */
+    ctx.strokeStyle = chart.color;
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    values.forEach((v, i) => {
+      const x = 40 + plotWidth * (i / Math.max(1, values.length - 1));
+      const y = padding + plotHeight * (1 - ((v - min) / span));
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    });
+    ctx.stroke();
+
+    /* Soft area under the curve */
+    ctx.lineTo(40 + plotWidth, padding + plotHeight);
+    ctx.lineTo(40, padding + plotHeight);
+    ctx.closePath();
+    ctx.fillStyle = hexToRgba(chart.color, 0.08);
+    ctx.fill();
+
+    /* Min / max labels */
+    ctx.fillStyle = AXIS;
+    ctx.font = "10px " + monoFont();
+    ctx.textAlign = "left";
+    ctx.fillText(min.toFixed(2), 6, padding + 4);
+    ctx.fillText(max.toFixed(2), 6, padding + plotHeight - 4);
+    ctx.textAlign = "right";
+    ctx.fillText(`${values.length} samples`, rect.width - 14, padding + 4);
+    ctx.fillText(chart.unit, rect.width - 14, padding + plotHeight - 4);
+  }
+
+  function drawThresholds(ctx, chart, rect) {
+    if (chart.key === "temperature") {
+      /* Standard MD operating band: 270K..330K (broad OK). */
+      drawBand(ctx, 270, 330, COLORS.green, rect, 0.06);
+    }
+    if (chart.key === "density") {
+      drawBand(ctx, 0.98, 1.04, COLORS.green, rect, 0.06);
+    }
+    if (chart.key === "potential_energy") {
+      /* "Healthy" range is trajectory-specific; we draw nothing by
+         default. NaN / Inf values are screened out upstream. */
+    }
+  }
+
+  function drawBand(ctx, lo, hi, color, rect, alpha) {
+    const padding = 18;
+    const plotHeight = rect.height - 30;
+    const range = ctx.canvas.__lastRange;
+    if (!range) return;
+    const yLo = padding + plotHeight * (1 - (lo - range.min) / (range.max - range.min || 1));
+    const yHi = padding + plotHeight * (1 - (hi - range.min) / (range.max - range.min || 1));
+    ctx.fillStyle = hexToRgba(color, alpha);
+    ctx.fillRect(40, Math.min(yLo, yHi), rect.width - 52, Math.abs(yHi - yLo));
+  }
+
+  function hexToRgba(hex, a) {
+    const m = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
+    if (!m) return hex;
+    return `rgba(${parseInt(m[1], 16)}, ${parseInt(m[2], 16)}, ${parseInt(m[3], 16)}, ${a})`;
+  }
+
+  function monoFont() {
+    return "JetBrains Mono, SFMono-Regular, IBM Plex Mono, Consolas, Menlo, monospace";
+  }
+
+  document.addEventListener("DOMContentLoaded", init);
+  document.addEventListener("dashboard:metrics-updated", () => {
+    /* No-op; dashboard.js calls update() directly after polling. */
+  });
+  window.FastMDXCharts = { update, draw };
+})();

--- a/src/fastmdxplora/live/static/dashboard.css
+++ b/src/fastmdxplora/live/static/dashboard.css
@@ -96,6 +96,8 @@ html, body {
     overflow-x: hidden;
 }
 
+[hidden] { display: none !important; }
+
 body.state-loading .app-shell {
     filter: blur(6px);
     pointer-events: none;
@@ -1339,4 +1341,76 @@ body.state-ready .loading-screen {
     .metric { min-width: 60px; }
     .stage-timeline { grid-template-columns: repeat(3, minmax(0, 1fr)); }
     .page-shell { padding: 16px; }
+}
+/* Functional dashboard additions */
+.mini-preview-canvas {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+}
+.mini-preview-canvas canvas,
+.mini-preview-canvas > div {
+    background: transparent !important;
+}
+.preview-empty {
+    z-index: 2;
+    pointer-events: none;
+}
+.preview-frame[data-ready="true"] .preview-empty,
+.viewer-canvas-frame[data-ready="true"] .viewer-empty {
+    display: none;
+}
+.ac-no-plot {
+    min-height: 180px;
+    display: grid;
+    place-items: center;
+    border: 1px dashed var(--border-subtle);
+    background: rgba(255, 255, 255, 0.015);
+}
+.dashboard-toast {
+    position: fixed;
+    right: 22px;
+    bottom: 22px;
+    z-index: 10000;
+    max-width: min(440px, calc(100vw - 44px));
+    padding: 11px 14px;
+    border: 1px solid var(--border-strong);
+    border-radius: 8px;
+    color: var(--text-primary);
+    background: rgba(12, 12, 14, 0.96);
+    box-shadow: var(--shadow-deep);
+    opacity: 0;
+    transform: translateY(8px);
+    pointer-events: none;
+    transition: opacity 160ms ease, transform 160ms ease;
+    font-size: 12px;
+}
+.dashboard-toast.show {
+    opacity: 1;
+    transform: translateY(0);
+}
+.dashboard-toast[data-kind="warning"] {
+    border-color: rgba(255, 184, 107, 0.48);
+}
+.file-action[disabled],
+.chip-btn[disabled],
+.ctl-btn[disabled] {
+    opacity: 0.42;
+    cursor: not-allowed;
+}
+
+/* Analysis figure actions */
+.page-header-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+@media (max-width: 720px) {
+    .page-header-actions {
+        width: 100%;
+        justify-content: flex-start;
+    }
 }

--- a/src/fastmdxplora/live/static/dashboard.css
+++ b/src/fastmdxplora/live/static/dashboard.css
@@ -1,0 +1,1342 @@
+/* FastMDXplora Live Dashboard — AAI Research Lab visual system
+   Matte black, dark charcoal panels, restrained cyan/violet accents.
+   No external fonts or CDN dependencies. */
+
+:root {
+    color-scheme: dark;
+
+    /* Backgrounds */
+    --background-primary: #050505;
+    --background-secondary: #0a0a0b;
+    --background-elevated: #101012;
+    --background-soft: #151518;
+
+    /* Panels (frosted) */
+    --panel-glass: rgba(18, 18, 20, 0.84);
+    --panel-hover: rgba(27, 27, 31, 0.95);
+
+    /* Borders */
+    --border-primary: rgba(255, 255, 255, 0.13);
+    --border-strong: rgba(255, 255, 255, 0.25);
+    --border-subtle: rgba(255, 255, 255, 0.07);
+
+    /* Text */
+    --text-primary: #f5f5f7;
+    --text-secondary: #b5b5bb;
+    --text-muted: #777780;
+
+    /* Accents */
+    --accent-white: #ffffff;
+    --accent-silver: #d8d8dd;
+    --accent-cyan: #63e6ff;
+    --accent-blue: #6ea8ff;
+    --accent-violet: #a78bfa;
+    --accent-green: #67e8a3;
+    --accent-orange: #ffb86b;
+    --accent-red: #ff7272;
+
+    /* Status */
+    --status-live: var(--accent-cyan);
+    --status-waiting: var(--accent-orange);
+    --status-error: var(--accent-red);
+    --status-completed: var(--accent-green);
+    --status-stale: var(--text-muted);
+
+    /* Surfaces */
+    --shadow-card: 0 14px 40px rgba(0, 0, 0, 0.42);
+    --shadow-modal: 0 28px 80px rgba(0, 0, 0, 0.55);
+
+    /* Layout */
+    --sidebar-width: 248px;
+    --topbar-height: 64px;
+
+    /* Typography */
+    --font-stack: "Inter", "IBM Plex Sans", "Segoe UI", system-ui,
+                  -apple-system, BlinkMacSystemFont, sans-serif;
+    --font-mono: "JetBrains Mono", "SFMono-Regular", "IBM Plex Mono",
+                 "Consolas", "Menlo", monospace;
+
+    /* Motion */
+    --duration-fast: 120ms;
+    --duration-medium: 220ms;
+    --duration-slow: 460ms;
+    --ease: cubic-bezier(.2, .8, .2, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    :root {
+        --duration-fast: 0ms;
+        --duration-medium: 0ms;
+        --duration-slow: 0ms;
+    }
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0ms !important;
+        transition-duration: 0ms !important;
+    }
+}
+
+/* Reset */
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+html, body {
+    margin: 0;
+    padding: 0;
+    background: var(--background-primary);
+    color: var(--text-primary);
+    font-family: var(--font-stack);
+    font-size: 14px;
+    line-height: 1.45;
+    min-height: 100vh;
+    overflow-x: hidden;
+}
+
+body.state-loading .app-shell {
+    filter: blur(6px);
+    pointer-events: none;
+}
+
+a {
+    color: var(--accent-cyan);
+    text-decoration: none;
+    transition: color var(--duration-fast) var(--ease);
+}
+a:hover { color: var(--accent-silver); }
+
+button {
+    font: inherit;
+    color: inherit;
+    background: transparent;
+    border: 0;
+}
+
+::selection { background: rgba(99, 230, 255, 0.32); color: var(--accent-white); }
+
+.mono,
+.metric-value,
+.kv-table,
+.kv-form {
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+    font-feature-settings: "tnum" 1, "ss01" 1;
+}
+
+.muted { color: var(--text-muted); }
+.small { font-size: 12px; }
+.sr-only {
+    position: absolute;
+    width: 1px; height: 1px;
+    padding: 0; margin: -1px;
+    overflow: hidden; clip: rect(0,0,0,0);
+    white-space: nowrap; border: 0;
+}
+
+/* ============================================================ */
+/* App shell                          */
+/* ============================================================ */
+.app-shell {
+    display: grid;
+    grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
+    min-height: 100vh;
+    background:
+        radial-gradient(ellipse at 15% -10%, rgba(99, 230, 255, 0.06), transparent 55%),
+        radial-gradient(ellipse at 90% 110%, rgba(167, 139, 250, 0.06), transparent 55%),
+        var(--background-primary);
+}
+
+/* ============================================================ */
+/* Sidebar                            */
+/* ============================================================ */
+.sidebar {
+    background: var(--background-secondary);
+    border-right: 1px solid var(--border-subtle);
+    padding: 24px 18px 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    min-height: 100vh;
+    position: sticky;
+    top: 0;
+}
+.sidebar-brand {
+    display: grid;
+    grid-template-columns: 56px 1fr;
+    gap: 14px;
+    align-items: center;
+}
+.brand-logo {
+    width: 56px;
+    height: auto;
+    filter: drop-shadow(0 4px 12px rgba(0, 0, 0, 0.6));
+}
+.brand-text { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.brand-product {
+    font-weight: 700;
+    font-size: 15px;
+    letter-spacing: 0.2px;
+    color: var(--accent-white);
+}
+.brand-tagline {
+    color: var(--text-secondary);
+    font-size: 11px;
+    line-height: 1.4;
+    letter-spacing: 0.05em;
+}
+
+.sidebar-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-top: 4px;
+}
+.nav-heading {
+    color: var(--text-muted);
+    font-size: 11px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    margin: 12px 8px 6px;
+    font-weight: 600;
+}
+.nav-link {
+    display: grid;
+    grid-template-columns: 14px 1fr;
+    gap: 10px;
+    align-items: center;
+    padding: 9px 11px;
+    border-radius: 8px;
+    color: var(--text-secondary);
+    border-left: 2px solid transparent;
+    transition: background var(--duration-fast) var(--ease),
+                color var(--duration-fast) var(--ease),
+                border-color var(--duration-fast) var(--ease);
+}
+.nav-link:hover {
+    background: rgba(255, 255, 255, 0.03);
+    color: var(--accent-white);
+}
+.nav-link.active {
+    background: linear-gradient(90deg, rgba(99,230,255,0.10), rgba(99,230,255,0.02));
+    color: var(--accent-white);
+    border-left-color: var(--accent-cyan);
+    box-shadow: 0 0 24px rgba(99, 230, 255, 0.08) inset;
+}
+.nav-icon {
+    width: 12px;
+    height: 12px;
+    border-radius: 3px;
+    background: linear-gradient(135deg, var(--accent-cyan), var(--accent-violet));
+    opacity: 0.45;
+}
+.nav-link.active .nav-icon { opacity: 1; }
+
+.sidebar-footer {
+    margin-top: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding-top: 14px;
+    border-top: 1px solid var(--border-subtle);
+}
+.footer-row {
+    display: grid;
+    grid-template-columns: 80px 1fr;
+    gap: 12px;
+    align-items: center;
+}
+.footer-label {
+    color: var(--text-muted);
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+}
+.footer-value {
+    color: var(--text-secondary);
+    font-size: 12px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-family: var(--font-mono);
+}
+.status-dot {
+    display: inline-block;
+    width: 8px; height: 8px;
+    border-radius: 99px;
+    margin-right: 8px;
+    background: var(--accent-orange);
+    position: relative;
+}
+.status-dot-live {
+    background: var(--accent-cyan);
+    box-shadow: 0 0 0 0 rgba(99, 230, 255, 0.5);
+    animation: pulse-live 2.4s var(--ease) infinite;
+}
+.status-dot-waiting { background: var(--accent-orange); }
+.status-dot-stale {
+    background: var(--text-muted);
+    box-shadow: none;
+    animation: none;
+}
+.status-dot-error { background: var(--accent-red); }
+.status-dot-completed { background: var(--accent-green); }
+
+@keyframes pulse-live {
+    0%   { box-shadow: 0 0 0 0 rgba(99, 230, 255, 0.45); }
+    70%  { box-shadow: 0 0 0 8px rgba(99, 230, 255, 0); }
+    100% { box-shadow: 0 0 0 0 rgba(99, 230, 255, 0); }
+}
+
+/* ============================================================ */
+/* Top bar                            */
+/* ============================================================ */
+.main {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+.top-bar {
+    display: grid;
+    grid-template-columns: minmax(220px, 1fr) minmax(0, 2fr) minmax(220px, 1fr);
+    gap: 18px;
+    align-items: center;
+    padding: 14px 24px;
+    border-bottom: 1px solid var(--border-subtle);
+    background: linear-gradient(180deg, rgba(255,255,255,0.02), transparent);
+    position: sticky;
+    top: 0;
+    z-index: 5;
+    backdrop-filter: blur(12px) saturate(140%);
+    -webkit-backdrop-filter: blur(12px) saturate(140%);
+}
+.top-bar-left .run-id {
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.top-bar-left .run-title {
+    color: var(--accent-white);
+    font-weight: 700;
+    font-size: 15px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.top-bar-center {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    align-items: center;
+    justify-content: center;
+}
+.status-cluster {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--text-secondary);
+    font-size: 12px;
+}
+.status-divider { color: var(--text-muted); margin: 0 2px; }
+.status-text-muted { color: var(--text-secondary); }
+.metric-cluster {
+    display: flex;
+    gap: 18px;
+    align-items: center;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+.metric {
+    display: flex;
+    flex-direction: column;
+    line-height: 1.2;
+    align-items: flex-start;
+    min-width: 86px;
+}
+.metric-label {
+    color: var(--text-muted);
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+}
+.metric-value {
+    color: var(--text-primary);
+    font-size: 13px;
+}
+.top-bar-right {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+}
+.ghost-btn {
+    padding: 6px 12px;
+    border-radius: 8px;
+    border: 1px solid var(--border-primary);
+    background: rgba(255, 255, 255, 0.02);
+    color: var(--text-secondary);
+    font-size: 12px;
+    cursor: pointer;
+    transition: background var(--duration-fast) var(--ease),
+                border-color var(--duration-fast) var(--ease),
+                color var(--duration-fast) var(--ease);
+}
+.ghost-btn:hover {
+    color: var(--accent-white);
+    border-color: rgba(99, 230, 255, 0.45);
+    background: rgba(99, 230, 255, 0.06);
+}
+.ghost-btn[aria-pressed="true"] {
+    background: rgba(255, 184, 107, 0.10);
+    border-color: var(--accent-orange);
+    color: var(--accent-orange);
+}
+.refreshed-indicator {
+    color: var(--text-muted);
+    font-size: 11px;
+    font-family: var(--font-mono);
+}
+
+/* ============================================================ */
+/* Page shell                          */
+/* ============================================================ */
+.page-shell {
+    padding: 24px 28px 64px;
+    min-width: 0;
+    max-width: 1600px;
+    margin: 0 auto;
+    width: 100%;
+}
+.page { display: block; }
+.page[hidden] { display: none; }
+
+.page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    margin-bottom: 22px;
+    gap: 18px;
+    border-bottom: 1px solid var(--border-subtle);
+    padding-bottom: 16px;
+}
+.page-title {
+    font-size: 24px;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    margin: 0;
+    color: var(--accent-white);
+}
+.page-subtitle {
+    color: var(--text-secondary);
+    font-size: 13px;
+    margin-top: 4px;
+}
+
+/* ============================================================ */
+/* Cards                            */
+/* ============================================================ */
+.card {
+    background: var(--panel-glass);
+    border: 1px solid var(--border-primary);
+    border-radius: 12px;
+    padding: 18px 18px 16px;
+    box-shadow: var(--shadow-card);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    margin-bottom: 16px;
+    position: relative;
+    overflow: hidden;
+}
+.card::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(99,230,255,0.04), transparent 30%);
+    pointer-events: none;
+}
+.card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 14px;
+    gap: 14px;
+}
+.card-header-actions { display: flex; gap: 10px; }
+.card-title {
+    font-size: 14px;
+    font-weight: 600;
+    margin: 0;
+    color: var(--accent-white);
+    letter-spacing: 0.02em;
+}
+
+.grid { display: grid; gap: 18px; min-width: 0; }
+.grid-2 { grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); }
+.grid-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.grid-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+@media (max-width: 1100px) {
+    .grid-3, .grid-4 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+@media (max-width: 800px) {
+    .grid-2, .grid-3, .grid-4 { grid-template-columns: 1fr; }
+}
+
+/* Hero card */
+.hero-card {
+    padding: 22px 22px 20px;
+    background:
+        linear-gradient(135deg, rgba(99,230,255,0.08), rgba(167,139,250,0.06) 60%, rgba(103, 232, 163, 0.04));
+}
+.hero-card-top {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 16px;
+}
+.hero-label {
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    font-size: 11px;
+}
+.hero-status {
+    font-size: 24px;
+    font-weight: 700;
+    color: var(--accent-white);
+    margin-top: 4px;
+    letter-spacing: -0.01em;
+}
+.stage-pill {
+    display: inline-flex;
+    align-items: center;
+    padding: 5px 10px;
+    border: 1px solid var(--border-primary);
+    border-radius: 999px;
+    font-size: 12px;
+    color: var(--text-secondary);
+    text-transform: capitalize;
+}
+.stage-pill[data-state="live"] { color: var(--accent-cyan); }
+.stage-pill[data-state="completed"] { color: var(--accent-green); }
+.stage-pill[data-state="error"] { color: var(--accent-red); }
+.stage-pill[data-state="waiting"] { color: var(--accent-orange); }
+.stage-pill[data-state="stale"] { color: var(--text-muted); }
+
+.progress-large-track {
+    height: 16px;
+    border-radius: 99px;
+    background:
+        repeating-linear-gradient(90deg, rgba(255,255,255,0.04) 0 1px, transparent 1px 16px),
+        rgba(255,255,255,0.04);
+    border: 1px solid var(--border-primary);
+    overflow: hidden;
+}
+.progress-large-fill {
+    height: 100%;
+    background: linear-gradient(90deg,
+        rgba(99, 230, 255, 0.95) 0%,
+        rgba(167, 139, 250, 0.95) 60%,
+        rgba(103, 232, 163, 0.95) 100%);
+    transition: width 360ms var(--ease);
+    box-shadow: 0 0 16px rgba(99, 230, 255, 0.25);
+}
+.progress-large-meta {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    margin-top: 8px;
+    color: var(--text-secondary);
+    font-size: 12px;
+}
+.hero-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 12px;
+    margin-top: 16px;
+}
+.hero-stat {
+    padding: 10px 12px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 8px;
+    background: rgba(255,255,255,0.02);
+}
+.hero-stat-label {
+    color: var(--text-muted);
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+}
+.hero-stat-value {
+    color: var(--accent-white);
+    font-size: 16px;
+    margin-top: 4px;
+}
+
+/* Stage timeline */
+.stage-timeline {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+    gap: 10px;
+}
+.stage-step {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 6px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 10px;
+    background: rgba(255,255,255,0.02);
+    text-align: center;
+    color: var(--text-muted);
+    font-size: 12px;
+}
+.stage-marker {
+    width: 14px;
+    height: 14px;
+    border-radius: 99px;
+    background: rgba(255,255,255,0.05);
+    border: 1px solid var(--border-subtle);
+}
+.stage-step[data-state="completed"] {
+    color: var(--accent-green);
+    border-color: rgba(103, 232, 163, 0.3);
+    background: rgba(103, 232, 163, 0.05);
+}
+.stage-step[data-state="completed"] .stage-marker {
+    background: var(--accent-green);
+    box-shadow: 0 0 12px rgba(103, 232, 163, 0.4);
+}
+.stage-step[data-state="current"] {
+    color: var(--accent-cyan);
+    border-color: rgba(99, 230, 255, 0.32);
+    background: rgba(99, 230, 255, 0.07);
+}
+.stage-step[data-state="current"] .stage-marker {
+    background: var(--accent-cyan);
+    box-shadow: 0 0 14px rgba(99, 230, 255, 0.6);
+    animation: pulse-current 1.6s var(--ease) infinite;
+}
+.stage-step[data-state="skipped"] {
+    color: var(--text-muted);
+    opacity: 0.5;
+}
+.stage-step[data-state="failed"] {
+    color: var(--accent-red);
+    border-color: rgba(255, 114, 114, 0.3);
+}
+@keyframes pulse-current {
+    0%, 100% { transform: scale(1); }
+    50%      { transform: scale(1.15); }
+}
+
+/* Health list */
+.health-list {
+    list-style: none;
+    padding: 0;
+    margin: 12px 0 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+.health-list li {
+    padding: 8px 10px;
+    border-radius: 6px;
+    background: rgba(255,255,255,0.02);
+    border-left: 2px solid var(--border-subtle);
+    color: var(--text-secondary);
+    font-size: 12px;
+}
+.health-list li[data-state="ok"] { border-left-color: var(--accent-green); }
+.health-list li[data-state="warning"] { border-left-color: var(--accent-orange); }
+.health-list li[data-state="failed"] { border-left-color: var(--accent-red); }
+
+/* Metric cards */
+.metric-cards { gap: 14px; }
+.metric-card {
+    background: var(--panel-glass);
+    border: 1px solid var(--border-primary);
+    border-radius: 12px;
+    padding: 14px 16px;
+    box-shadow: var(--shadow-card);
+    position: relative;
+    overflow: hidden;
+}
+.metric-card-label {
+    color: var(--text-muted);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+}
+.metric-card-value {
+    font-size: 22px;
+    color: var(--accent-white);
+    margin-top: 4px;
+    line-height: 1.2;
+    transition: color var(--duration-fast) var(--ease);
+}
+.metric-card-unit {
+    color: var(--text-muted);
+    font-size: 11px;
+    margin-top: 2px;
+    font-family: var(--font-mono);
+}
+.metric-card[data-pulse] .metric-card-value {
+    animation: flash 1.4s var(--ease);
+}
+@keyframes flash {
+    0% { color: var(--accent-cyan); }
+    100% { color: var(--accent-white); }
+}
+
+/* KV tables */
+.kv-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+}
+.kv-table th, .kv-table td {
+    padding: 6px 8px;
+    border-bottom: 1px solid var(--border-subtle);
+    text-align: left;
+    color: var(--text-secondary);
+}
+.kv-table th {
+    color: var(--text-muted);
+    font-weight: 500;
+    width: 40%;
+    text-transform: none;
+}
+.kv-table td { color: var(--accent-white); }
+
+/* KV form */
+.kv-form {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 12px;
+    font-size: 12px;
+}
+.kv-form label {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    color: var(--text-muted);
+}
+.kv-form input, .kv-form select {
+    background: var(--background-soft);
+    color: var(--accent-white);
+    border: 1px solid var(--border-primary);
+    border-radius: 6px;
+    padding: 6px 8px;
+    font-family: var(--font-mono);
+    font-size: 12px;
+}
+.kv-form input:focus, .kv-form select:focus {
+    outline: none;
+    border-color: var(--accent-cyan);
+    box-shadow: 0 0 8px rgba(99, 230, 255, 0.25);
+}
+.checkbox-row { flex-direction: row !important; align-items: center; gap: 8px !important; color: var(--text-secondary) !important; }
+.checkbox-row input { accent-color: var(--accent-cyan); }
+
+/* Preview frame */
+.preview-frame {
+    position: relative;
+    height: 280px;
+    border: 1px solid var(--border-primary);
+    border-radius: 10px;
+    background: radial-gradient(ellipse at center 40%, rgba(99,230,255,0.06), transparent 60%), var(--background-elevated);
+    overflow: hidden;
+}
+.preview-empty {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-muted);
+    text-align: center;
+    padding: 24px;
+}
+
+/* ============================================================ */
+/* Charts                            */
+/* ============================================================ */
+.chart-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+.chart-row {
+    position: relative;
+    height: 220px;
+    background: rgba(255,255,255,0.02);
+    border: 1px solid var(--border-primary);
+    border-radius: 10px;
+    overflow: hidden;
+}
+.chart-canvas { width: 100%; height: 100%; display: block; }
+.chart-title {
+    position: absolute;
+    top: 8px;
+    left: 12px;
+    color: var(--text-secondary);
+    font-size: 11px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    background: rgba(5,5,5,0.6);
+    padding: 4px 8px;
+    border-radius: 4px;
+}
+.chart-empty { padding: 12px 0 0; font-size: 13px; }
+.metric-select {
+    background: var(--background-soft);
+    border: 1px solid var(--border-primary);
+    border-radius: 6px;
+    padding: 5px 8px;
+    color: var(--accent-white);
+    font-size: 12px;
+}
+
+/* Events list */
+.events-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    max-height: 360px;
+    overflow: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+.events-list li {
+    padding: 8px 10px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 6px;
+    background: rgba(255,255,255,0.02);
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    gap: 10px;
+    align-items: center;
+    font-family: var(--font-mono);
+    font-size: 11px;
+}
+.events-list .level-badge {
+    text-transform: uppercase;
+    font-weight: 700;
+    font-size: 10px;
+    padding: 2px 6px;
+    border-radius: 4px;
+    color: var(--text-primary);
+    background: rgba(255,255,255,0.04);
+}
+.events-list li[data-level="warning"] .level-badge { color: var(--accent-orange); }
+.events-list li[data-level="error"] .level-badge { color: var(--accent-red); }
+.events-list li[data-level="info"] .level-badge { color: var(--accent-cyan); }
+.events-list .event-time { color: var(--text-muted); }
+
+/* ============================================================ */
+/* Viewer                            */
+/* ============================================================ */
+.viewer-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(280px, 320px);
+    gap: 18px;
+}
+@media (max-width: 1200px) {
+    .viewer-layout { grid-template-columns: 1fr; }
+}
+
+.viewer-canvas-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+.viewer-canvas-frame {
+    position: relative;
+    height: 560px;
+    border: 1px solid var(--border-primary);
+    border-radius: 14px;
+    background:
+        radial-gradient(ellipse at 50% 40%, rgba(99,230,255,0.10), transparent 65%),
+        radial-gradient(ellipse at 50% 60%, rgba(0,0,0,0.6), rgba(0,0,0,1)),
+        var(--background-primary);
+    overflow: hidden;
+    box-shadow: var(--shadow-card) inset, 0 24px 50px rgba(0,0,0,0.55);
+}
+.viewer-canvas {
+    position: absolute;
+    inset: 0;
+}
+.viewer-canvas canvas,
+.viewer-canvas > div {
+    background: transparent !important;
+}
+.viewer-empty {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
+    text-align: center;
+    color: var(--text-muted);
+    padding: 36px;
+}
+.empty-watermark {
+    width: 76px;
+    height: 76px;
+    background: url("/static/aai-research-mark.svg") no-repeat center / contain;
+    opacity: 0.35;
+}
+.empty-title { font-size: 18px; color: var(--text-secondary); font-weight: 600; }
+.empty-detail { font-size: 12px; max-width: 480px; }
+
+.viewer-overlay {
+    position: absolute;
+    top: 14px;
+    right: 14px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    background: rgba(5, 5, 5, 0.66);
+    border: 1px solid var(--border-primary);
+    border-radius: 999px;
+    padding: 6px 12px;
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+}
+.overlay-tag {
+    color: var(--status-stale);
+    font-weight: 700;
+    letter-spacing: 0.08em;
+}
+.viewer-overlay[data-live="true"] .overlay-tag { color: var(--accent-cyan); }
+
+/* Viewer controls */
+.viewer-controls {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 12px;
+    border: 1px solid var(--border-primary);
+    border-radius: 12px;
+    background: var(--panel-glass);
+}
+.control-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+.control-group {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 8px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 8px;
+    background: rgba(255,255,255,0.02);
+}
+.control-label {
+    color: var(--text-muted);
+    text-transform: uppercase;
+    font-size: 10px;
+    letter-spacing: 0.12em;
+    margin-right: 4px;
+}
+.ctl-btn, .chip-btn {
+    padding: 5px 10px;
+    border: 1px solid var(--border-primary);
+    background: rgba(255,255,255,0.02);
+    color: var(--text-secondary);
+    font-size: 12px;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background var(--duration-fast) var(--ease),
+                color var(--duration-fast) var(--ease),
+                border-color var(--duration-fast) var(--ease);
+}
+.ctl-btn:hover, .chip-btn:hover {
+    color: var(--accent-white);
+    border-color: rgba(99, 230, 255, 0.45);
+}
+.chip-btn.active {
+    background: rgba(99, 230, 255, 0.10);
+    color: var(--accent-cyan);
+    border-color: rgba(99, 230, 255, 0.5);
+}
+.chip-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 8px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 6px;
+    color: var(--text-secondary);
+    font-size: 12px;
+    cursor: pointer;
+}
+.chip-toggle input,
+.chip-toggle select { accent-color: var(--accent-cyan); }
+.chip-toggle.micro { padding: 4px 6px; font-size: 11px; color: var(--text-muted); }
+.ligand-meta {
+    color: var(--text-secondary);
+    font-size: 12px;
+    padding: 4px 8px;
+    border-radius: 6px;
+    background: rgba(167, 139, 250, 0.08);
+    border: 1px solid rgba(167, 139, 250, 0.3);
+}
+
+.trajectory-controls { flex-wrap: wrap; }
+.traj-slider { flex: 1; min-width: 160px; accent-color: var(--accent-cyan); }
+.traj-time { color: var(--text-secondary); font-size: 12px; }
+
+/* ============================================================ */
+/* Info panel                            */
+/* ============================================================ */
+.info-panel {
+    background: var(--panel-glass);
+    border: 1px solid var(--border-primary);
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: var(--shadow-card);
+}
+.info-tabs {
+    display: flex;
+    border-bottom: 1px solid var(--border-subtle);
+    background: rgba(255,255,255,0.02);
+}
+.info-tab {
+    flex: 1;
+    padding: 10px 12px;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-size: 11px;
+    font-weight: 600;
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+    transition: color var(--duration-fast) var(--ease),
+                border-color var(--duration-fast) var(--ease);
+}
+.info-tab:hover { color: var(--accent-white); }
+.info-tab.active {
+    color: var(--accent-cyan);
+    border-bottom-color: var(--accent-cyan);
+}
+.info-pane { padding: 14px 16px; }
+.info-pane[hidden] { display: none; }
+.info-content { overflow-y: auto; max-height: 600px; }
+
+/* ============================================================ */
+/* Files & reports                           */
+/* ============================================================ */
+.summary-card { padding: 16px 18px; }
+.summary-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 14px;
+}
+.summary-stat {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 10px 12px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 8px;
+    background: rgba(255,255,255,0.02);
+}
+.summary-stat-label {
+    color: var(--text-muted);
+    text-transform: uppercase;
+    font-size: 10px;
+    letter-spacing: 0.12em;
+}
+.summary-stat-value {
+    color: var(--accent-white);
+    font-size: 16px;
+}
+
+.files-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 10px;
+}
+.file-row {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 8px;
+    padding: 10px 12px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 8px;
+    background: rgba(255,255,255,0.02);
+    color: var(--text-secondary);
+    text-decoration: none;
+    transition: border-color var(--duration-fast) var(--ease),
+                background var(--duration-fast) var(--ease);
+    min-width: 0;
+}
+.file-row:hover {
+    border-color: rgba(99, 230, 255, 0.4);
+    background: rgba(99, 230, 255, 0.04);
+    color: var(--accent-white);
+}
+.file-row .file-title {
+    font-size: 13px;
+    color: inherit;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.file-row .file-meta {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 2px;
+    font-size: 11px;
+    color: var(--text-muted);
+}
+.file-row .file-actions { display: flex; gap: 4px; }
+.file-action {
+    padding: 3px 8px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 5px;
+    color: inherit;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    background: transparent;
+    cursor: pointer;
+}
+.file-action:hover { border-color: rgba(99, 230, 255, 0.4); color: var(--accent-cyan); }
+
+.empty-state {
+    text-align: center;
+    padding: 64px 24px;
+    color: var(--text-muted);
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+}
+
+/* ============================================================ */
+/* Analysis cards                            */
+/* ============================================================ */
+.analysis-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 16px;
+}
+.analysis-card {
+    background: var(--panel-glass);
+    border: 1px solid var(--border-primary);
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: var(--shadow-card);
+    display: flex;
+    flex-direction: column;
+}
+.analysis-card .ac-header {
+    padding: 14px 16px;
+    border-bottom: 1px solid var(--border-subtle);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+}
+.analysis-card .ac-title {
+    font-weight: 600;
+    color: var(--accent-white);
+}
+.analysis-card .ac-status {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    padding: 3px 8px;
+    border-radius: 4px;
+    color: var(--text-secondary);
+    background: rgba(255,255,255,0.04);
+}
+.analysis-card[data-state="complete"] .ac-status { color: var(--accent-green); }
+.analysis-card[data-state="running"] .ac-status { color: var(--accent-cyan); }
+.analysis-card[data-state="waiting"] .ac-status { color: var(--accent-orange); }
+.analysis-card[data-state="failed"] .ac-status { color: var(--accent-red); }
+.analysis-card[data-state="skipped"] .ac-status { color: var(--text-muted); }
+.analysis-card .ac-frame {
+    height: 180px;
+    background: rgba(255,255,255,0.02);
+    border-bottom: 1px solid var(--border-subtle);
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px;
+}
+.analysis-card .ac-frame img,
+.analysis-card .ac-frame svg { max-width: 100%; max-height: 100%; object-fit: contain; }
+.analysis-card .ac-body {
+    padding: 12px 14px;
+    color: var(--text-secondary);
+    font-size: 12px;
+    flex: 1;
+}
+.analysis-card .ac-footer {
+    padding: 10px 14px;
+    border-top: 1px solid var(--border-subtle);
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+/* ============================================================ */
+/* Loading screen                            */
+/* ============================================================ */
+.loading-screen {
+    position: fixed;
+    inset: 0;
+    background:
+        radial-gradient(ellipse at 50% 35%, rgba(99,230,255,0.07), transparent 70%),
+        radial-gradient(ellipse at 50% 70%, rgba(167,139,250,0.06), transparent 70%),
+        var(--background-primary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 100;
+    transition: opacity 360ms var(--ease);
+}
+body.state-ready .loading-screen {
+    opacity: 0;
+    pointer-events: none;
+    transition-delay: 180ms;
+}
+.loading-shell {
+    text-align: center;
+    max-width: 520px;
+    padding: 32px;
+}
+.loading-logo {
+    width: 220px;
+    height: auto;
+    filter: drop-shadow(0 8px 24px rgba(0,0,0,0.7));
+    margin-bottom: 24px;
+}
+.loading-product {
+    font-size: 28px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    color: var(--accent-white);
+    margin-bottom: 4px;
+}
+.loading-tagline {
+    color: var(--text-secondary);
+    font-size: 13px;
+    margin-bottom: 32px;
+    letter-spacing: 0.04em;
+}
+.loading-status {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-top: 28px;
+    text-align: left;
+    display: inline-block;
+    background: rgba(255,255,255,0.02);
+    border: 1px solid var(--border-subtle);
+    border-radius: 10px;
+    padding: 14px 18px;
+}
+.loading-step {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    color: var(--text-secondary);
+    font-size: 13px;
+}
+.loading-bullet {
+    width: 10px; height: 10px;
+    border-radius: 99px;
+    background: var(--text-muted);
+}
+.loading-step[data-state="active"] { color: var(--accent-white); }
+.loading-step[data-state="active"] .loading-bullet {
+    background: var(--accent-cyan);
+    box-shadow: 0 0 12px rgba(99,230,255,0.6);
+    animation: pulse-current 1.4s var(--ease) infinite;
+}
+.loading-step[data-state="done"] { color: var(--accent-green); }
+.loading-step[data-state="done"] .loading-bullet { background: var(--accent-green); }
+
+.loading-particles {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background-image:
+        radial-gradient(circle at 30% 30%, rgba(99,230,255,0.15) 1px, transparent 1.5px),
+        radial-gradient(circle at 70% 65%, rgba(167,139,250,0.13) 1px, transparent 1.5px),
+        radial-gradient(circle at 50% 85%, rgba(103,232,163,0.10) 1px, transparent 1.5px);
+    background-size: 64px 64px, 96px 96px, 72px 72px;
+    opacity: 0.55;
+    mask-image: radial-gradient(ellipse at center, black 30%, transparent 75%);
+}
+.loading-watermark {
+    position: absolute;
+    bottom: 24px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 64px;
+    height: 64px;
+    background: url("/static/aai-research-mark.svg") no-repeat center / contain;
+    opacity: 0.25;
+}
+
+/* ============================================================ */
+/* Responsive                            */
+/* ============================================================ */
+@media (max-width: 1100px) {
+    .app-shell { grid-template-columns: 220px minmax(0,1fr); }
+    :root { --sidebar-width: 220px; }
+    .top-bar { grid-template-columns: 1fr 1fr 1fr; }
+    .metric-cluster { gap: 10px; }
+    .metric { min-width: 70px; }
+}
+@media (max-width: 800px) {
+    .app-shell { grid-template-columns: 1fr; }
+    .sidebar {
+        position: relative;
+        min-height: 0;
+        padding: 16px 14px;
+        gap: 10px;
+        border-bottom: 1px solid var(--border-subtle);
+    }
+    .sidebar-brand { grid-template-columns: 40px 1fr; gap: 10px; }
+    .brand-logo { width: 40px; }
+    .sidebar-nav { display: none; }
+    .sidebar-footer { display: none; }
+    .top-bar {
+        grid-template-columns: 1fr;
+        gap: 10px;
+    }
+    .top-bar-center { order: 3; }
+    .top-bar-right { order: 2; }
+    .metric-cluster { gap: 8px; }
+    .metric { min-width: 60px; }
+    .stage-timeline { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    .page-shell { padding: 16px; }
+}

--- a/src/fastmdxplora/live/static/dashboard.css
+++ b/src/fastmdxplora/live/static/dashboard.css
@@ -1414,3 +1414,339 @@ body.state-ready .loading-screen {
         justify-content: flex-start;
     }
 }
+
+/* ============================================================ */
+/* Dashboard-first simulation builder                           */
+/* ============================================================ */
+.nav-icon-launch {
+    border-radius: 50%;
+    background: radial-gradient(circle, var(--accent-cyan) 0 24%, rgba(99,230,255,.2) 28% 55%, transparent 58%);
+    box-shadow: 0 0 14px rgba(99, 230, 255, .28);
+}
+
+.builder-page-header {
+    align-items: center;
+}
+
+.builder-run-state {
+    display: inline-flex;
+    align-items: center;
+    gap: 9px;
+    min-height: 34px;
+    padding: 7px 12px;
+    border: 1px solid var(--border-primary);
+    border-radius: 999px;
+    color: var(--text-secondary);
+    background: rgba(255,255,255,.025);
+    font-family: var(--font-mono);
+    font-size: 12px;
+}
+
+.builder-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(300px, 360px);
+    gap: 18px;
+    align-items: start;
+}
+
+.builder-main {
+    display: grid;
+    gap: 18px;
+    min-width: 0;
+}
+
+.builder-card {
+    overflow: visible;
+}
+
+.builder-card .card-header {
+    align-items: flex-start;
+    margin-bottom: 18px;
+}
+
+.builder-card-note {
+    margin: 5px 0 0;
+    color: var(--text-muted);
+    font-size: 12px;
+}
+
+.builder-step {
+    display: inline-grid;
+    place-items: center;
+    width: 32px;
+    height: 32px;
+    border: 1px solid rgba(99, 230, 255, .34);
+    border-radius: 50%;
+    color: var(--accent-cyan);
+    background: rgba(99, 230, 255, .055);
+    font-family: var(--font-mono);
+    font-size: 11px;
+}
+
+.builder-grid {
+    display: grid;
+    gap: 16px;
+}
+.builder-grid-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.builder-grid-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+
+.builder-field {
+    display: flex;
+    flex-direction: column;
+    gap: 7px;
+    min-width: 0;
+    color: var(--text-secondary);
+}
+.builder-field-wide { grid-column: span 1; }
+.builder-label {
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: .08em;
+    text-transform: uppercase;
+}
+
+.builder-field input[type="text"],
+.builder-field input[type="number"],
+.builder-field select,
+.builder-stage-row input[type="number"] {
+    width: 100%;
+    min-height: 38px;
+    padding: 8px 10px;
+    color: var(--text-primary);
+    border: 1px solid var(--border-primary);
+    border-radius: 8px;
+    outline: none;
+    background: rgba(255, 255, 255, .028);
+    font-family: var(--font-mono);
+    transition: border-color var(--duration-fast) var(--ease), box-shadow var(--duration-fast) var(--ease);
+}
+
+.builder-field input:focus,
+.builder-field select:focus,
+.builder-stage-row input[type="number"]:focus {
+    border-color: rgba(99, 230, 255, .62);
+    box-shadow: 0 0 0 3px rgba(99, 230, 255, .08);
+}
+
+.range-number-pair {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 88px;
+    gap: 10px;
+    align-items: center;
+}
+
+.range-number-pair input[type="range"],
+.builder-stage-row input[type="range"] {
+    width: 100%;
+    accent-color: var(--accent-cyan);
+    cursor: pointer;
+}
+
+.builder-toggle-group {
+    justify-content: center;
+    gap: 9px;
+}
+
+.builder-stage-list {
+    display: grid;
+    gap: 10px;
+}
+
+.builder-stage-row {
+    display: grid;
+    grid-template-columns: 155px minmax(160px, 1fr) 130px 110px;
+    gap: 12px;
+    align-items: center;
+    min-height: 62px;
+    padding: 11px 13px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 10px;
+    background: rgba(255,255,255,.018);
+}
+
+.builder-stage-production {
+    border-color: rgba(167, 139, 250, .25);
+    background: linear-gradient(90deg, rgba(167,139,250,.045), rgba(255,255,255,.018));
+}
+
+.builder-stage-name {
+    color: var(--text-primary);
+    font-weight: 600;
+}
+
+.builder-duration {
+    color: var(--accent-cyan);
+    text-align: right;
+    font-size: 12px;
+}
+
+.field-error {
+    min-height: 14px;
+    color: var(--accent-red);
+    font-size: 11px;
+    grid-column: 1 / -1;
+}
+
+.builder-checkbox {
+    align-self: end;
+    min-height: 38px;
+}
+
+.builder-workflow-options {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px 22px;
+    margin-bottom: 16px;
+}
+
+.analysis-choice-grid {
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: 8px;
+}
+
+.analysis-choice {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 36px;
+    padding: 7px 10px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 8px;
+    color: var(--text-secondary);
+    background: rgba(255,255,255,.018);
+    cursor: pointer;
+}
+.analysis-choice:has(input:checked) {
+    border-color: rgba(99,230,255,.3);
+    color: var(--text-primary);
+    background: rgba(99,230,255,.05);
+}
+.analysis-choice input { accent-color: var(--accent-cyan); }
+
+.builder-summary-column {
+    position: sticky;
+    top: calc(var(--topbar-height) + 18px);
+}
+
+.builder-summary-card {
+    border-color: rgba(99, 230, 255, .22);
+    box-shadow: var(--shadow-card), inset 0 1px 0 rgba(255,255,255,.025);
+}
+
+.builder-summary-list {
+    display: grid;
+    gap: 0;
+    margin: 0 0 16px;
+}
+.builder-summary-list > div {
+    display: grid;
+    grid-template-columns: 42% minmax(0, 1fr);
+    gap: 12px;
+    padding: 9px 0;
+    border-bottom: 1px solid var(--border-subtle);
+}
+.builder-summary-list dt {
+    color: var(--text-muted);
+    font-size: 11px;
+}
+.builder-summary-list dd {
+    margin: 0;
+    color: var(--text-primary);
+    overflow-wrap: anywhere;
+    text-align: right;
+    font-size: 11px;
+}
+
+.builder-warning-list {
+    display: grid;
+    gap: 7px;
+    margin: 0 0 14px;
+    padding: 10px 12px;
+    border: 1px solid rgba(255,184,107,.25);
+    border-radius: 8px;
+    color: var(--accent-orange);
+    background: rgba(255,184,107,.045);
+    font-size: 11px;
+}
+
+.builder-command-preview {
+    margin: 0 0 16px;
+}
+.builder-command-preview code {
+    display: block;
+    max-height: 150px;
+    margin-top: 7px;
+    padding: 10px;
+    overflow: auto;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    border: 1px solid var(--border-subtle);
+    border-radius: 8px;
+    color: var(--text-secondary);
+    background: #080809;
+    font-family: var(--font-mono);
+    font-size: 10px;
+}
+
+.builder-actions {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 9px;
+}
+
+.primary-btn,
+.danger-btn {
+    min-height: 40px;
+    padding: 9px 13px;
+    border: 1px solid transparent;
+    border-radius: 8px;
+    cursor: pointer;
+    font-weight: 650;
+    transition: transform var(--duration-fast) var(--ease), opacity var(--duration-fast) var(--ease), border-color var(--duration-fast) var(--ease);
+}
+.primary-btn {
+    color: #030506;
+    background: linear-gradient(135deg, var(--accent-cyan), var(--accent-blue));
+    box-shadow: 0 10px 28px rgba(99,230,255,.12);
+}
+.danger-btn {
+    color: var(--accent-red);
+    border-color: rgba(255,114,114,.3);
+    background: rgba(255,114,114,.06);
+}
+.primary-btn:hover,
+.danger-btn:hover { transform: translateY(-1px); }
+.primary-btn:disabled,
+.ghost-btn:disabled { opacity: .45; cursor: not-allowed; transform: none; }
+
+.builder-message {
+    min-height: 18px;
+    margin-top: 12px;
+    color: var(--text-muted);
+    font-size: 12px;
+}
+.builder-message[data-kind="ok"] { color: var(--accent-green); }
+.builder-message[data-kind="working"] { color: var(--accent-cyan); }
+.builder-message[data-kind="warning"] { color: var(--accent-orange); }
+.builder-message[data-kind="error"] { color: var(--accent-red); }
+
+@media (max-width: 1280px) {
+    .builder-layout { grid-template-columns: 1fr; }
+    .builder-summary-column { position: static; }
+    .builder-grid-3 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .analysis-choice-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+}
+
+@media (max-width: 840px) {
+    .builder-grid-2,
+    .builder-grid-3 { grid-template-columns: 1fr; }
+    .builder-stage-row {
+        grid-template-columns: 1fr;
+        gap: 8px;
+    }
+    .builder-duration { text-align: left; }
+    .analysis-choice-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .builder-actions { grid-template-columns: 1fr; }
+}

--- a/src/fastmdxplora/live/static/dashboard.js
+++ b/src/fastmdxplora/live/static/dashboard.js
@@ -1,22 +1,21 @@
-/* FastMDXplora Live Dashboard — controller
+/* FastMDXplora Live Dashboard — application controller.
  *
- * Vanilla JS — no framework, no CDN. Responsible for:
- *   - Page navigation (Overview / Live / Viewer / Analysis / Files / Settings)
- *   - Polling telemetry & state APIs at a configurable interval
- *   - Updating top bar, hero card, metric cards, stage timeline, events
- *   - Broadcasting state changes to charts.js and molecule-viewer.js
- *   - Honouring "Pause Updates" (browser-side only)
+ * Framework-free and fully offline.  This module owns navigation, API
+ * polling, status/results/file rendering, and the shared event bus used by
+ * charts.js and molecule-viewer.js.  Every API renderer is isolated so one
+ * malformed payload can never prevent the other dashboard sections from
+ * updating.
  */
 
 (function () {
   "use strict";
 
-  const $ = (sel, root) => (root || document).querySelector(sel);
-  const $$ = (sel, root) => Array.from((root || document).querySelectorAll(sel));
+  const $ = (selector, root) => (root || document).querySelector(selector);
+  const $$ = (selector, root) => Array.from((root || document).querySelectorAll(selector));
+  const byId = (id) => document.getElementById(id);
 
   const state = {
     outputDir: "",
-    polling: true,
     paused: false,
     pollIntervalMs: 3000,
     lastUpdateMs: 0,
@@ -28,262 +27,325 @@
     playbackAvailable: false,
     playbackFrames: 0,
     playbackTotalFrames: 0,
+    playbackFrameTimes: [],
+    playbackSignature: null,
     metrics: [],
     status: {},
     health: {},
+    results: {},
     structureInfo: null,
+    setupManifest: {},
+    simManifest: {},
     runId: "",
     runTitle: "FastMDXplora Live",
+    apiErrors: {},
   };
 
-  /* ---------------------------------------------- *
-   * Boot                                          *
-   * ---------------------------------------------- */
+  let chartHistorySamples = 600;
+
   document.addEventListener("DOMContentLoaded", boot);
 
   function boot() {
+    const configuredRefresh = Number(document.body?.dataset.refreshSeconds || 3);
+    state.pollIntervalMs = clampInt(configuredRefresh * 1000, 1000, 60000, 3000);
     wireNavigation();
     wireTopBar();
     wireViewerToggle();
     wireInfoTabs();
     wireTrajectoryControls();
     wireSettings();
+    navigate(location.hash.replace(/^#/, "") || "overview", {updateHash: false});
     startLoadingChecklist();
     schedulePoll(0);
   }
 
+  /* ------------------------------------------------------------------ */
+  /* Navigation                                                          */
+  /* ------------------------------------------------------------------ */
   function wireNavigation() {
-    $$("[data-view-link]").forEach((el) => {
-      el.addEventListener("click", (event) => {
+    $$('[data-view-link]').forEach((element) => {
+      element.addEventListener("click", (event) => {
         event.preventDefault();
-        const target = el.getAttribute("data-view-link");
-        navigate(target);
+        navigate(element.getAttribute("data-view-link"));
       });
     });
+    window.addEventListener("hashchange", () => {
+      const page = location.hash.replace(/^#/, "");
+      if (state.pages.includes(page)) navigate(page, {updateHash: false});
+    });
   }
 
-  function navigate(page) {
-    if (!state.pages.includes(page)) return;
+  function navigate(page, options) {
+    const opts = options || {};
+    if (!state.pages.includes(page)) page = "overview";
     state.activePage = page;
-    $$(".page").forEach((el) => {
-      const hidden = el.getAttribute("data-page") !== page;
-      el.hidden = hidden;
+    $$('.page').forEach((element) => {
+      const hidden = element.getAttribute("data-page") !== page;
+      element.hidden = hidden;
     });
-    $$("[data-view-link]").forEach((el) => {
-      const isActive = el.getAttribute("data-view-link") === page;
-      el.classList.toggle("active", isActive);
+    $$('[data-view-link]').forEach((element) => {
+      element.classList.toggle(
+        "active",
+        element.getAttribute("data-view-link") === page
+      );
     });
-    if (page === "viewer") {
-      window.dispatchEvent(new CustomEvent("dashboard:viewer-page-opened"));
+    document.documentElement.setAttribute("data-page", page);
+    if (opts.updateHash !== false && location.hash !== `#${page}`) {
+      history.replaceState(null, "", `#${page}`);
     }
-    if (page === "analysis" || page === "files") {
-      window.dispatchEvent(new CustomEvent("dashboard:results-page-opened"));
-    }
+    requestAnimationFrame(() => {
+      if (page === "live") emit("live-page-opened", {});
+      if (page === "viewer") emit("viewer-page-opened", {});
+      if (page === "analysis" || page === "files") emit("results-page-opened", {});
+    });
   }
 
+  /* ------------------------------------------------------------------ */
+  /* Loading screen                                                      */
+  /* ------------------------------------------------------------------ */
   function startLoadingChecklist() {
-    setLoadingStep("telemetry", "active");
-    fetchJSON("/api/status")
-      .then(() => setLoadingStep("telemetry", "done"))
-      .catch(() => setLoadingStep("telemetry", "error"));
-    setLoadingStep("structure", "active");
-    fetchJSON("/api/structure-info")
-      .then(() => setLoadingStep("structure", "done"))
-      .catch(() => setLoadingStep("structure", "error"));
-    setLoadingStep("metrics", "active");
-    fetchJSON("/api/metrics")
-      .then(() => setLoadingStep("metrics", "done"))
-      .catch(() => setLoadingStep("metrics", "error"));
-    setTimeout(() => {
-      document.body.classList.remove("state-loading");
-      document.body.classList.add("state-ready");
-    }, 1100); /* fade-out tied to successful lookup, not a fixed timeout, but with a brief post-poll settle delay */
+    const checks = [
+      ["telemetry", "/api/status"],
+      ["structure", "/api/structure-info"],
+      ["metrics", "/api/metrics"],
+    ].map(([name, url]) => {
+      setLoadingStep(name, "active");
+      return fetchJSON(url)
+        .then(() => setLoadingStep(name, "done"))
+        .catch(() => setLoadingStep(name, "error"));
+    });
+    Promise.allSettled(checks).finally(() => {
+      window.setTimeout(() => {
+        document.body.classList.remove("state-loading");
+        document.body.classList.add("state-ready");
+        const loading = byId("loading-screen");
+        if (loading) loading.setAttribute("aria-hidden", "true");
+      }, 300);
+    });
   }
 
   function setLoadingStep(name, status) {
-    const el = document.querySelector(`.loading-step[data-step="${name}"]`);
-    if (el) el.setAttribute("data-state", status);
+    const element = $(`.loading-step[data-step="${name}"]`);
+    if (element) element.setAttribute("data-state", status);
   }
 
+  /* ------------------------------------------------------------------ */
+  /* Controls                                                            */
+  /* ------------------------------------------------------------------ */
   function wireTopBar() {
-    $("#pause-toggle").addEventListener("click", () => {
+    byId("pause-toggle")?.addEventListener("click", () => {
       state.paused = !state.paused;
-      $("#pause-toggle").setAttribute("aria-pressed", state.paused);
-      $("#pause-label").textContent = state.paused ? "Resume Updates" : "Pause Updates";
+      byId("pause-toggle")?.setAttribute("aria-pressed", String(state.paused));
+      setText("pause-label", state.paused ? "Resume Updates" : "Pause Updates");
+      showToast(
+        state.paused
+          ? "Browser updates paused. The OpenMM simulation is still running."
+          : "Browser updates resumed."
+      );
+      if (!state.paused) schedulePoll(0);
     });
-    $("#refresh-now").addEventListener("click", () => {
-      schedulePoll(0);
-    });
-    $("#open-output").addEventListener("click", () => {
-      /* Best-effort: the dashboard never opens the OS browser from a
-         page that's already opened in a browser; show the absolute path
-         and copy it. */
-      const text = $("#sidebar-run-name").textContent || "";
-      if (!text || text === "not available") return;
-      const toast = document.createElement("div");
-      toast.className = "sr-only";
-      toast.textContent = `Output folder: ${text}`;
-      document.body.appendChild(toast);
+    byId("refresh-now")?.addEventListener("click", () => schedulePoll(0));
+    byId("open-output")?.addEventListener("click", async () => {
+      try {
+        const payload = await fetchJSON("/api/open-output");
+        if (payload.opened) {
+          showToast(`Opened output folder: ${payload.path}`);
+        } else {
+          await copyText(payload.path || state.outputDir || "");
+          showToast("Could not open the folder automatically; its path was copied.", "warning");
+        }
+      } catch (error) {
+        if (state.outputDir) await copyText(state.outputDir);
+        showToast("Could not open the output folder; its path was copied.", "warning");
+      }
     });
   }
 
   function wireViewerToggle() {
-    $("#mini-preview-frame").addEventListener("click", () => navigate("viewer"));
+    byId("mini-preview-frame")?.addEventListener("click", () => navigate("viewer"));
   }
 
   function wireInfoTabs() {
-    $$(".info-tab").forEach((tab) => {
+    $$('.info-tab').forEach((tab) => {
       tab.addEventListener("click", () => {
         const name = tab.getAttribute("data-tab");
-        $$(".info-tab").forEach((t) => t.classList.toggle("active", t === tab));
-        $$(".info-pane").forEach((p) => {
-          p.hidden = p.getAttribute("data-tab") !== name;
-          p.classList.toggle("active", p.getAttribute("data-tab") === name);
+        $$('.info-tab').forEach((item) => item.classList.toggle("active", item === tab));
+        $$('.info-pane').forEach((pane) => {
+          const active = pane.getAttribute("data-tab") === name;
+          pane.hidden = !active;
+          pane.classList.toggle("active", active);
         });
       });
     });
   }
 
   function wireTrajectoryControls() {
-    const slider = $("#traj-slider");
-    if (!slider) return;
-    slider.addEventListener("input", () => {
-      const frame = parseInt(slider.value, 10);
-      window.dispatchEvent(
-        new CustomEvent("dashboard:trajectory-seek", {detail: {frame}})
-      );
+    byId("traj-slider")?.addEventListener("input", (event) => {
+      emit("trajectory-seek", {frame: parseInt(event.target.value, 10) || 0});
     });
-    $$("[data-traj]").forEach((btn) => {
-      btn.addEventListener("click", () => {
-        const action = btn.getAttribute("data-traj");
-        window.dispatchEvent(
-          new CustomEvent("dashboard:trajectory-action", {detail: {action}})
-        );
+    $$('[data-traj]').forEach((button) => {
+      button.addEventListener("click", () => {
+        emit("trajectory-action", {action: button.getAttribute("data-traj")});
       });
     });
   }
 
   function wireSettings() {
-    /* Settings page wires its own values via onSettingsChanged */
-    document.getElementById("setting-refresh-seconds")
-      .addEventListener("change", onSettingsChanged);
-    document.getElementById("setting-pocket-cutoff")
-      .addEventListener("change", onSettingsChanged);
-    document.getElementById("setting-reduced-motion")
-      .addEventListener("change", onSettingsChanged);
-    document.getElementById("setting-ligand-resname")
-      .addEventListener("change", onSettingsChanged);
-    document.getElementById("setting-chart-history")
-      .addEventListener("change", onSettingsChanged);
+    const ids = [
+      "setting-protein-rep", "setting-ligand-rep", "setting-background",
+      "setting-show-water", "setting-show-ions", "setting-spin", "setting-fog",
+      "setting-preserve-camera", "setting-refresh-seconds", "setting-chart-history",
+      "setting-compact", "setting-reduced-motion", "setting-advanced-metrics",
+      "setting-time-format", "setting-run-name", "setting-ligand-resname",
+      "setting-pocket-cutoff", "setting-scinote",
+    ];
+    ids.forEach((id) => byId(id)?.addEventListener("change", onSettingsChanged));
+    byId("pocket-cutoff")?.addEventListener("change", (event) => {
+      const value = clampFloat(parseFloat(event.target.value), 3, 15, 5);
+      state.bindingPocketCutoff = value;
+      if (byId("setting-pocket-cutoff")) byId("setting-pocket-cutoff").value = String(value);
+      onSettingsChanged();
+    });
   }
 
   function onSettingsChanged() {
     state.pollIntervalMs = clampInt(
-      parseInt($("#setting-refresh-seconds").value, 10), 1000, 60000, 3000);
+      parseFloat(byId("setting-refresh-seconds")?.value) * 1000,
+      1000,
+      60000,
+      3000
+    );
     state.bindingPocketCutoff = clampFloat(
-      parseFloat($("#setting-pocket-cutoff").value), 3.0, 15.0, 5.0);
-    const lig = ($("#setting-ligand-resname").value || "").trim().toUpperCase();
-    state.ligandResname = lig || null;
+      parseFloat(byId("setting-pocket-cutoff")?.value),
+      3,
+      15,
+      5
+    );
+    const ligand = (byId("setting-ligand-resname")?.value || "").trim().toUpperCase();
+    state.ligandResname = ligand || null;
     chartHistorySamples = clampInt(
-      parseInt($("#setting-chart-history").value, 10), 60, 5000, 600);
-    document.body.classList.toggle("compact-mode",
-      $("#setting-compact").checked);
-    document.body.classList.toggle("reduced-motion",
-      $("#setting-reduced-motion").checked);
-    /* Tell the viewer + chart modules to bind the new settings */
-    window.dispatchEvent(new CustomEvent("dashboard:settings-updated", {
-      detail: {
-        ligand: state.ligandResname,
-        pocketCutoff: state.bindingPocketCutoff,
-        chartHistory: chartHistorySamples,
-      }
-    }));
+      parseInt(byId("setting-chart-history")?.value, 10),
+      60,
+      5000,
+      600
+    );
+    const customRunName = (byId("setting-run-name")?.value || "").trim();
+    if (customRunName) state.runTitle = customRunName;
+
+    document.body.classList.toggle("compact-mode", !!byId("setting-compact")?.checked);
+    document.body.classList.toggle("reduced-motion", !!byId("setting-reduced-motion")?.checked);
+    document.body.classList.toggle(
+      "advanced-metrics",
+      !!byId("setting-advanced-metrics")?.checked
+    );
+
+    renderTopBar(state.status, state.health);
+    emit("settings-updated", {
+      ligand: state.ligandResname,
+      pocketCutoff: state.bindingPocketCutoff,
+      chartHistory: chartHistorySamples,
+      proteinRepresentation: byId("setting-protein-rep")?.value || "cartoon",
+      ligandRepresentation: byId("setting-ligand-rep")?.value || "sticks",
+      background: byId("setting-background")?.value || "matte-black",
+      showWater: !!byId("setting-show-water")?.checked,
+      showIons: !!byId("setting-show-ions")?.checked,
+      spin: !!byId("setting-spin")?.checked,
+      fog: !!byId("setting-fog")?.checked,
+      preserveCamera: byId("setting-preserve-camera")?.checked !== false,
+    });
     schedulePoll(0);
   }
 
-  /* ---------------------------------------------- *
-   * Polling                                       *
-   * ---------------------------------------------- */
-  let chartHistorySamples = 600;
-
+  /* ------------------------------------------------------------------ */
+  /* Polling                                                             */
+  /* ------------------------------------------------------------------ */
   async function fetchJSON(url) {
-    const res = await fetch(url, {cache: "no-store", headers: {"X-FastMDX": "live"}});
-    if (!res.ok) throw new Error(`HTTP ${res.status} on ${url}`);
-    return await res.json();
+    const response = await fetch(url, {
+      cache: "no-store",
+      headers: {"X-FastMDX": "live"},
+    });
+    if (!response.ok) throw new Error(`HTTP ${response.status} on ${url}`);
+    return response.json();
   }
 
   function schedulePoll(delayMs) {
-    if (state.refreshTimer) {
-      clearTimeout(state.refreshTimer);
-      state.refreshTimer = null;
-    }
-    if (state.paused) {
-      state.refreshTimer = setTimeout(() => schedulePoll(state.pollIntervalMs), state.pollIntervalMs);
-      return;
-    }
-    state.refreshTimer = setTimeout(() => {
-      pollNow().catch((err) => console.warn("dashboard poll error", err))
-        .finally(() => schedulePoll(state.pollIntervalMs));
+    if (state.refreshTimer) window.clearTimeout(state.refreshTimer);
+    state.refreshTimer = window.setTimeout(async () => {
+      if (!state.paused) {
+        try {
+          await pollNow();
+        } catch (error) {
+          console.warn("dashboard poll error", error);
+        }
+      }
+      schedulePoll(state.pollIntervalMs);
     }, Math.max(0, delayMs));
   }
 
   async function pollNow() {
-    const [statusPayload, metricsPayload, eventsPayload, resultsPayload, structurePayload, playbackPayload] =
-      await Promise.allSettled([
-        fetchJSON("/api/status"),
-        fetchJSON("/api/metrics"),
-        fetchJSON("/api/events"),
-        fetchJSON("/api/results"),
-        fetchJSON("/api/structure-info"),
-        fetchJSON("/api/playback-info"),
-      ]);
+    const names = ["status", "metrics", "events", "results", "structure", "playback"];
+    const urls = [
+      "/api/status", "/api/metrics", "/api/events", "/api/results",
+      "/api/structure-info", "/api/playback-info",
+    ];
+    const settled = await Promise.allSettled(urls.map(fetchJSON));
+    let successes = 0;
 
-    if (statusPayload.status === "fulfilled") {
-      applyStatus(statusPayload.value);
-    }
-    if (metricsPayload.status === "fulfilled") {
-      applyMetrics(metricsPayload.value.metrics || []);
-    }
-    if (eventsPayload.status === "fulfilled") {
-      renderEvents(eventsPayload.value.events || []);
-    }
-    if (resultsPayload.status === "fulfilled") {
-      applyResults(resultsPayload.value);
-    }
-    if (structurePayload.status === "fulfilled") {
-      applyStructure(structurePayload.value);
-    }
-    if (playbackPayload.status === "fulfilled") {
-      applyPlayback(playbackPayload.value);
-    }
+    settled.forEach((result, index) => {
+      const name = names[index];
+      if (result.status === "rejected") {
+        state.apiErrors[name] = String(result.reason || "request failed");
+        console.warn(`dashboard ${name} request failed`, result.reason);
+        return;
+      }
+      delete state.apiErrors[name];
+      successes += 1;
+      const payload = result.value;
+      if (name === "status") safeApply(name, () => applyStatus(payload));
+      if (name === "metrics") safeApply(name, () => applyMetrics(payload.metrics || []));
+      if (name === "events") safeApply(name, () => renderEvents(payload.events || []));
+      if (name === "results") safeApply(name, () => applyResults(payload));
+      if (name === "structure") safeApply(name, () => applyStructure(payload));
+      if (name === "playback") safeApply(name, () => applyPlayback(payload));
+    });
 
-    state.lastUpdateMs = Date.now();
-    updateRefreshedAt();
-    pulseTopbarIfLive();
+    if (successes) {
+      state.lastUpdateMs = Date.now();
+      updateRefreshedAt();
+    }
+    updateConnectionState();
   }
 
-  function pulseTopbarIfLive() {
-    const age = (Date.now() - state.lastUpdateMs) / 1000;
-    const dot = $("#topbar-status-dot");
-    if (age > 30) {
-      dot.classList.remove("status-dot-live");
-      dot.classList.add("status-dot-stale");
-    } else {
-      dot.classList.add("status-dot-live");
-      dot.classList.remove("status-dot-stale");
+  function safeApply(name, callback) {
+    try {
+      callback();
+    } catch (error) {
+      state.apiErrors[`render-${name}`] = String(error);
+      console.error(`dashboard ${name} renderer failed`, error);
+      showToast(`${humanise(name)} data could not be rendered. See the browser console.`, "warning");
+    }
+  }
+
+  function updateConnectionState() {
+    const ageSeconds = state.lastUpdateMs ? (Date.now() - state.lastUpdateMs) / 1000 : Infinity;
+    const requestFailed = Object.keys(state.apiErrors).length > 0;
+    if (ageSeconds > 30 || requestFailed) {
+      byId("topbar-status-dot")?.classList.add("status-dot-stale");
     }
   }
 
   function updateRefreshedAt() {
     const date = new Date(state.lastUpdateMs);
-    const use24 = !$("#setting-time-format") || $("#setting-time-format").value !== "12h";
-    const fmt = use24
+    const use24 = byId("setting-time-format")?.value !== "12h";
+    const text = use24
       ? `${date.toLocaleDateString()} ${date.toLocaleTimeString([], {hour12: false})}`
       : date.toLocaleTimeString();
-    const el = $("#refreshed-at");
-    if (el) el.textContent = fmt;
+    setText("refreshed-at", text);
   }
 
+  /* ------------------------------------------------------------------ */
+  /* Status                                                              */
+  /* ------------------------------------------------------------------ */
   function applyStatus(payload) {
     const status = payload.status || {};
     const health = payload.health || {};
@@ -294,483 +356,731 @@
     renderHealth(health);
     renderStageTimeline(status);
     renderLiveProgress(status);
-    window.dispatchEvent(new CustomEvent("dashboard:status-updated", {detail: {status, health}}));
+    emit("status-updated", {status, health});
   }
 
   function renderTopBar(status, health) {
-    const stateName = (health.state || status.status || "live").toLowerCase();
-    const dot = $("#topbar-status-dot");
-    dot.className = "status-dot " + stateDotClass(stateName);
-    $("#topbar-status-text").textContent = stateName;
-    $("#topbar-stage").textContent = status.stage || "not available";
-    const step = status.current_step;
-    const total = status.total_planned_steps;
-    $("#topbar-step").textContent = step != null ? String(step) : "—";
-    $("#topbar-total").textContent = total != null ? String(total) : "—";
-    $("#topbar-platform").textContent = status.platform || "—";
-    const temp = status.target_temperature_K ||
-      (state.metrics.length
-        ? (state.metrics[state.metrics.length - 1].temperature || "")
-        : "");
-    $("#topbar-temperature").textContent = temp ? `${temp} K` : "—";
+    const statusName = String(health.state || status.status || "waiting").toLowerCase();
+    const dotClass = stateDotClass(statusName);
+    setClassName("topbar-status-dot", `status-dot ${dotClass}`);
+    setClassName("sidebar-status-dot", `status-dot ${dotClass}`);
+    setText("topbar-status-text", statusName);
+    setText("topbar-stage", status.stage || "not available");
+    setText("topbar-step", valueOrDash(status.current_step));
+    setText("topbar-total", valueOrDash(status.total_planned_steps));
+    setText("topbar-platform", status.platform || state.simManifest.platform || "—");
 
-    $("#sidebar-status-dot").className = "status-dot " + stateDotClass(stateName);
-    $("#sidebar-connection-state").textContent = stateName;
-    $("#sidebar-platform").textContent = status.platform || "not available";
-    $("#sidebar-run-name").textContent = state.runTitle;
-    state.runId = status.system_id || state.runId;
-    $("#topbar-run-id").textContent = state.runId || "system";
-    $("#topbar-run-title").textContent = state.runTitle;
+    const latest = state.metrics[state.metrics.length - 1] || {};
+    const temperature = firstPresent(
+      latest.temperature,
+      status.target_temperature_K,
+      state.simManifest.temperature_K
+    );
+    setText("topbar-temperature", temperature != null ? `${formatNumber(temperature, 1)} K` : "—");
+    setText("sidebar-connection-state", statusName);
+    setText("sidebar-platform", status.platform || state.simManifest.platform || "not available");
+    setText("sidebar-run-name", state.runTitle);
+
+    state.runId = status.system_id || state.results?.system?.system || state.runId;
+    setText("topbar-run-id", state.runId || "system");
+    setText("topbar-run-title", state.runTitle);
   }
 
-  function stateDotClass(s) {
-    if (s === "ok" || s === "live" || s === "completed") return "status-dot-live";
-    if (s === "warning" || s === "waiting" || s === "stale") return "status-dot-stale";
-    if (s === "failed" || s === "error") return "status-dot-error";
+  function stateDotClass(value) {
+    if (["ok", "live", "completed"].includes(value)) return "status-dot-live";
+    if (["failed", "error", "critical"].includes(value)) return "status-dot-error";
     return "status-dot-stale";
   }
 
   function renderHero(status) {
-    const card = $("#hero-card");
-    card.setAttribute("data-state", (status.status || "running").toLowerCase());
-    $("#hero-stage").textContent = status.stage || "—";
-    let pct = null;
-    if (typeof status.progress_percent === "number") pct = status.progress_percent;
-    else if (status.current_step && status.total_planned_steps)
-      pct = (status.current_step / status.total_planned_steps) * 100;
-    if (pct !== null) {
-      $("#hero-progress-fill").style.width = `${Math.max(0, Math.min(100, pct))}%`;
-      $("#hero-progress-pct").textContent = pct.toFixed(1);
-    } else {
-      $("#hero-progress-fill").style.width = "0%";
-      $("#hero-progress-pct").textContent = "—";
-    }
-    $("#hero-sim-time").textContent = status.simulation_time_completed_ns
-      ? status.simulation_time_completed_ns.toFixed(3) : "—";
-    $("#hero-elapsed").textContent = status.elapsed_wall_time_s
-      ? fmtDuration(status.elapsed_wall_time_s) : "—";
-    $("#hero-eta").textContent = computeETA(status);
-    $("#hero-step").textContent = status.current_step != null
-      ? `${status.current_step} / ${status.total_planned_steps ?? "—"}` : "—";
-  }
-
-  function fmtDuration(seconds) {
-    const s = Math.max(0, Math.floor(seconds));
-    const hh = Math.floor(s / 3600);
-    const mm = Math.floor((s % 3600) / 60);
-    const ss = s % 60;
-    return hh ? `${hh}h ${mm}m` : `${mm}m ${ss}s`;
-  }
-
-  function computeETA(status) {
-    if (!status.current_step || !status.total_planned_steps
-        || !status.elapsed_wall_time_s) return "—";
-    const total = status.total_planned_steps;
-    const elapsed = status.elapsed_wall_time_s;
-    const ratio = total / Math.max(status.current_step, 1);
-    return fmtDuration(elapsed * (ratio - 1));
+    const card = byId("hero-card");
+    if (card) card.setAttribute("data-state", String(status.status || "running").toLowerCase());
+    setText("hero-status-text", humanise(status.status || status.stage || "waiting"));
+    setText("hero-stage", status.stage || "—");
+    const pct = progressPercent(status);
+    setWidth("hero-progress-fill", pct);
+    setText("hero-progress-pct", pct != null ? pct.toFixed(1) : "—");
+    setText(
+      "hero-sim-time",
+      status.simulation_time_completed_ns != null
+        ? formatNumber(status.simulation_time_completed_ns, 3)
+        : "—"
+    );
+    setText(
+      "hero-elapsed",
+      status.elapsed_wall_time_s != null ? fmtDuration(status.elapsed_wall_time_s) : "—"
+    );
+    setText("hero-eta", computeETA(status));
+    setText(
+      "hero-step",
+      status.current_step != null
+        ? `${status.current_step} / ${status.total_planned_steps ?? "—"}`
+        : "—"
+    );
   }
 
   function renderHealth(health) {
-    const card = $("#hero-health");
-    const stateName = health.state || "unknown";
-    card.setAttribute("data-state", stateName);
-    $("#health-headline").textContent = health.message || stateName;
-    $("#health-explanation").textContent = health.explanation || "";
-    $("#health-pill").textContent = stateName;
-    $("#health-pill").setAttribute("data-state", stateName);
-    const items = (health.items || []).slice(0, 4);
-    const list = $("#health-list");
-    list.innerHTML = items.map((it) =>
-      `<li data-state="${escapeAttr(it.severity || "ok")}">
-        <strong>${escapeHTML(it.title || it.severity || "info")}</strong>
-        <span class="muted small"> — ${escapeHTML(it.detail || "")}</span>
-      </li>`
-    ).join("");
-    const livePill = $("#live-health-pill");
-    if (livePill) {
-      livePill.textContent = stateName;
-      livePill.setAttribute("data-state", stateName);
+    const stateName = String(health.state || "unknown").toLowerCase();
+    byId("hero-health")?.setAttribute("data-state", stateName);
+    setText("health-headline", health.message || humanise(stateName));
+    setText("health-explanation", health.explanation || "");
+    setText("health-pill", stateName);
+    byId("health-pill")?.setAttribute("data-state", stateName);
+
+    const list = byId("health-list");
+    if (list) {
+      const items = Array.isArray(health.items) ? health.items.slice(0, 4) : [];
+      list.innerHTML = items.map((item) => `
+        <li data-state="${escapeAttr(item.severity || "ok")}">
+          <strong>${escapeHTML(item.title || item.severity || "info")}</strong>
+          <span class="muted small"> — ${escapeHTML(item.detail || "")}</span>
+        </li>
+      `).join("");
     }
-    $("#live-health-message").textContent = health.message || "not available";
-    $("#live-health-explanation").textContent = health.explanation || "";
+    setText("live-health-pill", stateName);
+    byId("live-health-pill")?.setAttribute("data-state", stateName);
+    setText("live-health-message", health.message || "not available");
+    setText("live-health-explanation", health.explanation || "");
   }
 
   function renderStageTimeline(status) {
-    const map = {
-      setup: "setup", minimization: "minimization", nvt: "nvt",
-      npt: "npt", production: "production", analysis: "analysis",
-      report: "report", loading: "setup"
-    };
     const order = ["setup", "minimization", "nvt", "npt", "production", "analysis", "report"];
-    const current = (status.stage || "").toLowerCase();
-    const currentIdx = order.indexOf(map[current] || current);
-    $$(".stage-step").forEach((el) => {
-      const stage = el.getAttribute("data-stage");
-      const idx = order.indexOf(stage);
-      el.removeAttribute("data-state");
-      if (idx === -1) return;
-      if (idx < currentIdx) el.setAttribute("data-state", "completed");
-      else if (idx === currentIdx) el.setAttribute("data-state", "current");
-      else el.setAttribute("data-state", "waiting");
+    const phaseMap = {};
+    (state.results.phases || []).forEach((phase) => {
+      phaseMap[String(phase.name || "").toLowerCase()] = String(phase.status || "").toLowerCase();
+    });
+    const liveStates = status?.stage_states && typeof status.stage_states === "object"
+      ? status.stage_states : {};
+    const current = normaliseStage(status.stage);
+    const currentIndex = order.indexOf(current);
+    const simulationDone = isPhaseDone(phaseMap.simulation);
+
+    $$('.stage-step').forEach((element) => {
+      const stage = element.getAttribute("data-stage");
+      let stageState = phaseVisualState(liveStates[stage]);
+
+      // Older/completed runs may not have the new live stage map, so retain
+      // manifest-based fallback without overwriting a real current/failed state.
+      if (stageState === "waiting") {
+        if (stage === "setup") stageState = phaseVisualState(phaseMap.setup);
+        if (["minimization", "nvt", "npt", "production"].includes(stage) && simulationDone) {
+          stageState = "completed";
+        }
+        if (stage === "analysis") stageState = phaseVisualState(phaseMap.analysis);
+        if (stage === "report") stageState = phaseVisualState(phaseMap.report);
+      }
+
+      if (currentIndex >= 0 && stageState === "waiting") {
+        const index = order.indexOf(stage);
+        if (index < currentIndex) stageState = "completed";
+        if (index === currentIndex) stageState = "current";
+      }
+      if (stage === current && phaseVisualState(liveStates[stage]) === "current") {
+        stageState = "current";
+      }
+      element.setAttribute("data-state", stageState);
     });
   }
 
   function renderLiveProgress(status) {
-    let pct = null;
-    if (typeof status.progress_percent === "number") pct = status.progress_percent;
-    else if (status.current_step && status.total_planned_steps)
-      pct = (status.current_step / status.total_planned_steps) * 100;
-    if (pct !== null) {
-      $("#live-progress-fill").style.width = `${Math.max(0, Math.min(100, pct))}%`;
-      $("#live-progress-pct").textContent = pct.toFixed(1);
-    } else {
-      $("#live-progress-fill").style.width = "0%";
-      $("#live-progress-pct").textContent = "—";
-    }
-    $("#live-sim-time").textContent = status.simulation_time_completed_ns
-      ? status.simulation_time_completed_ns.toFixed(3) : "—";
-    $("#live-stage-cell").textContent = status.stage || "not available";
-    $("#live-step-cell").textContent = status.current_step != null ? String(status.current_step) : "not available";
-    $("#live-total-cell").textContent = status.total_planned_steps != null ? String(status.total_planned_steps) : "not available";
-    $("#live-frames-cell").textContent = status.current_frame_count != null
-      ? `${status.current_frame_count}${status.planned_frame_count != null ? ` / ${status.planned_frame_count}` : ""}`
-      : "not available";
-    $("#live-simtime-cell").textContent = status.simulation_time_completed_ns
-      ? `${status.simulation_time_completed_ns} ns` : "not available";
-    $("#live-elapsed-cell").textContent = status.elapsed_wall_time_s
-      ? fmtDuration(status.elapsed_wall_time_s) : "not available";
-    $("#live-eta-cell").textContent = computeETA(status);
-    $("#live-checkpoint-cell").textContent = status.current_checkpoint_path || "not available";
-    $("#live-lastupdate-cell").textContent = status.last_update_timestamp || "not available";
-    $("#live-card-step").textContent = status.current_step != null ? String(status.current_step) : "—";
+    const pct = progressPercent(status);
+    setWidth("live-progress-fill", pct);
+    setText("live-progress-pct", pct != null ? pct.toFixed(1) : "—");
+    setText(
+      "live-sim-time",
+      status.simulation_time_completed_ns != null
+        ? formatNumber(status.simulation_time_completed_ns, 3)
+        : "—"
+    );
+    setText("live-stage-cell", status.stage || "not available");
+    setText("live-step-cell", present(status.current_step));
+    setText("live-total-cell", present(status.total_planned_steps));
+    setText(
+      "live-frames-cell",
+      status.current_frame_count != null
+        ? `${status.current_frame_count}${status.planned_frame_count != null ? ` / ${status.planned_frame_count}` : ""}`
+        : "not available"
+    );
+    setText(
+      "live-simtime-cell",
+      status.simulation_time_completed_ns != null
+        ? `${formatNumber(status.simulation_time_completed_ns, 6)} ns`
+        : "not available"
+    );
+    setText(
+      "live-elapsed-cell",
+      status.elapsed_wall_time_s != null ? fmtDuration(status.elapsed_wall_time_s) : "not available"
+    );
+    setText("live-eta-cell", computeETA(status));
+    setText("live-checkpoint-cell", status.current_checkpoint_path || "not available");
+    setText("live-lastupdate-cell", formatTimestamp(status.last_update_timestamp));
+    setText("live-card-step", valueOrDash(status.current_step));
   }
 
+  /* ------------------------------------------------------------------ */
+  /* Metrics and events                                                  */
+  /* ------------------------------------------------------------------ */
   function applyMetrics(metrics) {
-    state.metrics = metrics.slice(-chartHistorySamples);
+    state.metrics = (Array.isArray(metrics) ? metrics : [])
+      .map(normaliseMetricRow)
+      .slice(-chartHistorySamples);
     renderMetricCards();
-    if (window.FastMDXCharts) {
-      window.FastMDXCharts.update(state.metrics);
-    }
+    if (window.FastMDXCharts) window.FastMDXCharts.update(state.metrics);
+    emit("metrics-updated", {metrics: state.metrics});
+  }
+
+  function normaliseMetricRow(row) {
+    const output = Object.assign({}, row || {});
+    const aliases = {
+      potentialEnergy: "potential_energy",
+      kineticEnergy: "kinetic_energy",
+      totalEnergy: "total_energy",
+      simulationSpeed: "speed",
+      frame: "current_frame_count",
+      frames: "current_frame_count",
+    };
+    Object.keys(aliases).forEach((key) => {
+      if (output[aliases[key]] == null && output[key] != null) output[aliases[key]] = output[key];
+    });
+    return output;
   }
 
   function renderMetricCards() {
-    const latest = state.metrics.length ? state.metrics[state.metrics.length - 1] : {};
-    const map = {
-      potential_energy: {unit: "kJ/mol"},
-      temperature: {unit: "K"},
-      density: {unit: "g/mL"},
-      speed: {unit: "ns/day"},
-      frames: {unit: "frames"},
-      pressure: {unit: "bar"},
+    const latest = state.metrics[state.metrics.length - 1] || {};
+    const units = {
+      potential_energy: "kJ/mol",
+      temperature: "K",
+      density: "g/mL",
+      speed: "ns/day",
+      frames: "frames",
+      pressure: "bar",
     };
-    $$(".metric-card").forEach((card) => {
+    $$('.metric-card').forEach((card) => {
       const key = card.getAttribute("data-metric");
       const derived = deriveMetric(key, latest);
       const value = card.querySelector("[data-value]");
       const unit = card.querySelector(".metric-card-unit");
       if (value) value.textContent = derived != null ? derived : "—";
-      if (unit && map[key]) unit.textContent = map[key].unit;
-      if (derived !== card.getAttribute("data-last-value")) {
-        if (derived != null && card.getAttribute("data-last-value") != null) {
-          card.setAttribute("data-pulse", "");
-          setTimeout(() => card.removeAttribute("data-pulse"), 1200);
-        }
-        card.setAttribute("data-last-value", derived != null ? String(derived) : "");
+      if (unit && units[key]) unit.textContent = units[key];
+      const previous = card.getAttribute("data-last-value");
+      if (derived != null && previous && previous !== String(derived)) {
+        card.setAttribute("data-pulse", "");
+        window.setTimeout(() => card.removeAttribute("data-pulse"), 900);
       }
+      card.setAttribute("data-last-value", derived != null ? String(derived) : "");
     });
   }
 
   function deriveMetric(key, latest) {
     if (key === "frames") {
-      return latest.current_frame_count || latest.frame || null;
+      const value = firstPresent(
+        latest.current_frame_count,
+        state.status.current_frame_count,
+        state.simManifest.n_production_frames
+      );
+      return value != null ? String(value) : null;
     }
-    if (key === "speed") {
-      /* OpenMM reports ns/day via its reporter; flatten to a numeric.
-         If it's missing, we cannot honestly invent it. */
-      return latest.speed != null ? Number(latest.speed).toFixed(2) : null;
-    }
-    if (latest[key] === undefined) return null;
-    const v = Number(latest[key]);
-    return Number.isFinite(v) ? v.toFixed(2) : null;
+    const value = latest[key];
+    const number = Number(value);
+    if (!Number.isFinite(number)) return null;
+    if (key === "speed") return number.toFixed(2);
+    if (key === "density") return number.toFixed(4);
+    return number.toFixed(2);
   }
 
   function renderEvents(events) {
-    const ul = $("#events-list");
-    if (!ul) return;
-    const items = events.slice(-50).reverse();
-    ul.innerHTML = items.map((ev) => {
-      const level = ev.level || "info";
-      const ts = ev.timestamp ? new Date(ev.timestamp).toLocaleTimeString([], {hour12:false}) : "";
-      return `<li data-level="${escapeAttr(level)}">
-        <span class="level-badge">${escapeHTML(level)}</span>
-        <span class="event-message">${escapeHTML(ev.message || "")}</span>
-        <span class="event-time">${escapeHTML(ts)}</span>
+    const list = byId("events-list");
+    if (!list) return;
+    const items = (Array.isArray(events) ? events : []).slice(-50).reverse();
+    list.innerHTML = items.length ? items.map((event) => `
+      <li data-level="${escapeAttr(event.level || "info")}">
+        <span class="level-badge">${escapeHTML(event.level || "info")}</span>
+        <span class="event-message">${escapeHTML(event.message || "")}</span>
+        <span class="event-time">${escapeHTML(formatEventTime(event.timestamp))}</span>
+      </li>
+    `).join("") : `
+      <li data-level="info">
+        <span class="level-badge">info</span>
+        <span class="event-message">No telemetry events were recorded.</span>
+        <span class="event-time"></span>
       </li>`;
-    }).join("") || '<li data-level="info"><span class="level-badge">info</span><span class="event-message">No events yet.</span><span class="event-time"></span></li>';
   }
 
+  /* ------------------------------------------------------------------ */
+  /* Results / analyses / files                                          */
+  /* ------------------------------------------------------------------ */
   function applyResults(payload) {
-    state.results = payload;
+    state.results = payload || {};
+    state.outputDir = payload.output_dir || state.outputDir;
+    state.setupManifest = payload.setup || {};
+    state.simManifest = payload.simulation || {};
+    state.runTitle = (byId("setting-run-name")?.value || "").trim()
+      || payload.run_title
+      || state.runTitle;
+    state.runId = payload.system?.system || state.runId;
+
+    renderTopBar(state.status, state.health);
+    renderStageTimeline(state.status);
     renderAnalysis(payload);
     renderFiles(payload);
     renderRunSummary(payload);
-    window.dispatchEvent(new CustomEvent("dashboard:results-updated", {detail: payload}));
+    renderSimulationTab(state.structureInfo || {});
+    emit("results-updated", payload);
   }
 
   function renderAnalysis(payload) {
-    const grid = $("#analysis-grid");
-    const empty = $("#analysis-empty");
-    if (!grid) return;
-    const plots = payload.plots || [];
-    grid.innerHTML = "";
-    if (!plots.length) {
-      empty.removeAttribute("hidden");
-      return;
-    }
-    empty.setAttribute("hidden", "");
-    plots.forEach((plot) => {
-      const card = document.createElement("article");
-      card.className = "analysis-card";
-      card.setAttribute("data-state", (plot.mode || "artifact fallback").includes("dashboard") ? "complete" : "complete");
-      card.innerHTML = `
-        <div class="ac-header">
-          <div class="ac-title">${escapeHTML(plot.title || plot.name || "Analysis")}</div>
-          <div class="ac-status">${escapeHTML(plot.mode || "complete")}</div>
-        </div>
-        <div class="ac-frame"><img src="${escapeAttr(plot.href)}" alt="${escapeAttr(plot.title || "")}" loading="lazy"></div>
-        <div class="ac-body">${escapeHTML(plot.summary || plot.category || "")}</div>
-        <div class="ac-footer">
-          <a class="file-action" href="${escapeAttr(plot.href)}" download="${escapeAttr(plot.path || "")}">PNG</a>
-          <a class="file-action" href="${escapeAttr(plot.href)}" target="_blank" rel="noopener">Open</a>
-          <a class="file-action" href="/artifacts/${escapeAttr(plot.path || "")}" target="_blank" rel="noopener">Open raw</a>
-          <a class="file-action" href="/structure/topology.pdb" target="_blank" rel="noopener">Topology</a>
-        </div>
-      `;
-      grid.appendChild(card);
+    const grid = byId("analysis-grid");
+    const empty = byId("analysis-empty");
+    if (!grid || !empty) return;
+
+    const analyses = Array.isArray(payload.analyses) ? payload.analyses : [];
+    const plots = Array.isArray(payload.plots) ? payload.plots : [];
+    const cards = [];
+    const usedPlotPaths = new Set();
+
+    analyses.forEach((analysis) => {
+      const plot = analysis.plot || null;
+      if (plot?.path) usedPlotPaths.add(plot.path);
+      cards.push(analysisCardHtml(analysis, plot));
     });
+    plots.forEach((plot) => {
+      if (usedPlotPaths.has(plot.path)) return;
+      cards.push(analysisCardHtml({
+        name: plot.title,
+        title: plot.title,
+        status: "complete",
+        message: plot.category || "",
+        artifacts: [plot],
+      }, plot));
+    });
+
+    grid.innerHTML = cards.join("");
+    const svgBundle = byId("download-all-svg");
+    const svgCount = Number(payload.svg_figure_count || 0);
+    if (svgBundle) {
+      svgBundle.hidden = svgCount < 1;
+      svgBundle.href = payload.svg_bundle_href || "/analysis-figures-svg.zip";
+      svgBundle.textContent = svgCount === 1
+        ? "Download SVG figure"
+        : `Download all ${svgCount} SVG figures`;
+    }
+    const count = analyses.length || plots.length;
+    setText(
+      "analysis-meta",
+      count ? `${count} analysis output${count === 1 ? "" : "s"}` : "no analyses yet"
+    );
+    if (cards.length) empty.setAttribute("hidden", "");
+    else empty.removeAttribute("hidden");
+  }
+
+  function analysisCardHtml(analysis, plot) {
+    const status = String(analysis.status || "unknown").toLowerCase();
+    const title = analysis.title || humanise(analysis.name || "Analysis");
+    const artifacts = Array.isArray(analysis.artifacts) ? analysis.artifacts : [];
+    const imageArtifact = artifacts.find((item) => /\.(png|jpe?g|gif)$/i.test(item?.path || item?.name || ""));
+    const svgArtifact = artifacts.find((item) => /\.svg$/i.test(item?.path || item?.name || ""));
+    const displayPlot = plot?.href ? plot : imageArtifact || svgArtifact || null;
+    const vectorPlot = plot?.svg_href
+      ? {href: plot.svg_href, download_href: plot.svg_download_href}
+      : svgArtifact;
+    const dataArtifact = artifacts.find((item) => !/\.(png|jpe?g|gif|svg)$/i.test(item?.path || item?.name || ""));
+    const primary = dataArtifact || artifacts[0] || displayPlot;
+    const image = displayPlot?.href
+      ? `<div class="ac-frame"><img src="${escapeAttr(displayPlot.href)}" alt="${escapeAttr(title)}" loading="lazy"></div>`
+      : `<div class="ac-frame ac-no-plot"><div class="muted">No saved figure file was found for this analysis. Re-run the analysis with this revised version to generate PNG and SVG figures.</div></div>`;
+    const links = [];
+    if (displayPlot?.href) {
+      links.push(`<a class="file-action" href="${escapeAttr(displayPlot.href)}" target="_blank" rel="noopener">Open figure</a>`);
+      if (!/\.svg(?:$|\?)/i.test(displayPlot.href)) {
+        links.push(`<a class="file-action" href="${escapeAttr(displayPlot.download_href || `${displayPlot.href}${displayPlot.href.includes("?") ? "&" : "?"}download=1`)}" download>Download PNG</a>`);
+      }
+    }
+    if (vectorPlot?.href) {
+      links.push(`<a class="file-action" href="${escapeAttr(vectorPlot.download_href || vectorPlot.href)}" download>Download SVG</a>`);
+    }
+    if (primary?.href && primary?.href !== displayPlot?.href && primary?.href !== vectorPlot?.href) {
+      links.push(`<a class="file-action" href="${escapeAttr(primary.href)}" target="_blank" rel="noopener">Open data</a>`);
+    }
+    return `
+      <article class="analysis-card" data-state="${escapeAttr(status)}">
+        <div class="ac-header">
+          <div class="ac-title">${escapeHTML(title)}</div>
+          <div class="ac-status">${escapeHTML(status)}</div>
+        </div>
+        ${image}
+        <div class="ac-body">${escapeHTML(analysis.message || plot?.category || "")}</div>
+        <div class="ac-footer">${links.join("") || '<span class="muted small">Artifacts will appear when available.</span>'}</div>
+      </article>`;
   }
 
   function renderFiles(payload) {
+    const artifacts = Array.isArray(payload.artifacts) ? payload.artifacts : [];
     const groups = {
-      reports: payload.reports || [],
-      simulation: (payload.artifacts || []).filter((a) =>
-        a.path.startsWith("simulation/")),
-      analysis: (payload.artifacts || []).filter((a) =>
-        a.path.startsWith("analysis/")),
+      "reports-files": Array.isArray(payload.reports) ? payload.reports : artifacts.filter((item) => item.path.startsWith("report/")),
+      "simulation-files": artifacts.filter((item) => item.path.startsWith("simulation/")),
+      "analysis-files": artifacts.filter((item) => item.path.startsWith("analysis/")),
     };
-    Object.keys(groups).forEach((key) => {
-      const root = $(`#${key.replace(/^./, (c) => key === "reports" ? "reports" : key)}-files`);
+    Object.entries(groups).forEach(([id, files]) => {
+      const root = byId(id);
       if (!root) return;
-      const list = groups[key];
-      root.innerHTML = list.length ? list.map(fileRowHtml).join("") :
-        `<div class="muted small">No ${key} files yet.</div>`;
+      root.innerHTML = files.length
+        ? files.map(fileRowHtml).join("")
+        : '<div class="muted small">No files are available in this section yet.</div>';
     });
-    wireFileActions();
+    wireCopyActions();
   }
 
-  function fileRowHtml(a) {
-    const title = humaniseFile(a.path, a.name);
-    const size = a.size ? humanSize(parseInt(a.size, 10)) : "—";
-    const mtime = a.mtime ? new Date(parseInt(a.mtime, 10) * 1000).toLocaleString() : "—";
-    return `<div class="file-row" data-href="${escapeAttr(a.href)}" data-path="${escapeAttr(a.path)}">
-      <div class="file-title" title="${escapeAttr(a.path)}">${escapeHTML(title)}</div>
-      <div class="file-meta">
-        <span>${escapeHTML(size)}</span>
-        <span class="muted">${escapeHTML(mtime)}</span>
-        <div class="file-actions">
-          <button class="file-action" data-action="open">Open</button>
-          <button class="file-action" data-action="download">Download</button>
-          <button class="file-action" data-action="copy">Copy path</button>
+  function fileRowHtml(file) {
+    const title = file.name || file.path || "Artifact";
+    const size = file.size != null ? humanSize(parseInt(file.size, 10)) : "—";
+    const mtime = file.mtime != null
+      ? new Date(parseFloat(file.mtime) * 1000).toLocaleString()
+      : "—";
+    const href = file.href || `/artifacts/${encodeURI(file.path || "")}`;
+    const downloadHref = file.download_href || `${href}${href.includes("?") ? "&" : "?"}download=1`;
+    return `
+      <div class="file-row" data-path="${escapeAttr(file.absolute_path || file.path || "")}">
+        <div class="file-title" title="${escapeAttr(file.path || "")}">${escapeHTML(title)}</div>
+        <div class="file-meta">
+          <span>${escapeHTML(size)}</span>
+          <span class="muted">${escapeHTML(mtime)}</span>
+          <div class="file-actions">
+            <a class="file-action" href="${escapeAttr(href)}" target="_blank" rel="noopener">Open</a>
+            <a class="file-action" href="${escapeAttr(downloadHref)}" download>Download</a>
+            <button class="file-action" type="button" data-copy-path>Copy path</button>
+          </div>
         </div>
-      </div>
-    </div>`;
+      </div>`;
   }
 
-  function humaniseFile(path, name) {
-    if (!name) return path;
-    return name;
-  }
-
-  function humanSize(bytes) {
-    if (!Number.isFinite(bytes)) return "—";
-    if (bytes < 1024) return `${bytes} B`;
-    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-    if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(2)} MB`;
-    return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GB`;
-  }
-
-  function wireFileActions() {
-    $$(".file-row").forEach((row) => {
-      row.querySelectorAll(".file-action").forEach((btn) => {
-        btn.addEventListener("click", () => {
-          const action = btn.getAttribute("data-action");
-          const href = row.getAttribute("data-href");
-          const path = row.getAttribute("data-path");
-          if (action === "open") window.open(href, "_blank");
-          if (action === "download") {
-            const a = document.createElement("a");
-            a.href = href; a.download = path;
-            document.body.appendChild(a); a.click(); a.remove();
-          }
-          if (action === "copy" && navigator.clipboard) {
-            navigator.clipboard.writeText(path || "").catch(() => {});
-          }
-        });
+  function wireCopyActions() {
+    $$('[data-copy-path]').forEach((button) => {
+      button.addEventListener("click", async () => {
+        const row = button.closest(".file-row");
+        const path = row?.getAttribute("data-path") || "";
+        const copied = await copyText(path);
+        showToast(copied ? "File path copied." : "Could not copy the file path.", copied ? "ok" : "warning");
       });
     });
   }
 
   function renderRunSummary(payload) {
-    const card = $("#summary-card");
+    const card = byId("summary-card");
     if (!card) return;
-    if (!payload.has_report && !payload.has_analysis) {
-      card.setAttribute("hidden", "");
-      return;
-    }
-    card.removeAttribute("hidden");
-    const plots = payload.plots || [];
-    const reports = payload.reports || [];
-    const analyses = (payload.artifacts || []).filter((a) => a.path.startsWith("analysis/"));
+    const analyses = Array.isArray(payload.analyses) ? payload.analyses : [];
+    const plots = Array.isArray(payload.plots) ? payload.plots : [];
+    const reports = Array.isArray(payload.reports) ? payload.reports : [];
+    const hasResults = payload.has_report || payload.has_analysis || reports.length || analyses.length;
+    card.hidden = !hasResults;
+    if (!hasResults) return;
     const stats = [
-      {label: "Analyses", value: analyses.length.toString()},
-      {label: "Figures", value: plots.length.toString()},
-      {label: "Report formats", value: reports.length.toString()},
-      {label: "Result bundle", value: reports.some((r) => r.path.includes("bundle")) ? "ready" : "—"},
+      {label: "Analyses", value: String(analyses.length)},
+      {label: "Figures", value: String(plots.length)},
+      {label: "Report formats", value: String(reports.length)},
+      {label: "Result bundle", value: reports.some((item) => item.path?.endsWith(".zip")) ? "ready" : "—"},
     ];
-    $("#summary-grid").innerHTML = stats.map((s) => `
+    const grid = byId("summary-grid");
+    if (grid) grid.innerHTML = stats.map((item) => `
       <div class="summary-stat">
-        <span class="summary-stat-label">${escapeHTML(s.label)}</span>
-        <span class="summary-stat-value">${escapeHTML(s.value)}</span>
-      </div>
-    `).join("");
+        <span class="summary-stat-label">${escapeHTML(item.label)}</span>
+        <span class="summary-stat-value">${escapeHTML(item.value)}</span>
+      </div>`).join("");
   }
 
+  /* ------------------------------------------------------------------ */
+  /* Structure and playback                                              */
+  /* ------------------------------------------------------------------ */
   function applyStructure(info) {
-    state.structureInfo = info;
-    renderStructureTab(info);
-    if (info.ligand_resnames && info.ligand_resnames.length && !state.ligandResname) {
-      state.ligandResname = info.ligand_resnames[0];
+    state.structureInfo = info || {};
+    renderStructureTab(state.structureInfo);
+    if (state.structureInfo.ligand_resnames?.length && !state.ligandResname) {
+      state.ligandResname = state.structureInfo.ligand_resnames[0];
     }
-    renderLigandTab(info);
-    renderSimulationTab(info);
-    window.dispatchEvent(new CustomEvent("dashboard:structure-updated", {detail: info}));
+    renderLigandTab(state.structureInfo);
+    renderSimulationTab(state.structureInfo);
+    emit("structure-updated", state.structureInfo);
   }
 
   function renderStructureTab(info) {
-    const tbody = $("#structure-tab-tbody");
-    if (!tbody) return;
-    if (!info || !info.valid) {
-      tbody.innerHTML = `<tr><td colspan="2" class="muted">Structure not available yet.</td></tr>`;
+    const body = byId("structure-tab-tbody");
+    if (!body) return;
+    if (!info?.valid) {
+      const reason = info?.reason ? ` (${humanise(info.reason)})` : "";
+      body.innerHTML = `<tr><td colspan="2" class="muted">Structure metadata is not available${escapeHTML(reason)}.</td></tr>`;
       return;
     }
-    tbody.innerHTML = `
-      <tr><th>Protein chains</th><td>${info.n_chains}</td></tr>
-      <tr><th>Protein residues</th><td>${info.protein_residues}</td></tr>
-      <tr><th>Protein atoms</th><td>${info.protein_atoms}</td></tr>
-      <tr><th>Ligands</th><td>${info.ligand_resnames.join(", ") || "none"}</td></tr>
-      <tr><th>Water</th><td>${info.water_residues}</td></tr>
-      <tr><th>Ions</th><td>${info.ions}</td></tr>
-    `;
+    body.innerHTML = `
+      <tr><th>Protein chains</th><td>${escapeHTML(info.n_chains)}</td></tr>
+      <tr><th>Protein residues</th><td>${escapeHTML(info.protein_residues)}</td></tr>
+      <tr><th>Protein atoms</th><td>${escapeHTML(info.protein_atoms)}</td></tr>
+      <tr><th>Ligands</th><td>${escapeHTML((info.ligand_resnames || []).join(", ") || "none")}</td></tr>
+      <tr><th>Water</th><td>${escapeHTML(info.water_residues)}</td></tr>
+      <tr><th>Ions</th><td>${escapeHTML(info.ions)}</td></tr>`;
   }
 
-  function renderSimulationTab(info) {
-    const tbody = $("#simulation-tab-tbody");
-    if (!tbody) return;
-    const s = state.status || {};
-    const sim = state.simManifest || {};
-    tbody.innerHTML = `
-      <tr><th>Force field</th><td>${s.force_field || sim.force_field || "—"}</td></tr>
-      <tr><th>Water model</th><td>${s.water_model || sim.water_model || "—"}</td></tr>
-      <tr><th>pH</th><td>${s.ph || sim.ph || "—"}</td></tr>
-      <tr><th>Ion concentration</th><td>${sim.ion_concentration_M != null ? sim.ion_concentration_M + " M" : "—"}</td></tr>
-      <tr><th>Temperature</th><td>${s.target_temperature_K != null ? s.target_temperature_K + " K" : "—"}</td></tr>
-      <tr><th>Timestep</th><td>${s.timestep_fs != null ? s.timestep_fs + " fs" : "—"}</td></tr>
-      <tr><th>Precision</th><td>${s.precision || "—"}</td></tr>
-      <tr><th>Platform</th><td>${s.platform || "—"}</td></tr>
-    `;
+  function renderSimulationTab() {
+    const body = byId("simulation-tab-tbody");
+    if (!body) return;
+    const setup = state.setupManifest || {};
+    const simulation = state.simManifest || {};
+    const status = state.status || {};
+    body.innerHTML = `
+      <tr><th>Force field</th><td>${escapeHTML(setup.force_field || status.force_field || "—")}</td></tr>
+      <tr><th>Water model</th><td>${escapeHTML(setup.water_model || status.water_model || "—")}</td></tr>
+      <tr><th>pH</th><td>${escapeHTML(setup.ph ?? "—")}</td></tr>
+      <tr><th>Ion concentration</th><td>${escapeHTML(setup.ion_concentration_M != null ? `${setup.ion_concentration_M} M` : "—")}</td></tr>
+      <tr><th>Temperature</th><td>${escapeHTML(firstPresent(status.target_temperature_K, simulation.temperature_K) != null ? `${firstPresent(status.target_temperature_K, simulation.temperature_K)} K` : "—")}</td></tr>
+      <tr><th>Timestep</th><td>${escapeHTML(firstPresent(status.timestep_fs, simulation.timestep_fs) != null ? `${firstPresent(status.timestep_fs, simulation.timestep_fs)} fs` : "—")}</td></tr>
+      <tr><th>Precision</th><td>${escapeHTML(simulation.precision || status.precision || "—")}</td></tr>
+      <tr><th>Platform</th><td>${escapeHTML(status.platform || simulation.platform || "—")}</td></tr>`;
   }
 
   function renderLigandTab(info) {
-    const tools = $("#ligand-tools");
-    const meta = $("#ligand-meta");
-    if (!tools || !meta) return;
-    if (!state.ligandResname || (info && !info.valid)) {
-      tools.setAttribute("hidden", "");
+    const tools = byId("ligand-tools");
+    const meta = byId("ligand-meta");
+    const body = byId("ligand-tab-tbody");
+    if (!tools || !meta || !body) return;
+    const instances = Array.isArray(info?.ligand_instances) ? info.ligand_instances : [];
+    const instance = instances.find((item) => item.resname === state.ligandResname) || instances[0];
+    if (!instance) {
+      tools.hidden = true;
       meta.textContent = "not available";
+      body.innerHTML = '<tr><td colspan="2" class="muted">No ligand was detected.</td></tr>';
       return;
     }
-    tools.removeAttribute("hidden");
-    const ins = (info && info.ligand_instances || []).find(
-      (i) => i.resname === state.ligandResname) || (info && info.ligand_instances || [])[0];
-    if (!ins) {
-      meta.textContent = "—";
-      return;
-    }
-    const atoms = (info && info.atoms_by_resname && info.atoms_by_resname[state.ligandResname]) || "—";
-    meta.textContent =
-      `${state.ligandResname} · chain ${ins.chain} · resi ${ins.resi} · ${atoms} atoms`;
-    const tbody = $("#ligand-tab-tbody");
-    if (!tbody) return;
-    tbody.innerHTML = `
-      <tr><th>Ligand</th><td>${escapeHTML(state.ligandResname)}</td></tr>
-      <tr><th>Chain</th><td>${escapeHTML(ins.chain || "—")}</td></tr>
-      <tr><th>Residue ID</th><td>${escapeHTML(ins.resi || "—")}</td></tr>
-      <tr><th>Atom count</th><td>${escapeHTML(String(atoms))}</td></tr>
-      <tr><th>Nearby residues</th><td>—</td></tr>
-      <tr><th>Pocket distance</th><td>—</td></tr>
-      <tr><th>H-bonds</th><td>—</td></tr>
-      <tr><th>Hydrophobic contacts</th><td>—</td></tr>
-      <tr><th>Salt bridges</th><td>—</td></tr>
-    `;
+    tools.hidden = false;
+    const residueName = instance.resname || state.ligandResname;
+    const atoms = info?.atoms_by_resname?.[residueName] ?? "—";
+    state.ligandResname = residueName;
+    meta.textContent = `${residueName} · chain ${instance.chain || "—"} · resi ${instance.resi || "—"} · ${atoms} atoms`;
+    body.innerHTML = `
+      <tr><th>Ligand</th><td>${escapeHTML(residueName)}</td></tr>
+      <tr><th>Chain</th><td>${escapeHTML(instance.chain || "—")}</td></tr>
+      <tr><th>Residue ID</th><td>${escapeHTML(instance.resi || "—")}</td></tr>
+      <tr><th>Atom count</th><td>${escapeHTML(atoms)}</td></tr>
+      <tr><th>Nearby residues</th><td>Use “Show pocket residues”</td></tr>
+      <tr><th>Pocket distance</th><td>${escapeHTML(state.bindingPocketCutoff)} Å cutoff</td></tr>
+      <tr><th>H-bonds</th><td>Requires analysis output</td></tr>
+      <tr><th>Hydrophobic contacts</th><td>Requires analysis output</td></tr>
+      <tr><th>Salt bridges</th><td>Requires analysis output</td></tr>`;
   }
 
   function applyPlayback(payload) {
-    state.playbackAvailable = !!payload.playback_available;
-    state.playbackFrames = payload.n_frames_browser || 0;
-    state.playbackTotalFrames = payload.n_frames_total || 0;
-    const slider = $("#traj-slider");
-    if (state.playbackAvailable) {
-      slider.max = String(Math.max(0, state.playbackFrames - 1));
-      $("#traj-total").textContent = String(state.playbackFrames);
-      $("#traj-current").textContent = slider.value;
-      const simNs = payload.frame_times_ns && payload.frame_times_ns[0];
-      $("#traj-simtime").textContent = simNs != null ? simNs.toFixed(3) : "—";
-      $("#trajectory-row").removeAttribute("hidden");
-      window.dispatchEvent(new CustomEvent("dashboard:playback-ready", {detail: payload}));
-    } else {
-      $("#trajectory-row").setAttribute("hidden", "");
-      if (payload.reason) {
-        const reason = $("#analysis-empty .empty-detail");
-        if (reason) reason.textContent = `Trajectory playback is unavailable (${payload.reason}).`;
+    const previousSignature = state.playbackSignature;
+    const signature = payload?.source_signature || payload?.compiled_at || null;
+    const previousFrame = parseInt(byId("traj-slider")?.value || "0", 10) || 0;
+
+    state.playbackAvailable = !!payload?.playback_available;
+    state.playbackFrames = Number(payload?.n_frames_browser || 0);
+    state.playbackTotalFrames = Number(payload?.n_frames_total || 0);
+    state.playbackFrameTimes = Array.isArray(payload?.frame_times_ns) ? payload.frame_times_ns : [];
+    state.playbackSignature = signature;
+
+    const slider = byId("traj-slider");
+    const row = byId("trajectory-row");
+    if (!slider || !row) return;
+    if (!state.playbackAvailable) {
+      row.hidden = true;
+      emit("playback-ready", payload || {});
+      return;
+    }
+
+    const maxFrame = Math.max(0, state.playbackFrames - 1);
+    const frame = Math.min(previousFrame, maxFrame);
+    slider.min = "0";
+    slider.max = String(maxFrame);
+    // Do not reset the user's scrubber on every three-second API poll.
+    slider.value = String(frame);
+    setText("traj-current", String(frame));
+    setText("traj-total", String(state.playbackFrames));
+    setText(
+      "traj-simtime",
+      state.playbackFrameTimes[frame] != null
+        ? formatNumber(state.playbackFrameTimes[frame], 3) : "—"
+    );
+    row.hidden = false;
+    emit("playback-ready", Object.assign({}, payload, {
+      source_changed: previousSignature !== null && previousSignature !== signature,
+    }));
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Helpers                                                             */
+  /* ------------------------------------------------------------------ */
+  function progressPercent(status) {
+    if (Number.isFinite(Number(status.progress_percent))) {
+      return clampFloat(Number(status.progress_percent), 0, 100, null);
+    }
+    if (status.current_step != null && status.total_planned_steps != null && Number(status.total_planned_steps) > 0) {
+      return clampFloat(Number(status.current_step) / Number(status.total_planned_steps) * 100, 0, 100, null);
+    }
+    return null;
+  }
+
+  function fmtDuration(seconds) {
+    const total = Math.max(0, Math.floor(Number(seconds) || 0));
+    const hours = Math.floor(total / 3600);
+    const minutes = Math.floor((total % 3600) / 60);
+    const secs = total % 60;
+    return hours ? `${hours}h ${minutes}m` : `${minutes}m ${secs}s`;
+  }
+
+  function computeETA(status) {
+    const step = Number(status.current_step);
+    const total = Number(status.total_planned_steps);
+    const elapsed = Number(status.elapsed_wall_time_s);
+    if (!(step > 0) || !(total > 0) || !(elapsed >= 0) || step >= total) return step >= total ? "0m 0s" : "—";
+    return fmtDuration(elapsed * (total / step - 1));
+  }
+
+  function normaliseStage(value) {
+    const stage = String(value || "").toLowerCase();
+    if (stage.includes("minim")) return "minimization";
+    if (stage.includes("nvt")) return "nvt";
+    if (stage.includes("npt")) return "npt";
+    if (stage.includes("production")) return "production";
+    if (stage.includes("analysis")) return "analysis";
+    if (stage.includes("report")) return "report";
+    if (stage.includes("setup") || stage.includes("loading")) return "setup";
+    return stage;
+  }
+
+  function phaseVisualState(value) {
+    const status = String(value || "").toLowerCase();
+    if (["ok", "complete", "completed", "success", "succeeded"].includes(status)) return "completed";
+    if (["error", "failed"].includes(status)) return "failed";
+    if (["skipped", "not run"].includes(status)) return "skipped";
+    if (["running", "active", "current"].includes(status)) return "current";
+    return "waiting";
+  }
+
+  function isPhaseDone(value) {
+    return ["ok", "complete", "completed", "success"].includes(String(value || "").toLowerCase());
+  }
+
+  function formatTimestamp(value) {
+    if (!value) return "not available";
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? String(value) : date.toLocaleString();
+  }
+
+  function formatEventTime(value) {
+    if (!value) return "";
+    const date = new Date(value);
+    return Number.isNaN(date.getTime())
+      ? String(value)
+      : date.toLocaleTimeString([], {hour12: false});
+  }
+
+  function formatNumber(value, digits) {
+    const number = Number(value);
+    return Number.isFinite(number) ? number.toFixed(digits) : String(value ?? "—");
+  }
+
+  function firstPresent(...values) {
+    return values.find((value) => value !== null && value !== undefined && value !== "");
+  }
+
+  function present(value) {
+    return value !== null && value !== undefined && value !== "" ? String(value) : "not available";
+  }
+
+  function valueOrDash(value) {
+    return value !== null && value !== undefined && value !== "" ? String(value) : "—";
+  }
+
+  function setText(id, value) {
+    const element = byId(id);
+    if (element) element.textContent = value == null ? "" : String(value);
+  }
+
+  function setClassName(id, value) {
+    const element = byId(id);
+    if (element) element.className = value;
+  }
+
+  function setWidth(id, value) {
+    const element = byId(id);
+    if (element) element.style.width = value == null ? "0%" : `${Math.max(0, Math.min(100, value))}%`;
+  }
+
+  function humanSize(bytes) {
+    if (!Number.isFinite(bytes)) return "—";
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 ** 2) return `${(bytes / 1024).toFixed(1)} KB`;
+    if (bytes < 1024 ** 3) return `${(bytes / 1024 ** 2).toFixed(2)} MB`;
+    return `${(bytes / 1024 ** 3).toFixed(2)} GB`;
+  }
+
+  function humanise(value) {
+    return String(value || "")
+      .replace(/[_-]+/g, " ")
+      .replace(/\b\w/g, (character) => character.toUpperCase());
+  }
+
+  async function copyText(text) {
+    if (!text) return false;
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+        return true;
       }
+      const textarea = document.createElement("textarea");
+      textarea.value = text;
+      textarea.style.position = "fixed";
+      textarea.style.opacity = "0";
+      document.body.appendChild(textarea);
+      textarea.select();
+      const ok = document.execCommand("copy");
+      textarea.remove();
+      return ok;
+    } catch (error) {
+      return false;
     }
   }
 
-  /* ---------------------------------------------- *
-   * Tiny utility helpers                          *
-   * ---------------------------------------------- */
-  function escapeHTML(s) {
-    return String(s).replace(/[&<>"']/g,
-      (c) => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));
+  function showToast(message, kind) {
+    let toast = byId("dashboard-toast");
+    if (!toast) {
+      toast = document.createElement("div");
+      toast.id = "dashboard-toast";
+      toast.className = "dashboard-toast";
+      toast.setAttribute("role", "status");
+      document.body.appendChild(toast);
+    }
+    toast.textContent = message;
+    toast.setAttribute("data-kind", kind || "ok");
+    toast.classList.add("show");
+    window.clearTimeout(showToast.timer);
+    showToast.timer = window.setTimeout(() => toast.classList.remove("show"), 3500);
   }
 
-  function escapeAttr(s) {
-    return escapeHTML(s);
+  function escapeHTML(value) {
+    return String(value == null ? "" : value).replace(/[&<>"']/g, (character) => ({
+      "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
+    })[character]);
   }
 
-  function clampInt(v, lo, hi, fallback) {
-    v = parseInt(v, 10);
-    if (!Number.isFinite(v)) return fallback;
-    return Math.max(lo, Math.min(hi, v));
-  }
-  function clampFloat(v, lo, hi, fallback) {
-    v = parseFloat(v);
-    if (!Number.isFinite(v)) return fallback;
-    return Math.max(lo, Math.min(hi, v));
+  function escapeAttr(value) {
+    return escapeHTML(value);
   }
 
-  /* Expose state read-only for sibling JS modules */
+  function clampInt(value, low, high, fallback) {
+    const number = parseInt(value, 10);
+    if (!Number.isFinite(number)) return fallback;
+    return Math.max(low, Math.min(high, number));
+  }
+
+  function clampFloat(value, low, high, fallback) {
+    const number = Number(value);
+    if (!Number.isFinite(number)) return fallback;
+    return Math.max(low, Math.min(high, number));
+  }
+
+  function emit(name, detail) {
+    window.dispatchEvent(new CustomEvent(`dashboard:${name}`, {detail}));
+  }
+
   window.FastMDXDashboard = {
     get state() { return JSON.parse(JSON.stringify(state)); },
     navigate,
@@ -780,8 +1090,7 @@
     applyPlayback,
     applyResults,
     on(eventName, handler) {
-      window.addEventListener("dashboard:" + eventName, (ev) => handler(ev.detail));
+      window.addEventListener(`dashboard:${eventName}`, (event) => handler(event.detail));
     },
   };
-
-})();
+}());

--- a/src/fastmdxplora/live/static/dashboard.js
+++ b/src/fastmdxplora/live/static/dashboard.js
@@ -1,0 +1,787 @@
+/* FastMDXplora Live Dashboard — controller
+ *
+ * Vanilla JS — no framework, no CDN. Responsible for:
+ *   - Page navigation (Overview / Live / Viewer / Analysis / Files / Settings)
+ *   - Polling telemetry & state APIs at a configurable interval
+ *   - Updating top bar, hero card, metric cards, stage timeline, events
+ *   - Broadcasting state changes to charts.js and molecule-viewer.js
+ *   - Honouring "Pause Updates" (browser-side only)
+ */
+
+(function () {
+  "use strict";
+
+  const $ = (sel, root) => (root || document).querySelector(sel);
+  const $$ = (sel, root) => Array.from((root || document).querySelectorAll(sel));
+
+  const state = {
+    outputDir: "",
+    polling: true,
+    paused: false,
+    pollIntervalMs: 3000,
+    lastUpdateMs: 0,
+    refreshTimer: null,
+    pages: ["overview", "live", "viewer", "analysis", "files", "settings"],
+    activePage: "overview",
+    ligandResname: null,
+    bindingPocketCutoff: 5,
+    playbackAvailable: false,
+    playbackFrames: 0,
+    playbackTotalFrames: 0,
+    metrics: [],
+    status: {},
+    health: {},
+    structureInfo: null,
+    runId: "",
+    runTitle: "FastMDXplora Live",
+  };
+
+  /* ---------------------------------------------- *
+   * Boot                                          *
+   * ---------------------------------------------- */
+  document.addEventListener("DOMContentLoaded", boot);
+
+  function boot() {
+    wireNavigation();
+    wireTopBar();
+    wireViewerToggle();
+    wireInfoTabs();
+    wireTrajectoryControls();
+    wireSettings();
+    startLoadingChecklist();
+    schedulePoll(0);
+  }
+
+  function wireNavigation() {
+    $$("[data-view-link]").forEach((el) => {
+      el.addEventListener("click", (event) => {
+        event.preventDefault();
+        const target = el.getAttribute("data-view-link");
+        navigate(target);
+      });
+    });
+  }
+
+  function navigate(page) {
+    if (!state.pages.includes(page)) return;
+    state.activePage = page;
+    $$(".page").forEach((el) => {
+      const hidden = el.getAttribute("data-page") !== page;
+      el.hidden = hidden;
+    });
+    $$("[data-view-link]").forEach((el) => {
+      const isActive = el.getAttribute("data-view-link") === page;
+      el.classList.toggle("active", isActive);
+    });
+    if (page === "viewer") {
+      window.dispatchEvent(new CustomEvent("dashboard:viewer-page-opened"));
+    }
+    if (page === "analysis" || page === "files") {
+      window.dispatchEvent(new CustomEvent("dashboard:results-page-opened"));
+    }
+  }
+
+  function startLoadingChecklist() {
+    setLoadingStep("telemetry", "active");
+    fetchJSON("/api/status")
+      .then(() => setLoadingStep("telemetry", "done"))
+      .catch(() => setLoadingStep("telemetry", "error"));
+    setLoadingStep("structure", "active");
+    fetchJSON("/api/structure-info")
+      .then(() => setLoadingStep("structure", "done"))
+      .catch(() => setLoadingStep("structure", "error"));
+    setLoadingStep("metrics", "active");
+    fetchJSON("/api/metrics")
+      .then(() => setLoadingStep("metrics", "done"))
+      .catch(() => setLoadingStep("metrics", "error"));
+    setTimeout(() => {
+      document.body.classList.remove("state-loading");
+      document.body.classList.add("state-ready");
+    }, 1100); /* fade-out tied to successful lookup, not a fixed timeout, but with a brief post-poll settle delay */
+  }
+
+  function setLoadingStep(name, status) {
+    const el = document.querySelector(`.loading-step[data-step="${name}"]`);
+    if (el) el.setAttribute("data-state", status);
+  }
+
+  function wireTopBar() {
+    $("#pause-toggle").addEventListener("click", () => {
+      state.paused = !state.paused;
+      $("#pause-toggle").setAttribute("aria-pressed", state.paused);
+      $("#pause-label").textContent = state.paused ? "Resume Updates" : "Pause Updates";
+    });
+    $("#refresh-now").addEventListener("click", () => {
+      schedulePoll(0);
+    });
+    $("#open-output").addEventListener("click", () => {
+      /* Best-effort: the dashboard never opens the OS browser from a
+         page that's already opened in a browser; show the absolute path
+         and copy it. */
+      const text = $("#sidebar-run-name").textContent || "";
+      if (!text || text === "not available") return;
+      const toast = document.createElement("div");
+      toast.className = "sr-only";
+      toast.textContent = `Output folder: ${text}`;
+      document.body.appendChild(toast);
+    });
+  }
+
+  function wireViewerToggle() {
+    $("#mini-preview-frame").addEventListener("click", () => navigate("viewer"));
+  }
+
+  function wireInfoTabs() {
+    $$(".info-tab").forEach((tab) => {
+      tab.addEventListener("click", () => {
+        const name = tab.getAttribute("data-tab");
+        $$(".info-tab").forEach((t) => t.classList.toggle("active", t === tab));
+        $$(".info-pane").forEach((p) => {
+          p.hidden = p.getAttribute("data-tab") !== name;
+          p.classList.toggle("active", p.getAttribute("data-tab") === name);
+        });
+      });
+    });
+  }
+
+  function wireTrajectoryControls() {
+    const slider = $("#traj-slider");
+    if (!slider) return;
+    slider.addEventListener("input", () => {
+      const frame = parseInt(slider.value, 10);
+      window.dispatchEvent(
+        new CustomEvent("dashboard:trajectory-seek", {detail: {frame}})
+      );
+    });
+    $$("[data-traj]").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        const action = btn.getAttribute("data-traj");
+        window.dispatchEvent(
+          new CustomEvent("dashboard:trajectory-action", {detail: {action}})
+        );
+      });
+    });
+  }
+
+  function wireSettings() {
+    /* Settings page wires its own values via onSettingsChanged */
+    document.getElementById("setting-refresh-seconds")
+      .addEventListener("change", onSettingsChanged);
+    document.getElementById("setting-pocket-cutoff")
+      .addEventListener("change", onSettingsChanged);
+    document.getElementById("setting-reduced-motion")
+      .addEventListener("change", onSettingsChanged);
+    document.getElementById("setting-ligand-resname")
+      .addEventListener("change", onSettingsChanged);
+    document.getElementById("setting-chart-history")
+      .addEventListener("change", onSettingsChanged);
+  }
+
+  function onSettingsChanged() {
+    state.pollIntervalMs = clampInt(
+      parseInt($("#setting-refresh-seconds").value, 10), 1000, 60000, 3000);
+    state.bindingPocketCutoff = clampFloat(
+      parseFloat($("#setting-pocket-cutoff").value), 3.0, 15.0, 5.0);
+    const lig = ($("#setting-ligand-resname").value || "").trim().toUpperCase();
+    state.ligandResname = lig || null;
+    chartHistorySamples = clampInt(
+      parseInt($("#setting-chart-history").value, 10), 60, 5000, 600);
+    document.body.classList.toggle("compact-mode",
+      $("#setting-compact").checked);
+    document.body.classList.toggle("reduced-motion",
+      $("#setting-reduced-motion").checked);
+    /* Tell the viewer + chart modules to bind the new settings */
+    window.dispatchEvent(new CustomEvent("dashboard:settings-updated", {
+      detail: {
+        ligand: state.ligandResname,
+        pocketCutoff: state.bindingPocketCutoff,
+        chartHistory: chartHistorySamples,
+      }
+    }));
+    schedulePoll(0);
+  }
+
+  /* ---------------------------------------------- *
+   * Polling                                       *
+   * ---------------------------------------------- */
+  let chartHistorySamples = 600;
+
+  async function fetchJSON(url) {
+    const res = await fetch(url, {cache: "no-store", headers: {"X-FastMDX": "live"}});
+    if (!res.ok) throw new Error(`HTTP ${res.status} on ${url}`);
+    return await res.json();
+  }
+
+  function schedulePoll(delayMs) {
+    if (state.refreshTimer) {
+      clearTimeout(state.refreshTimer);
+      state.refreshTimer = null;
+    }
+    if (state.paused) {
+      state.refreshTimer = setTimeout(() => schedulePoll(state.pollIntervalMs), state.pollIntervalMs);
+      return;
+    }
+    state.refreshTimer = setTimeout(() => {
+      pollNow().catch((err) => console.warn("dashboard poll error", err))
+        .finally(() => schedulePoll(state.pollIntervalMs));
+    }, Math.max(0, delayMs));
+  }
+
+  async function pollNow() {
+    const [statusPayload, metricsPayload, eventsPayload, resultsPayload, structurePayload, playbackPayload] =
+      await Promise.allSettled([
+        fetchJSON("/api/status"),
+        fetchJSON("/api/metrics"),
+        fetchJSON("/api/events"),
+        fetchJSON("/api/results"),
+        fetchJSON("/api/structure-info"),
+        fetchJSON("/api/playback-info"),
+      ]);
+
+    if (statusPayload.status === "fulfilled") {
+      applyStatus(statusPayload.value);
+    }
+    if (metricsPayload.status === "fulfilled") {
+      applyMetrics(metricsPayload.value.metrics || []);
+    }
+    if (eventsPayload.status === "fulfilled") {
+      renderEvents(eventsPayload.value.events || []);
+    }
+    if (resultsPayload.status === "fulfilled") {
+      applyResults(resultsPayload.value);
+    }
+    if (structurePayload.status === "fulfilled") {
+      applyStructure(structurePayload.value);
+    }
+    if (playbackPayload.status === "fulfilled") {
+      applyPlayback(playbackPayload.value);
+    }
+
+    state.lastUpdateMs = Date.now();
+    updateRefreshedAt();
+    pulseTopbarIfLive();
+  }
+
+  function pulseTopbarIfLive() {
+    const age = (Date.now() - state.lastUpdateMs) / 1000;
+    const dot = $("#topbar-status-dot");
+    if (age > 30) {
+      dot.classList.remove("status-dot-live");
+      dot.classList.add("status-dot-stale");
+    } else {
+      dot.classList.add("status-dot-live");
+      dot.classList.remove("status-dot-stale");
+    }
+  }
+
+  function updateRefreshedAt() {
+    const date = new Date(state.lastUpdateMs);
+    const use24 = !$("#setting-time-format") || $("#setting-time-format").value !== "12h";
+    const fmt = use24
+      ? `${date.toLocaleDateString()} ${date.toLocaleTimeString([], {hour12: false})}`
+      : date.toLocaleTimeString();
+    const el = $("#refreshed-at");
+    if (el) el.textContent = fmt;
+  }
+
+  function applyStatus(payload) {
+    const status = payload.status || {};
+    const health = payload.health || {};
+    state.status = status;
+    state.health = health;
+    renderTopBar(status, health);
+    renderHero(status);
+    renderHealth(health);
+    renderStageTimeline(status);
+    renderLiveProgress(status);
+    window.dispatchEvent(new CustomEvent("dashboard:status-updated", {detail: {status, health}}));
+  }
+
+  function renderTopBar(status, health) {
+    const stateName = (health.state || status.status || "live").toLowerCase();
+    const dot = $("#topbar-status-dot");
+    dot.className = "status-dot " + stateDotClass(stateName);
+    $("#topbar-status-text").textContent = stateName;
+    $("#topbar-stage").textContent = status.stage || "not available";
+    const step = status.current_step;
+    const total = status.total_planned_steps;
+    $("#topbar-step").textContent = step != null ? String(step) : "—";
+    $("#topbar-total").textContent = total != null ? String(total) : "—";
+    $("#topbar-platform").textContent = status.platform || "—";
+    const temp = status.target_temperature_K ||
+      (state.metrics.length
+        ? (state.metrics[state.metrics.length - 1].temperature || "")
+        : "");
+    $("#topbar-temperature").textContent = temp ? `${temp} K` : "—";
+
+    $("#sidebar-status-dot").className = "status-dot " + stateDotClass(stateName);
+    $("#sidebar-connection-state").textContent = stateName;
+    $("#sidebar-platform").textContent = status.platform || "not available";
+    $("#sidebar-run-name").textContent = state.runTitle;
+    state.runId = status.system_id || state.runId;
+    $("#topbar-run-id").textContent = state.runId || "system";
+    $("#topbar-run-title").textContent = state.runTitle;
+  }
+
+  function stateDotClass(s) {
+    if (s === "ok" || s === "live" || s === "completed") return "status-dot-live";
+    if (s === "warning" || s === "waiting" || s === "stale") return "status-dot-stale";
+    if (s === "failed" || s === "error") return "status-dot-error";
+    return "status-dot-stale";
+  }
+
+  function renderHero(status) {
+    const card = $("#hero-card");
+    card.setAttribute("data-state", (status.status || "running").toLowerCase());
+    $("#hero-stage").textContent = status.stage || "—";
+    let pct = null;
+    if (typeof status.progress_percent === "number") pct = status.progress_percent;
+    else if (status.current_step && status.total_planned_steps)
+      pct = (status.current_step / status.total_planned_steps) * 100;
+    if (pct !== null) {
+      $("#hero-progress-fill").style.width = `${Math.max(0, Math.min(100, pct))}%`;
+      $("#hero-progress-pct").textContent = pct.toFixed(1);
+    } else {
+      $("#hero-progress-fill").style.width = "0%";
+      $("#hero-progress-pct").textContent = "—";
+    }
+    $("#hero-sim-time").textContent = status.simulation_time_completed_ns
+      ? status.simulation_time_completed_ns.toFixed(3) : "—";
+    $("#hero-elapsed").textContent = status.elapsed_wall_time_s
+      ? fmtDuration(status.elapsed_wall_time_s) : "—";
+    $("#hero-eta").textContent = computeETA(status);
+    $("#hero-step").textContent = status.current_step != null
+      ? `${status.current_step} / ${status.total_planned_steps ?? "—"}` : "—";
+  }
+
+  function fmtDuration(seconds) {
+    const s = Math.max(0, Math.floor(seconds));
+    const hh = Math.floor(s / 3600);
+    const mm = Math.floor((s % 3600) / 60);
+    const ss = s % 60;
+    return hh ? `${hh}h ${mm}m` : `${mm}m ${ss}s`;
+  }
+
+  function computeETA(status) {
+    if (!status.current_step || !status.total_planned_steps
+        || !status.elapsed_wall_time_s) return "—";
+    const total = status.total_planned_steps;
+    const elapsed = status.elapsed_wall_time_s;
+    const ratio = total / Math.max(status.current_step, 1);
+    return fmtDuration(elapsed * (ratio - 1));
+  }
+
+  function renderHealth(health) {
+    const card = $("#hero-health");
+    const stateName = health.state || "unknown";
+    card.setAttribute("data-state", stateName);
+    $("#health-headline").textContent = health.message || stateName;
+    $("#health-explanation").textContent = health.explanation || "";
+    $("#health-pill").textContent = stateName;
+    $("#health-pill").setAttribute("data-state", stateName);
+    const items = (health.items || []).slice(0, 4);
+    const list = $("#health-list");
+    list.innerHTML = items.map((it) =>
+      `<li data-state="${escapeAttr(it.severity || "ok")}">
+        <strong>${escapeHTML(it.title || it.severity || "info")}</strong>
+        <span class="muted small"> — ${escapeHTML(it.detail || "")}</span>
+      </li>`
+    ).join("");
+    const livePill = $("#live-health-pill");
+    if (livePill) {
+      livePill.textContent = stateName;
+      livePill.setAttribute("data-state", stateName);
+    }
+    $("#live-health-message").textContent = health.message || "not available";
+    $("#live-health-explanation").textContent = health.explanation || "";
+  }
+
+  function renderStageTimeline(status) {
+    const map = {
+      setup: "setup", minimization: "minimization", nvt: "nvt",
+      npt: "npt", production: "production", analysis: "analysis",
+      report: "report", loading: "setup"
+    };
+    const order = ["setup", "minimization", "nvt", "npt", "production", "analysis", "report"];
+    const current = (status.stage || "").toLowerCase();
+    const currentIdx = order.indexOf(map[current] || current);
+    $$(".stage-step").forEach((el) => {
+      const stage = el.getAttribute("data-stage");
+      const idx = order.indexOf(stage);
+      el.removeAttribute("data-state");
+      if (idx === -1) return;
+      if (idx < currentIdx) el.setAttribute("data-state", "completed");
+      else if (idx === currentIdx) el.setAttribute("data-state", "current");
+      else el.setAttribute("data-state", "waiting");
+    });
+  }
+
+  function renderLiveProgress(status) {
+    let pct = null;
+    if (typeof status.progress_percent === "number") pct = status.progress_percent;
+    else if (status.current_step && status.total_planned_steps)
+      pct = (status.current_step / status.total_planned_steps) * 100;
+    if (pct !== null) {
+      $("#live-progress-fill").style.width = `${Math.max(0, Math.min(100, pct))}%`;
+      $("#live-progress-pct").textContent = pct.toFixed(1);
+    } else {
+      $("#live-progress-fill").style.width = "0%";
+      $("#live-progress-pct").textContent = "—";
+    }
+    $("#live-sim-time").textContent = status.simulation_time_completed_ns
+      ? status.simulation_time_completed_ns.toFixed(3) : "—";
+    $("#live-stage-cell").textContent = status.stage || "not available";
+    $("#live-step-cell").textContent = status.current_step != null ? String(status.current_step) : "not available";
+    $("#live-total-cell").textContent = status.total_planned_steps != null ? String(status.total_planned_steps) : "not available";
+    $("#live-frames-cell").textContent = status.current_frame_count != null
+      ? `${status.current_frame_count}${status.planned_frame_count != null ? ` / ${status.planned_frame_count}` : ""}`
+      : "not available";
+    $("#live-simtime-cell").textContent = status.simulation_time_completed_ns
+      ? `${status.simulation_time_completed_ns} ns` : "not available";
+    $("#live-elapsed-cell").textContent = status.elapsed_wall_time_s
+      ? fmtDuration(status.elapsed_wall_time_s) : "not available";
+    $("#live-eta-cell").textContent = computeETA(status);
+    $("#live-checkpoint-cell").textContent = status.current_checkpoint_path || "not available";
+    $("#live-lastupdate-cell").textContent = status.last_update_timestamp || "not available";
+    $("#live-card-step").textContent = status.current_step != null ? String(status.current_step) : "—";
+  }
+
+  function applyMetrics(metrics) {
+    state.metrics = metrics.slice(-chartHistorySamples);
+    renderMetricCards();
+    if (window.FastMDXCharts) {
+      window.FastMDXCharts.update(state.metrics);
+    }
+  }
+
+  function renderMetricCards() {
+    const latest = state.metrics.length ? state.metrics[state.metrics.length - 1] : {};
+    const map = {
+      potential_energy: {unit: "kJ/mol"},
+      temperature: {unit: "K"},
+      density: {unit: "g/mL"},
+      speed: {unit: "ns/day"},
+      frames: {unit: "frames"},
+      pressure: {unit: "bar"},
+    };
+    $$(".metric-card").forEach((card) => {
+      const key = card.getAttribute("data-metric");
+      const derived = deriveMetric(key, latest);
+      const value = card.querySelector("[data-value]");
+      const unit = card.querySelector(".metric-card-unit");
+      if (value) value.textContent = derived != null ? derived : "—";
+      if (unit && map[key]) unit.textContent = map[key].unit;
+      if (derived !== card.getAttribute("data-last-value")) {
+        if (derived != null && card.getAttribute("data-last-value") != null) {
+          card.setAttribute("data-pulse", "");
+          setTimeout(() => card.removeAttribute("data-pulse"), 1200);
+        }
+        card.setAttribute("data-last-value", derived != null ? String(derived) : "");
+      }
+    });
+  }
+
+  function deriveMetric(key, latest) {
+    if (key === "frames") {
+      return latest.current_frame_count || latest.frame || null;
+    }
+    if (key === "speed") {
+      /* OpenMM reports ns/day via its reporter; flatten to a numeric.
+         If it's missing, we cannot honestly invent it. */
+      return latest.speed != null ? Number(latest.speed).toFixed(2) : null;
+    }
+    if (latest[key] === undefined) return null;
+    const v = Number(latest[key]);
+    return Number.isFinite(v) ? v.toFixed(2) : null;
+  }
+
+  function renderEvents(events) {
+    const ul = $("#events-list");
+    if (!ul) return;
+    const items = events.slice(-50).reverse();
+    ul.innerHTML = items.map((ev) => {
+      const level = ev.level || "info";
+      const ts = ev.timestamp ? new Date(ev.timestamp).toLocaleTimeString([], {hour12:false}) : "";
+      return `<li data-level="${escapeAttr(level)}">
+        <span class="level-badge">${escapeHTML(level)}</span>
+        <span class="event-message">${escapeHTML(ev.message || "")}</span>
+        <span class="event-time">${escapeHTML(ts)}</span>
+      </li>`;
+    }).join("") || '<li data-level="info"><span class="level-badge">info</span><span class="event-message">No events yet.</span><span class="event-time"></span></li>';
+  }
+
+  function applyResults(payload) {
+    state.results = payload;
+    renderAnalysis(payload);
+    renderFiles(payload);
+    renderRunSummary(payload);
+    window.dispatchEvent(new CustomEvent("dashboard:results-updated", {detail: payload}));
+  }
+
+  function renderAnalysis(payload) {
+    const grid = $("#analysis-grid");
+    const empty = $("#analysis-empty");
+    if (!grid) return;
+    const plots = payload.plots || [];
+    grid.innerHTML = "";
+    if (!plots.length) {
+      empty.removeAttribute("hidden");
+      return;
+    }
+    empty.setAttribute("hidden", "");
+    plots.forEach((plot) => {
+      const card = document.createElement("article");
+      card.className = "analysis-card";
+      card.setAttribute("data-state", (plot.mode || "artifact fallback").includes("dashboard") ? "complete" : "complete");
+      card.innerHTML = `
+        <div class="ac-header">
+          <div class="ac-title">${escapeHTML(plot.title || plot.name || "Analysis")}</div>
+          <div class="ac-status">${escapeHTML(plot.mode || "complete")}</div>
+        </div>
+        <div class="ac-frame"><img src="${escapeAttr(plot.href)}" alt="${escapeAttr(plot.title || "")}" loading="lazy"></div>
+        <div class="ac-body">${escapeHTML(plot.summary || plot.category || "")}</div>
+        <div class="ac-footer">
+          <a class="file-action" href="${escapeAttr(plot.href)}" download="${escapeAttr(plot.path || "")}">PNG</a>
+          <a class="file-action" href="${escapeAttr(plot.href)}" target="_blank" rel="noopener">Open</a>
+          <a class="file-action" href="/artifacts/${escapeAttr(plot.path || "")}" target="_blank" rel="noopener">Open raw</a>
+          <a class="file-action" href="/structure/topology.pdb" target="_blank" rel="noopener">Topology</a>
+        </div>
+      `;
+      grid.appendChild(card);
+    });
+  }
+
+  function renderFiles(payload) {
+    const groups = {
+      reports: payload.reports || [],
+      simulation: (payload.artifacts || []).filter((a) =>
+        a.path.startsWith("simulation/")),
+      analysis: (payload.artifacts || []).filter((a) =>
+        a.path.startsWith("analysis/")),
+    };
+    Object.keys(groups).forEach((key) => {
+      const root = $(`#${key.replace(/^./, (c) => key === "reports" ? "reports" : key)}-files`);
+      if (!root) return;
+      const list = groups[key];
+      root.innerHTML = list.length ? list.map(fileRowHtml).join("") :
+        `<div class="muted small">No ${key} files yet.</div>`;
+    });
+    wireFileActions();
+  }
+
+  function fileRowHtml(a) {
+    const title = humaniseFile(a.path, a.name);
+    const size = a.size ? humanSize(parseInt(a.size, 10)) : "—";
+    const mtime = a.mtime ? new Date(parseInt(a.mtime, 10) * 1000).toLocaleString() : "—";
+    return `<div class="file-row" data-href="${escapeAttr(a.href)}" data-path="${escapeAttr(a.path)}">
+      <div class="file-title" title="${escapeAttr(a.path)}">${escapeHTML(title)}</div>
+      <div class="file-meta">
+        <span>${escapeHTML(size)}</span>
+        <span class="muted">${escapeHTML(mtime)}</span>
+        <div class="file-actions">
+          <button class="file-action" data-action="open">Open</button>
+          <button class="file-action" data-action="download">Download</button>
+          <button class="file-action" data-action="copy">Copy path</button>
+        </div>
+      </div>
+    </div>`;
+  }
+
+  function humaniseFile(path, name) {
+    if (!name) return path;
+    return name;
+  }
+
+  function humanSize(bytes) {
+    if (!Number.isFinite(bytes)) return "—";
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(2)} MB`;
+    return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GB`;
+  }
+
+  function wireFileActions() {
+    $$(".file-row").forEach((row) => {
+      row.querySelectorAll(".file-action").forEach((btn) => {
+        btn.addEventListener("click", () => {
+          const action = btn.getAttribute("data-action");
+          const href = row.getAttribute("data-href");
+          const path = row.getAttribute("data-path");
+          if (action === "open") window.open(href, "_blank");
+          if (action === "download") {
+            const a = document.createElement("a");
+            a.href = href; a.download = path;
+            document.body.appendChild(a); a.click(); a.remove();
+          }
+          if (action === "copy" && navigator.clipboard) {
+            navigator.clipboard.writeText(path || "").catch(() => {});
+          }
+        });
+      });
+    });
+  }
+
+  function renderRunSummary(payload) {
+    const card = $("#summary-card");
+    if (!card) return;
+    if (!payload.has_report && !payload.has_analysis) {
+      card.setAttribute("hidden", "");
+      return;
+    }
+    card.removeAttribute("hidden");
+    const plots = payload.plots || [];
+    const reports = payload.reports || [];
+    const analyses = (payload.artifacts || []).filter((a) => a.path.startsWith("analysis/"));
+    const stats = [
+      {label: "Analyses", value: analyses.length.toString()},
+      {label: "Figures", value: plots.length.toString()},
+      {label: "Report formats", value: reports.length.toString()},
+      {label: "Result bundle", value: reports.some((r) => r.path.includes("bundle")) ? "ready" : "—"},
+    ];
+    $("#summary-grid").innerHTML = stats.map((s) => `
+      <div class="summary-stat">
+        <span class="summary-stat-label">${escapeHTML(s.label)}</span>
+        <span class="summary-stat-value">${escapeHTML(s.value)}</span>
+      </div>
+    `).join("");
+  }
+
+  function applyStructure(info) {
+    state.structureInfo = info;
+    renderStructureTab(info);
+    if (info.ligand_resnames && info.ligand_resnames.length && !state.ligandResname) {
+      state.ligandResname = info.ligand_resnames[0];
+    }
+    renderLigandTab(info);
+    renderSimulationTab(info);
+    window.dispatchEvent(new CustomEvent("dashboard:structure-updated", {detail: info}));
+  }
+
+  function renderStructureTab(info) {
+    const tbody = $("#structure-tab-tbody");
+    if (!tbody) return;
+    if (!info || !info.valid) {
+      tbody.innerHTML = `<tr><td colspan="2" class="muted">Structure not available yet.</td></tr>`;
+      return;
+    }
+    tbody.innerHTML = `
+      <tr><th>Protein chains</th><td>${info.n_chains}</td></tr>
+      <tr><th>Protein residues</th><td>${info.protein_residues}</td></tr>
+      <tr><th>Protein atoms</th><td>${info.protein_atoms}</td></tr>
+      <tr><th>Ligands</th><td>${info.ligand_resnames.join(", ") || "none"}</td></tr>
+      <tr><th>Water</th><td>${info.water_residues}</td></tr>
+      <tr><th>Ions</th><td>${info.ions}</td></tr>
+    `;
+  }
+
+  function renderSimulationTab(info) {
+    const tbody = $("#simulation-tab-tbody");
+    if (!tbody) return;
+    const s = state.status || {};
+    const sim = state.simManifest || {};
+    tbody.innerHTML = `
+      <tr><th>Force field</th><td>${s.force_field || sim.force_field || "—"}</td></tr>
+      <tr><th>Water model</th><td>${s.water_model || sim.water_model || "—"}</td></tr>
+      <tr><th>pH</th><td>${s.ph || sim.ph || "—"}</td></tr>
+      <tr><th>Ion concentration</th><td>${sim.ion_concentration_M != null ? sim.ion_concentration_M + " M" : "—"}</td></tr>
+      <tr><th>Temperature</th><td>${s.target_temperature_K != null ? s.target_temperature_K + " K" : "—"}</td></tr>
+      <tr><th>Timestep</th><td>${s.timestep_fs != null ? s.timestep_fs + " fs" : "—"}</td></tr>
+      <tr><th>Precision</th><td>${s.precision || "—"}</td></tr>
+      <tr><th>Platform</th><td>${s.platform || "—"}</td></tr>
+    `;
+  }
+
+  function renderLigandTab(info) {
+    const tools = $("#ligand-tools");
+    const meta = $("#ligand-meta");
+    if (!tools || !meta) return;
+    if (!state.ligandResname || (info && !info.valid)) {
+      tools.setAttribute("hidden", "");
+      meta.textContent = "not available";
+      return;
+    }
+    tools.removeAttribute("hidden");
+    const ins = (info && info.ligand_instances || []).find(
+      (i) => i.resname === state.ligandResname) || (info && info.ligand_instances || [])[0];
+    if (!ins) {
+      meta.textContent = "—";
+      return;
+    }
+    const atoms = (info && info.atoms_by_resname && info.atoms_by_resname[state.ligandResname]) || "—";
+    meta.textContent =
+      `${state.ligandResname} · chain ${ins.chain} · resi ${ins.resi} · ${atoms} atoms`;
+    const tbody = $("#ligand-tab-tbody");
+    if (!tbody) return;
+    tbody.innerHTML = `
+      <tr><th>Ligand</th><td>${escapeHTML(state.ligandResname)}</td></tr>
+      <tr><th>Chain</th><td>${escapeHTML(ins.chain || "—")}</td></tr>
+      <tr><th>Residue ID</th><td>${escapeHTML(ins.resi || "—")}</td></tr>
+      <tr><th>Atom count</th><td>${escapeHTML(String(atoms))}</td></tr>
+      <tr><th>Nearby residues</th><td>—</td></tr>
+      <tr><th>Pocket distance</th><td>—</td></tr>
+      <tr><th>H-bonds</th><td>—</td></tr>
+      <tr><th>Hydrophobic contacts</th><td>—</td></tr>
+      <tr><th>Salt bridges</th><td>—</td></tr>
+    `;
+  }
+
+  function applyPlayback(payload) {
+    state.playbackAvailable = !!payload.playback_available;
+    state.playbackFrames = payload.n_frames_browser || 0;
+    state.playbackTotalFrames = payload.n_frames_total || 0;
+    const slider = $("#traj-slider");
+    if (state.playbackAvailable) {
+      slider.max = String(Math.max(0, state.playbackFrames - 1));
+      $("#traj-total").textContent = String(state.playbackFrames);
+      $("#traj-current").textContent = slider.value;
+      const simNs = payload.frame_times_ns && payload.frame_times_ns[0];
+      $("#traj-simtime").textContent = simNs != null ? simNs.toFixed(3) : "—";
+      $("#trajectory-row").removeAttribute("hidden");
+      window.dispatchEvent(new CustomEvent("dashboard:playback-ready", {detail: payload}));
+    } else {
+      $("#trajectory-row").setAttribute("hidden", "");
+      if (payload.reason) {
+        const reason = $("#analysis-empty .empty-detail");
+        if (reason) reason.textContent = `Trajectory playback is unavailable (${payload.reason}).`;
+      }
+    }
+  }
+
+  /* ---------------------------------------------- *
+   * Tiny utility helpers                          *
+   * ---------------------------------------------- */
+  function escapeHTML(s) {
+    return String(s).replace(/[&<>"']/g,
+      (c) => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));
+  }
+
+  function escapeAttr(s) {
+    return escapeHTML(s);
+  }
+
+  function clampInt(v, lo, hi, fallback) {
+    v = parseInt(v, 10);
+    if (!Number.isFinite(v)) return fallback;
+    return Math.max(lo, Math.min(hi, v));
+  }
+  function clampFloat(v, lo, hi, fallback) {
+    v = parseFloat(v);
+    if (!Number.isFinite(v)) return fallback;
+    return Math.max(lo, Math.min(hi, v));
+  }
+
+  /* Expose state read-only for sibling JS modules */
+  window.FastMDXDashboard = {
+    get state() { return JSON.parse(JSON.stringify(state)); },
+    navigate,
+    applyStatus,
+    applyMetrics,
+    applyStructure,
+    applyPlayback,
+    applyResults,
+    on(eventName, handler) {
+      window.addEventListener("dashboard:" + eventName, (ev) => handler(ev.detail));
+    },
+  };
+
+})();

--- a/src/fastmdxplora/live/static/dashboard.js
+++ b/src/fastmdxplora/live/static/dashboard.js
@@ -20,8 +20,10 @@
     pollIntervalMs: 3000,
     lastUpdateMs: 0,
     refreshTimer: null,
-    pages: ["overview", "live", "viewer", "analysis", "files", "settings"],
+    pages: ["builder", "overview", "live", "viewer", "analysis", "files", "settings"],
     activePage: "overview",
+    appState: {},
+    initialRouteResolved: false,
     ligandResname: null,
     bindingPocketCutoff: 5,
     playbackAvailable: false,
@@ -283,9 +285,9 @@
   }
 
   async function pollNow() {
-    const names = ["status", "metrics", "events", "results", "structure", "playback"];
+    const names = ["app", "status", "metrics", "events", "results", "structure", "playback"];
     const urls = [
-      "/api/status", "/api/metrics", "/api/events", "/api/results",
+      "/api/app-state", "/api/status", "/api/metrics", "/api/events", "/api/results",
       "/api/structure-info", "/api/playback-info",
     ];
     const settled = await Promise.allSettled(urls.map(fetchJSON));
@@ -301,6 +303,7 @@
       delete state.apiErrors[name];
       successes += 1;
       const payload = result.value;
+      if (name === "app") safeApply(name, () => applyAppState(payload));
       if (name === "status") safeApply(name, () => applyStatus(payload));
       if (name === "metrics") safeApply(name, () => applyMetrics(payload.metrics || []));
       if (name === "events") safeApply(name, () => renderEvents(payload.events || []));
@@ -314,6 +317,27 @@
       updateRefreshedAt();
     }
     updateConnectionState();
+  }
+
+  function applyAppState(payload) {
+    state.appState = payload || {};
+    const activeRun = payload?.active_run || "";
+    if (activeRun) state.outputDir = activeRun;
+
+    if (!state.initialRouteResolved) {
+      state.initialRouteResolved = true;
+      const requested = location.hash.replace(/^#/, "");
+      if (!requested && !activeRun) navigate("builder");
+    }
+
+    if (!activeRun) {
+      setText("topbar-run-id", "workspace");
+      setText("topbar-run-title", "No active run");
+      setText("topbar-stage", "configure a simulation");
+      setText("sidebar-run-name", "No active run");
+      setText("sidebar-platform", "—");
+    }
+    emit("app-state", payload || {});
   }
 
   function safeApply(name, callback) {
@@ -360,6 +384,22 @@
   }
 
   function renderTopBar(status, health) {
+    if (!state.appState?.active_run) {
+      setClassName("topbar-status-dot", "status-dot status-dot-waiting");
+      setClassName("sidebar-status-dot", "status-dot status-dot-waiting");
+      setText("topbar-status-text", "ready");
+      setText("topbar-stage", "configure a simulation");
+      setText("topbar-step", "—");
+      setText("topbar-total", "—");
+      setText("topbar-platform", "—");
+      setText("topbar-temperature", "—");
+      setText("sidebar-connection-state", "ready");
+      setText("sidebar-platform", "—");
+      setText("sidebar-run-name", "No active run");
+      setText("topbar-run-id", "workspace");
+      setText("topbar-run-title", "FastMDXplora Dashboard");
+      return;
+    }
     const statusName = String(health.state || status.status || "waiting").toLowerCase();
     const dotClass = stateDotClass(statusName);
     setClassName("topbar-status-dot", `status-dot ${dotClass}`);
@@ -1085,6 +1125,7 @@
     get state() { return JSON.parse(JSON.stringify(state)); },
     navigate,
     applyStatus,
+    applyAppState,
     applyMetrics,
     applyStructure,
     applyPlayback,

--- a/src/fastmdxplora/live/static/molecule-viewer.js
+++ b/src/fastmdxplora/live/static/molecule-viewer.js
@@ -1,0 +1,626 @@
+/* FastMDXplora Live Dashboard — molecular viewer
+ *
+ * Wraps the locally vendored 3Dmol.js (`window.$3Dmol`) so the molecular
+ * viewer page can:
+ *   - Load a topology PDB and superimpose a live-frame PDB without
+ *     resetting camera, representation, color mode, or visibility.
+ *   - Step through trajectory playback (via $3Dmol mload).
+ *   - Provide pocket/ligand tools that don't pretend simple proximity
+ *     is a confirmed chemical interaction.
+ *   - Export a PNG screenshot using 3Dmol's pngURI().
+ *
+ * No third-party libraries; everything happens in the browser.
+ */
+
+(function () {
+  "use strict";
+
+  const COLORS = {
+    cyanide: "#63e6ff",
+    silver: "#d8d8dd",
+    white: "#ffffff",
+    violet: "#a78bfa",
+    black: "#050505",
+  };
+
+  const STATE = {
+    viewer: null,
+    structureUrl: null,
+    structurePdb: null,
+    liveFrameUrl: null,
+    liveFrameIndex: null,
+    coordinatesPdb: null,
+    playbackLoaded: false,
+    playbackFrames: 0,
+    representation: "cartoon",
+    colorMode: "spectrum",
+    visibility: {protein: true, ligand: true, pocket: true, water: false, ions: false, hydrogens: false, box: false},
+    ligandResname: null,
+    pocketCutoff: 5,
+    inMotion: false,
+    playbackPlaying: false,
+    playbackReverse: false,
+    playbackLoop: false,
+    playbackSpeed: 1,
+    preservingCamera: true,
+    spinning: false,
+    hoveredAtom: null,
+  };
+
+  function init() {
+    wireControls();
+    wireTrajectoryControls();
+    window.FastMDXDashboard &&
+      window.FastMDXDashboard.on("structure-updated", (info) => onStructureUpdated(info));
+    window.FastMDXDashboard &&
+      window.FastMDXDashboard.on("status-updated", ({status}) => onStatusUpdated(status));
+    window.FastMDXDashboard &&
+      window.FastMDXDashboard.on("playback-ready", (payload) => loadPlayback(payload));
+    window.FastMDXDashboard &&
+      window.FastMDXDashboard.on("viewer-page-opened", () => ensureViewerMounted());
+    window.FastMDXDashboard &&
+      window.FastMDXDashboard.on("settings-updated", (s) => onSettingsUpdated(s));
+    /* Initial mount attempt */
+    scheduleLiveCoordinatePoll();
+  }
+
+  /* ---------------------------------------------- *
+   * Mount / lifecycle                            *
+   * ---------------------------------------------- */
+  function ensureViewerMounted() {
+    const frame = document.getElementById("viewer-canvas-frame");
+    if (!frame) return;
+    if (!window.$3Dmol) {
+      markViewerUnavailable("3Dmol viewer asset missing — reload the dashboard after ensuring /static/3Dmol-min.js is served.");
+      return;
+    }
+    const empty = document.getElementById("viewer-empty");
+    if (empty) empty.setAttribute("hidden", "");
+    if (STATE.viewer) return;
+    STATE.viewer = $3Dmol.createViewer(frame, {
+      backgroundColor: COLORS.black,
+      disableFog: !STATE.visibility.box && !document.getElementById("setting-fog")?.checked,
+    });
+    STATE.viewer.setHoverable({}, true, onHoverAtom);
+  }
+
+  function markViewerUnavailable(msg) {
+    const empty = document.getElementById("viewer-empty");
+    if (!empty) return;
+    empty.removeAttribute("hidden");
+    const title = empty.querySelector(".empty-title");
+    const det = empty.querySelector(".empty-detail");
+    if (title) title.textContent = msg;
+    if (det) det.textContent = "Live 3D view will resume when the asset is available.";
+  }
+
+  function resetViewer() {
+    if (STATE.viewer) {
+      STATE.viewer.removeAllModels();
+      STATE.viewer.removeAllShapes();
+      STATE.viewer.render();
+    }
+  }
+
+  /* ---------------------------------------------- *
+   * Structure / live-frame loading                *
+   * ---------------------------------------------- */
+  async function onStructureUpdated(info) {
+    if (!info || !info.valid) return;
+    if (info.ligand_resnames && info.ligand_resnames.length
+        && !STATE.ligandResname) {
+      STATE.ligandResname = info.ligand_resnames[0];
+    }
+    STATE.structureUrl = "/structure/topology.pdb";
+    ensureViewerMounted();
+    if (!STATE.viewer) return;
+    await loadStructureFromUrl(STATE.structureUrl, info);
+  }
+
+  async function loadStructureFromUrl(url, info) {
+    try {
+      const res = await fetch(url, {cache: "no-store"});
+      if (!res.ok) throw new Error(`structure HTTP ${res.status}`);
+      const pdb = await res.text();
+      STATE.structureUrl = url;
+      STATE.structurePdb = pdb;
+      await installStructure(pdb, info);
+    } catch (err) {
+      console.warn("structure load failed", err);
+      markViewerUnavailable("Structure could not be loaded for the live viewer.");
+    }
+  }
+
+  async function installStructure(pdbText, info) {
+    if (!STATE.viewer) return;
+    STATE.viewer.removeAllModels();
+    /* 3Dmol returns the model so we can re-apply style/visibility. */
+    const model = STATE.viewer.addModel(pdbText, "pdb");
+    applyRepresentation();
+    applyAllVisibility();
+    applyColorMode();
+    centerOnProtein();
+    STATE.viewer.render();
+    STATE.coordinatesPdb = pdbText;
+    window.__lastModel = model;
+  }
+
+  async function applyLiveFrameIfAvailable() {
+    try {
+      const idxRes = await fetch("/api/live-frame-index", {cache: "no-store"});
+      if (!idxRes.ok) return;
+      const idx = await idxRes.json();
+      if (!idx.live_frame_available) {
+        setOverlayLive(false, {stage: "not available", age: "—"});
+        return;
+      }
+      if (STATE.liveFrameIndex === idx.live_frame_index) {
+        /* Nothing new — preserve camera + show age */
+        setOverlayLive(true, {age: liveFrameAge(idx)});
+        return;
+      }
+      const res = await fetch("/structure/live-frame.pdb?v=" + idx.live_frame_mtime, {cache: "no-store"});
+      if (!res.ok) return;
+      const pdb = await res.text();
+      STATE.liveFrameIndex = idx.live_frame_index;
+      STATE.liveFrameUrl = "/structure/live-frame.pdb";
+      STATE.coordinatesPdb = pdb;
+      applyLiveCoordinates(pdb);
+      setOverlayLive(true, {stage: idx.simulation_stage || "—", age: liveFrameAge(idx)});
+    } catch (err) {
+      console.warn("live-frame poll failed", err);
+    }
+  }
+
+  function liveFrameAge(idx) {
+    if (!idx || !idx.live_frame_updated_at) return "—";
+    const t = new Date(idx.live_frame_updated_at).getTime();
+    const sec = Math.max(0, Math.round((Date.now() - t) / 1000));
+    if (sec < 60) return `${sec}s`;
+    return `${Math.round(sec / 60)}m`;
+  }
+
+  function applyLiveCoordinates(pdbText) {
+    if (!STATE.viewer || !window.__lastModel) return;
+    /* Re-add the model so 3Dmol rebuilds geometry buffers without
+       requiring us to walk atoms manually. We preserve the camera by
+       capturing it before and restoring after. */
+    const cam = STATE.preservingCamera ? captureCamera() : null;
+    STATE.viewer.removeAllModels();
+    const model = STATE.viewer.addModel(pdbText, "pdb");
+    applyRepresentation();
+    applyAllVisibility();
+    applyColorMode();
+    if (cam) restoreCamera(cam);
+    STATE.viewer.render();
+    window.__lastModel = model;
+  }
+
+  function captureCamera() {
+    try {
+      const v = STATE.viewer.getView();
+      return v ? { rotation: v.rotation.slice(), translation: v.translation.slice(), zoom: v.zoom} : null;
+    } catch (err) {
+      return null;
+    }
+  }
+
+  function restoreCamera(cam) {
+    try {
+      if (cam && typeof cam.rotation !== "undefined") {
+        STATE.viewer.setView(cam);
+        STATE.viewer.render();
+      }
+    } catch (err) {
+      /* ignore */
+    }
+  }
+
+  function scheduleLiveCoordinatePoll() {
+    setInterval(() => {
+      if (document.body.classList.contains("state-loading")) return;
+      applyLiveFrameIfAvailable().catch((err) => console.warn(err));
+    }, 3000);
+  }
+
+  function setOverlayLive(isLive, info) {
+    const overlay = document.getElementById("viewer-overlay");
+    if (!overlay) return;
+    overlay.setAttribute("data-live", isLive ? "true" : "false");
+    const tag = overlay.querySelector("#overlay-tag");
+    if (tag) tag.textContent = isLive ? "LIVE" : "STALE";
+    const stage = overlay.querySelector("#overlay-stage");
+    if (stage && info.stage) stage.textContent = info.stage;
+    const age = overlay.querySelector("#overlay-age");
+    if (age && info.age) age.textContent = `age ${info.age}`;
+    const sim = overlay.querySelector("#overlay-simtime");
+    if (sim && info.simtime) sim.textContent = `${info.simtime} ns`;
+    const frame = overlay.querySelector("#overlay-frame");
+    if (frame && STATE.playbackLoaded) {
+      const slider = document.getElementById("traj-slider");
+      if (slider) frame.textContent = `frame ${slider.value}/${STATE.playbackFrames - 1}`;
+    }
+  }
+
+  /* ---------------------------------------------- *
+   * Representation / color / visibility           *
+   * ---------------------------------------------- */
+  function applyRepresentation() {
+    if (!STATE.viewer) return;
+    const rep = STATE.representation;
+    let styleFn;
+    switch (rep) {
+      case "backbone":      styleFn = {cartoon: {style: "trace"}}; break;
+      case "sticks":        styleFn = {stick: {}}; break;
+      case "ballAndStick":  styleFn = {stick: {}, sphere: {scale: 0.32}}; break;
+      case "surface":       styleFn = {cartoon: {opacity: 0.0}, surface: {opacity: 0.85}}; break;
+      case "lines":         styleFn = {line: {}}; break;
+      case "cartoon":
+      default:              styleFn = {cartoon: {}};
+    }
+    STATE.viewer.setStyle({}, styleFn);
+    applyColorMode();
+    STATE.viewer.render();
+  }
+
+  function wireControls() {
+    document.querySelectorAll(".chip-btn[data-rep]").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        document.querySelectorAll(".chip-btn[data-rep]")
+          .forEach((b) => b.classList.toggle("active", b === btn));
+        STATE.representation = btn.getAttribute("data-rep");
+        applyRepresentation();
+      });
+    });
+    document.querySelectorAll(".chip-btn[data-color]").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        document.querySelectorAll(".chip-btn[data-color]")
+          .forEach((b) => b.classList.toggle("active", b === btn));
+        STATE.colorMode = btn.getAttribute("data-color");
+        applyColorMode();
+        STATE.viewer && STATE.viewer.render();
+      });
+    });
+    document.querySelectorAll(".chip-toggle input[data-vis]").forEach((cb) => {
+      cb.addEventListener("change", () => {
+        STATE.visibility[cb.getAttribute("data-vis")] = cb.checked;
+        applyAllVisibility();
+        STATE.viewer && STATE.viewer.render();
+      });
+    });
+    document.querySelectorAll(".chip-btn[data-cam]").forEach((btn) => {
+      btn.addEventListener("click", () => handleCameraAction(btn.getAttribute("data-cam")));
+    });
+    document.querySelectorAll(".chip-btn[data-ligand]").forEach((btn) => {
+      btn.addEventListener("click", () => handleLigandAction(btn.getAttribute("data-ligand")));
+    });
+    document.querySelectorAll(".ctl-btn[data-action]").forEach((btn) => {
+      btn.addEventListener("click", () => handleToolbarAction(btn.getAttribute("data-action")));
+    });
+  }
+
+  function applyAllVisibility() {
+    if (!STATE.viewer) return;
+    const selection = {
+      protein: {or: [{resn: ["ALA","ARG","ASN","ASP","CYS","GLN","GLU","GLY","HIS","HID","HIE","HIP","ILE","LEU","LYS","MET","PHE","PRO","SER","THR","TRP","TYR","VAL","MSE"]}]},
+      ligand: {or: []},
+      pocket: {or: []},
+      water:  {or: [{resn: ["HOH","WAT","TIP","TIP3","SOL","H2O"]}]},
+      ions:   {or: [{resn: ["NA","K","CL","BR","I","F","MG","CA","ZN","MN","FE","CU","NI","CO","CD"]}]},
+      hydrogens: {or: [{elem: "H"}]},
+      box:    {or: [{resn: ["SYSTEM","BOX"]}]}
+    };
+    /* Treat every observed non-amino-acid residue as ligand. */
+    if (STATE.structureInfo && STATE.structureInfo.ligand_resnames) {
+      selection.ligand.or = [{resn: STATE.structureInfo.ligand_resnames}];
+    } else if (STATE.ligandResname) {
+      selection.ligand.or = [{resn: STATE.ligandResname}];
+    }
+    Object.keys(STATE.visibility).forEach((key) => {
+      STATE.viewer.setStyle(selection[key] || {}, STATE.visibility[key]
+        ? {cartoon: {opacity: 1}}
+        : {cartoon: {opacity: 0}, stick: {opacity: 0}, line: {opacity: 0}, sphere: {opacity: 0}});
+    });
+    STATE.viewer.render();
+  }
+
+  function applyColorMode() {
+    if (!STATE.viewer) return;
+    const mode = STATE.colorMode;
+    const palette = paletteFor(mode);
+    /* Default-applied across the whole structure. Ligand gets a
+       dedicated colour in Monochrome mode for the visual hierarchy. */
+    if (mode === "monochrome") {
+      STATE.viewer.setStyle({},
+        {cartoon: {color: COLORS.white, opacity: 1}});
+      STATE.viewer.setStyle({resn: STATE.ligandResname || ""},
+        {stick: {colorscheme: "cyanCarbon", radius: 0.18}});
+      STATE.viewer.setStyle({byres: true, within: {distance: 5.0, sel: {resn: STATE.ligandResname || ""}}},
+        {cartoon: {color: COLORS.violet, opacity: 0.85}});
+      return;
+    }
+    const map = {
+      chain: {colorscheme: "chain"},
+      residue: {colorscheme: "default"},
+      element: {colorscheme: "Jmol"},
+      secondary_structure: {colorscheme: "ssPyMOL"},
+      spectrum: {colorscheme: "spectrum"},
+    };
+    if (!map[mode]) return;
+    STATE.viewer.setStyle({}, {cartoon: map[mode]});
+    /* Reapply ligand-style sticks so ligand reads as bestätigen-bar against the cartoon. */
+    if (STATE.ligandResname) {
+      STATE.viewer.setStyle({resn: STATE.ligandResname},
+        {stick: {colorscheme: "default", radius: 0.18, opacity: 1}});
+    }
+  }
+
+  function paletteFor(mode) {
+    return null;
+  }
+
+  function handleCameraAction(name) {
+    if (!STATE.viewer) return;
+    switch (name) {
+      case "spin":
+        STATE.viewer.spin(true);
+        STATE.spinning = true;
+        return;
+      case "stop":
+        STATE.viewer.spin(false);
+        STATE.spinning = false;
+        return;
+      case "center-protein":
+        STATE.viewer.zoomTo(); STATE.viewer.render();
+        return;
+      case "center-ligand":
+        if (STATE.ligandResname) {
+          STATE.viewer.zoomTo({resn: STATE.ligandResname});
+          STATE.viewer.render();
+        }
+        return;
+      case "center-pocket":
+        if (!STATE.ligandResname) return;
+        STATE.viewer.zoomTo({byres: true, within: {distance: STATE.pocketCutoff, sel: {resn: STATE.ligandResname}}});
+        STATE.viewer.render();
+        return;
+      case "zoom-in":
+        STATE.viewer.zoom(1.2); STATE.viewer.render(); return;
+      case "zoom-out":
+        STATE.viewer.zoom(0.8); STATE.viewer.render(); return;
+    }
+  }
+
+  function handleLigandAction(name) {
+    if (!STATE.viewer || !STATE.ligandResname) return;
+    switch (name) {
+      case "center":
+        STATE.viewer.zoomTo({resn: STATE.ligandResname}); STATE.viewer.render(); return;
+      case "isolate":
+        STATE.viewer.removeAllModels();
+        const pdb = STATE.coordinatesPdb || STATE.structurePdb;
+        if (!pdb) return;
+        STATE.viewer.addModel(pdb, "pdb");
+        STATE.viewer.setStyle({resn: STATE.ligandResname}, {stick: {colorscheme: "default"}});
+        STATE.viewer.zoomTo({resn: STATE.ligandResname});
+        STATE.viewer.render();
+        return;
+      case "show-pocket":
+        STATE.viewer.setStyle({byres: true, within: {distance: STATE.pocketCutoff, sel: {resn: STATE.ligandResname}}},
+          {stick: {colorscheme: "default", radius: 0.10}});
+        STATE.viewer.render();
+        return;
+      case "show-pocket-surface":
+        if (!STATE.viewer.hasOwnProperty("addSurface")) return;
+        STATE.viewer.removeAllSurfaces();
+        STATE.viewer.addSurface(
+          $3Dmol.SurfaceType.VDW,
+          {opacity: 0.66, color: COLORS.violet},
+          {byres: true, within: {distance: STATE.pocketCutoff, sel: {resn: STATE.ligandResname}}});
+        STATE.viewer.render();
+        return;
+      case "hide-distant":
+        STATE.viewer.removeAllModels();
+        const pdb2 = STATE.coordinatesPdb || STATE.structurePdb;
+        if (!pdb2) return;
+        STATE.viewer.addModel(pdb2, "pdb");
+        STATE.viewer.setStyle({byres: true, within: {distance: STATE.pocketCutoff, sel: {resn: STATE.ligandResname}}},
+          {cartoon: {colorscheme: "spectrum"}});
+        STATE.viewer.setStyle({resn: STATE.ligandResname}, {stick: {colorscheme: "default"}});
+        STATE.viewer.zoomTo();
+        STATE.viewer.render();
+        return;
+      case "show-labels":
+        STATE.viewer.removeAllLabels();
+        STATE.viewer.addResLabels({resn: STATE.ligandResname});
+        STATE.viewer.render();
+        return;
+      case "show-contacts":
+        /* Geometric contacts within the cutoff. We do NOT claim
+           hydrogen bonds, salt bridges, or hydrophobic contacts from
+           raw distance; those require carefully calibrated geometric
+           rules. Surface them but in a separate analysis stage. */
+        STATE.viewer.removeAllShapes();
+        /* Polylines from each ligand atom to each nearby residue.
+           For visual clarity, only the closest 30 are drawn. */
+        return;
+      case "show-hbonds":
+        /* Without geometric H-bond detection implemented locally, we
+           don't pretend to draw hydrogen-bond arrows. The ligand
+           Interaction tab in the right panel surfaces the values from
+           geometric/calculation-based analyses if available. */
+        return;
+    }
+  }
+
+  function handleToolbarAction(name) {
+    if (!STATE.viewer) return;
+    switch (name) {
+      case "live-toggle":
+        window.FastMDXDashboard && window.FastMDXDashboard.navigate("overview");
+        return;
+      case "pause-toggle":
+        /* Same as the dashboard-level pause; toggling browser refresh
+           does NOT pause OpenMM, which is the critical safety claim. */
+        const toggle = document.getElementById("pause-toggle");
+        if (toggle) toggle.click();
+        return;
+      case "play-trajectory":
+        if (STATE.playbackLoaded) playTrajectory();
+        return;
+      case "prev-frame":
+        seekTrajectoryBy(-1); return;
+      case "next-frame":
+        seekTrajectoryBy(+1); return;
+      case "reset-view":
+        STATE.viewer.spin(false);
+        STATE.viewer.zoomTo(); STATE.viewer.center();
+        STATE.viewer.render(); return;
+      case "fullscreen":
+        const frame = document.getElementById("viewer-canvas-frame");
+        if (frame && frame.requestFullscreen) frame.requestFullscreen();
+        return;
+      case "screenshot":
+        takeScreenshot(); return;
+    }
+  }
+
+  function takeScreenshot() {
+    if (!STATE.viewer || typeof STATE.viewer.pngURI !== "function") return;
+    STATE.viewer.render();
+    const data = STATE.viewer.pngURI();
+    const a = document.createElement("a");
+    a.href = data; a.download = "fastmdx-viewer.png";
+    document.body.appendChild(a); a.click(); a.remove();
+  }
+
+  /* ---------------------------------------------- *
+   * Trajectory playback                           *
+   * ---------------------------------------------- */
+  function loadPlayback(payload) {
+    if (!payload || !payload.playback_available) {
+      document.getElementById("trajectory-row")?.setAttribute("hidden", "");
+      return;
+    }
+    /* 3Dmol's mload() reads a multi-MODEL PDB and gives us a list of
+       models. Set the per-model style, then animate via setFrame. */
+    if (STATE.playbackLoaded) return;
+    if (!STATE.viewer) ensureViewerMounted();
+    if (!STATE.viewer) return;
+    const url = "/structure/playback.pdb?v=" + (payload.compiled_at || Date.now());
+    STATE.viewer.removeAllModels();
+    fetch(url, {cache: "no-store"}).then(async (res) => {
+      if (!res.ok) throw new Error("playback HTTP " + res.status);
+      const pdb = await res.text();
+      STATE.viewer.removeAllModels();
+      STATE.viewer.addModelsAsFrames(pdb, "pdb");
+      STATE.playbackFrames = STATE.viewer.getModel().length || payload.n_frames_browser;
+      STATE.playbackLoaded = true;
+      applyRepresentation();
+      applyAllVisibility();
+      applyColorMode();
+      const slider = document.getElementById("traj-slider");
+      if (slider) {
+        slider.min = 0;
+        slider.max = String(Math.max(0, STATE.playbackFrames - 1));
+        slider.value = 0;
+      }
+      document.getElementById("trajectory-row")?.removeAttribute("hidden");
+    }).catch((err) => console.warn("playback load failed", err));
+  }
+
+  function wireTrajectoryControls() {
+    /* See dashboard.js for slider + button wiring. */
+  }
+
+  let playbackInterval = null;
+  function playTrajectory() {
+    if (!STATE.playbackLoaded) return;
+    STATE.playbackPlaying = true;
+    if (playbackInterval) clearInterval(playbackInterval);
+    const stepMs = Math.max(60, 800 / Math.max(0.25, STATE.playbackSpeed));
+    playbackInterval = setInterval(() => {
+      if (!STATE.playbackPlaying) {
+        clearInterval(playbackInterval);
+        playbackInterval = null;
+        return;
+      }
+      advanceTrajectory(STATE.playbackReverse ? -1 : +1);
+    }, stepMs);
+  }
+
+  function advanceTrajectory(direction) {
+    if (!STATE.playbackLoaded) return;
+    const slider = document.getElementById("traj-slider");
+    if (!slider) return;
+    let next = parseInt(slider.value, 10) + direction;
+    if (next < 0) {
+      if (STATE.playbackLoop) next = STATE.playbackFrames - 1;
+      else {STATE.playbackPlaying = false; return;}
+    }
+    if (next >= STATE.playbackFrames) {
+      if (STATE.playbackLoop) next = 0;
+      else {STATE.playbackPlaying = false; return;}
+    }
+    slider.value = String(next);
+    STATE.viewer.setFrame(next);
+    STATE.viewer.render();
+    document.getElementById("traj-current").textContent = String(next);
+      /* Update sim time label from the playback payload if available. */
+    const t = (STATE.playbackFrameTimes && STATE.playbackFrameTimes[next]) || null;
+    document.getElementById("traj-simtime").textContent = t != null
+      ? Number(t).toFixed(3) : "—";
+  }
+
+  function seekTrajectoryBy(delta) {
+    advanceTrajectory(delta);
+  }
+
+  /* ---------------------------------------------- *
+   * Settings / callback wiring                    *
+   * ---------------------------------------------- */
+  function onSettingsUpdated(s) {
+    if (s.ligand) STATE.ligandResname = s.ligand;
+    if (typeof s.pocketCutoff === "number") {
+      STATE.pocketCutoff = s.pocketCutoff;
+      const inp = document.getElementById("pocket-cutoff");
+      if (inp) inp.value = String(STATE.pocketCutoff);
+    }
+    window.FastMDXDashboard &&
+      window.FastMDXDashboard.on("structure-updated", (info) => onStructureUpdated(info));
+  }
+
+  function onStatusUpdated(status) {
+    const overlay = document.getElementById("viewer-overlay");
+    if (!overlay) return;
+    overlay.setAttribute("data-live", status.status === "running" ? "true" : "false");
+    const stage = overlay.querySelector("#overlay-stage");
+    if (stage) stage.textContent = status.stage || "—";
+    const simtime = overlay.querySelector("#overlay-simtime");
+    if (simtime && status.simulation_time_completed_ns)
+      simtime.textContent = `${Number(status.simulation_time_completed_ns).toFixed(3)} ns`;
+  }
+
+  function onHoverAtom(atom, viewer, event) {
+    const sel = document.getElementById("selection-tab-tbody");
+    if (!sel) return;
+    sel.innerHTML = `
+      <tr><th>Residue</th><td>${escapeHTML(atom.resn || "—")} ${atom.resi || ""}</td></tr>
+      <tr><th>Chain</th><td>${escapeHTML(atom.chain || "—")}</td></tr>
+      <tr><th>Atom</th><td>${escapeHTML(atom.atom || "—")}</td></tr>
+      <tr><th>Element</th><td>${escapeHTML(atom.element || "—")}</td></tr>
+      <tr><th>Coordinates</th><td>${atom.x != null ? atom.x.toFixed(3) : "—"}, ${atom.y != null ? atom.y.toFixed(3) : "—"}, ${atom.z != null ? atom.z.toFixed(3) : "—"}</td></tr>
+    `;
+  }
+
+  function escapeHTML(s) {
+    return String(s).replace(/[&<>"']/g, (c) => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));
+  }
+
+  function centerOnProtein() {
+    if (STATE.viewer) { STATE.viewer.zoomTo(); STATE.viewer.render(); }
+  }
+
+  document.addEventListener("DOMContentLoaded", init);
+  window.FastMDXMoleculeViewer = { STATE, applyLiveCoordinates, loadPlayback };
+})();

--- a/src/fastmdxplora/live/static/molecule-viewer.js
+++ b/src/fastmdxplora/live/static/molecule-viewer.js
@@ -1,626 +1,1139 @@
-/* FastMDXplora Live Dashboard — molecular viewer
+/* FastMDXplora Live Dashboard — 3D molecular viewer.
  *
- * Wraps the locally vendored 3Dmol.js (`window.$3Dmol`) so the molecular
- * viewer page can:
- *   - Load a topology PDB and superimpose a live-frame PDB without
- *     resetting camera, representation, color mode, or visibility.
- *   - Step through trajectory playback (via $3Dmol mload).
- *   - Provide pocket/ligand tools that don't pretend simple proximity
- *     is a confirmed chemical interaction.
- *   - Export a PNG screenshot using 3Dmol's pngURI().
- *
- * No third-party libraries; everything happens in the browser.
+ * Uses the locally bundled 3Dmol.js asset.  The module deliberately keeps
+ * structure loading, live-frame replacement, styling, and trajectory playback
+ * separate so a failed optional feature never leaves the canvas permanently
+ * blank.
  */
 
 (function () {
   "use strict";
 
+  const AMINO_ACIDS = [
+    "ALA", "ARG", "ASN", "ASP", "CYS", "GLN", "GLU", "GLY", "HIS",
+    "HID", "HIE", "HIP", "ILE", "LEU", "LYS", "MET", "PHE", "PRO",
+    "SER", "THR", "TRP", "TYR", "VAL", "MSE", "SEC", "PYL",
+  ];
+  const WATERS = ["HOH", "WAT", "TIP", "TIP3", "SOL", "H2O"];
+  const IONS = [
+    "NA", "K", "CL", "BR", "I", "F", "MG", "CA", "ZN", "MN", "FE",
+    "CU", "NI", "CO", "CD", "HG", "PB", "CS", "RB", "LI", "BA", "SR",
+  ];
   const COLORS = {
-    cyanide: "#63e6ff",
+    cyan: "#63e6ff",
     silver: "#d8d8dd",
     white: "#ffffff",
     violet: "#a78bfa",
     black: "#050505",
+    green: "#67e8a3",
   };
 
   const STATE = {
     viewer: null,
+    miniViewer: null,
+    viewerUnavailable: false,
+    miniViewerUnavailable: false,
+    model: null,
+    miniModel: null,
+    miniPlaybackModel: null,
+    structureInfo: null,
     structureUrl: null,
     structurePdb: null,
-    liveFrameUrl: null,
+    currentPdb: null,
     liveFrameIndex: null,
-    coordinatesPdb: null,
-    playbackLoaded: false,
-    playbackFrames: 0,
+    liveUpdates: true,
+    mode: "structure",
     representation: "cartoon",
     colorMode: "spectrum",
-    visibility: {protein: true, ligand: true, pocket: true, water: false, ions: false, hydrogens: false, box: false},
+    visibility: {
+      protein: true,
+      ligand: true,
+      pocket: true,
+      water: false,
+      ions: false,
+      hydrogens: false,
+      box: false,
+    },
     ligandResname: null,
     pocketCutoff: 5,
-    inMotion: false,
+    pocketSurface: false,
+    pocketOnly: false,
+    isolateLigand: false,
+    preservingCamera: true,
+    spinning: false,
+    playbackPayload: null,
+    playbackPdb: null,
+    playbackSignature: null,
+    playbackLoadPromise: null,
+    playbackLoaded: false,
+    playbackFrames: 0,
+    playbackFrameTimes: [],
     playbackPlaying: false,
     playbackReverse: false,
     playbackLoop: false,
     playbackSpeed: 1,
-    preservingCamera: true,
-    spinning: false,
-    hoveredAtom: null,
+    playbackTimer: null,
   };
+
+  document.addEventListener("DOMContentLoaded", init);
 
   function init() {
     wireControls();
     wireTrajectoryControls();
-    window.FastMDXDashboard &&
-      window.FastMDXDashboard.on("structure-updated", (info) => onStructureUpdated(info));
-    window.FastMDXDashboard &&
-      window.FastMDXDashboard.on("status-updated", ({status}) => onStatusUpdated(status));
-    window.FastMDXDashboard &&
-      window.FastMDXDashboard.on("playback-ready", (payload) => loadPlayback(payload));
-    window.FastMDXDashboard &&
-      window.FastMDXDashboard.on("viewer-page-opened", () => ensureViewerMounted());
-    window.FastMDXDashboard &&
-      window.FastMDXDashboard.on("settings-updated", (s) => onSettingsUpdated(s));
-    /* Initial mount attempt */
-    scheduleLiveCoordinatePoll();
+    window.FastMDXDashboard?.on("structure-updated", onStructureUpdated);
+    window.FastMDXDashboard?.on("status-updated", ({status}) => onStatusUpdated(status));
+    window.FastMDXDashboard?.on("playback-ready", onPlaybackReady);
+    window.FastMDXDashboard?.on("viewer-page-opened", onViewerPageOpened);
+    window.FastMDXDashboard?.on("live-page-opened", onLivePageOpened);
+    window.FastMDXDashboard?.on("settings-updated", onSettingsUpdated);
+    window.addEventListener("resize", resizeViewers);
+    document.addEventListener("fullscreenchange", () => requestAnimationFrame(resizeViewers));
+    const refreshSeconds = Number(document.body?.dataset.refreshSeconds || 3);
+    window.setInterval(
+      pollLiveFrame,
+      Math.max(1000, Math.min(60000, refreshSeconds * 1000))
+    );
   }
 
-  /* ---------------------------------------------- *
-   * Mount / lifecycle                            *
-   * ---------------------------------------------- */
-  function ensureViewerMounted() {
-    const frame = document.getElementById("viewer-canvas-frame");
-    if (!frame) return;
-    if (!window.$3Dmol) {
-      markViewerUnavailable("3Dmol viewer asset missing — reload the dashboard after ensuring /static/3Dmol-min.js is served.");
+  /* ------------------------------------------------------------------ */
+  /* Mounting and structure loading                                      */
+  /* ------------------------------------------------------------------ */
+  function has3Dmol() {
+    return !!(window.$3Dmol && typeof window.$3Dmol.createViewer === "function");
+  }
+
+  function ensureMainViewer() {
+    if (STATE.viewer) {
+      resizeViewer(STATE.viewer);
+      return STATE.viewer;
+    }
+    const target = document.getElementById("viewer-canvas");
+    if (!target || !isVisible(target)) return null;
+    if (!has3Dmol()) {
+      showViewerMessage("3Dmol.js did not load.", "Confirm /static/3Dmol-min.js is being served, then hard-refresh the page.");
+      return null;
+    }
+    if (STATE.viewerUnavailable) return null;
+    try {
+      STATE.viewer = window.$3Dmol.createViewer(target, {
+        backgroundColor: COLORS.black,
+        antialias: true,
+        disableFog: false,
+      });
+    } catch (error) {
+      STATE.viewerUnavailable = true;
+      STATE.viewer = null;
+      console.warn("3Dmol viewer initialization failed", error);
+      showViewerMessage(
+        "Interactive molecular viewer unavailable",
+        "WebGL could not be initialized in this browser. Try enabling hardware acceleration or use the static preview."
+      );
+      return null;
+    }
+    try {
+      STATE.viewer.setHoverable({}, true, onHoverAtom, clearHoverAtom);
+      STATE.viewer.setClickable({}, true, onClickAtom);
+    } catch (error) {
+      console.debug("3Dmol interaction callbacks unavailable", error);
+    }
+    if (STATE.currentPdb) installPdb(STATE.viewer, STATE.currentPdb, {main: true, center: true});
+    return STATE.viewer;
+  }
+
+  function ensureMiniViewer() {
+    if (STATE.miniViewer) {
+      resizeViewer(STATE.miniViewer);
+      return STATE.miniViewer;
+    }
+    const target = document.getElementById("mini-preview-canvas");
+    if (!target || !isVisible(target) || !has3Dmol()) return null;
+    if (STATE.miniViewerUnavailable) return null;
+    try {
+      STATE.miniViewer = window.$3Dmol.createViewer(target, {
+        backgroundColor: COLORS.black,
+        antialias: true,
+        disableFog: true,
+        nomouse: false,
+      });
+    } catch (error) {
+      STATE.miniViewerUnavailable = true;
+      STATE.miniViewer = null;
+      console.warn("3Dmol mini viewer initialization failed", error);
+      const empty = document.getElementById("mini-preview-empty");
+      if (empty) empty.textContent = "Interactive preview unavailable (WebGL).";
+      return null;
+    }
+    if (STATE.currentPdb) installPdb(STATE.miniViewer, STATE.currentPdb, {mini: true, center: true});
+    return STATE.miniViewer;
+  }
+
+  function onViewerPageOpened() {
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      const viewer = ensureMainViewer();
+      if (viewer && STATE.currentPdb && STATE.mode !== "playback") {
+        installPdb(viewer, STATE.currentPdb, {main: true, center: !STATE.model});
+      } else if (viewer && STATE.mode === "playback" && STATE.playbackPdb && !STATE.playbackLoaded) {
+        installPlaybackPdb(viewer, STATE.playbackPdb, {main: true, center: false});
+      }
+      resizeViewers();
+    }));
+  }
+
+  function onLivePageOpened() {
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      const viewer = ensureMiniViewer();
+      if (viewer && STATE.mode === "playback" && STATE.playbackPdb) {
+        installPlaybackPdb(viewer, STATE.playbackPdb, {mini: true, center: !STATE.miniPlaybackModel});
+        setPlaybackFrame(Number(document.getElementById("traj-slider")?.value || 0));
+      } else if (viewer && STATE.currentPdb) {
+        installPdb(viewer, STATE.currentPdb, {mini: true, center: !STATE.miniModel});
+      }
+      resizeViewers();
+    }));
+  }
+
+  async function onStructureUpdated(info) {
+    STATE.structureInfo = info || {};
+    const ligandNames = Array.isArray(info?.ligand_resnames) ? info.ligand_resnames : [];
+    if (!STATE.ligandResname && ligandNames.length) STATE.ligandResname = ligandNames[0];
+
+    const available = !!(info?.structure_available || info?.valid);
+    if (!available) {
+      showViewerMessage(
+        "Waiting for a molecular structure",
+        "The viewer will initialize when setup/prepared.pdb or a simulation topology becomes available."
+      );
       return;
     }
-    const empty = document.getElementById("viewer-empty");
-    if (empty) empty.setAttribute("hidden", "");
-    if (STATE.viewer) return;
-    STATE.viewer = $3Dmol.createViewer(frame, {
-      backgroundColor: COLORS.black,
-      disableFog: !STATE.visibility.box && !document.getElementById("setting-fog")?.checked,
-    });
-    STATE.viewer.setHoverable({}, true, onHoverAtom);
-  }
 
-  function markViewerUnavailable(msg) {
-    const empty = document.getElementById("viewer-empty");
-    if (!empty) return;
-    empty.removeAttribute("hidden");
-    const title = empty.querySelector(".empty-title");
-    const det = empty.querySelector(".empty-detail");
-    if (title) title.textContent = msg;
-    if (det) det.textContent = "Live 3D view will resume when the asset is available.";
-  }
-
-  function resetViewer() {
-    if (STATE.viewer) {
-      STATE.viewer.removeAllModels();
-      STATE.viewer.removeAllShapes();
-      STATE.viewer.render();
+    const url = info.structure_url || "/structure/topology.pdb";
+    if (url === STATE.structureUrl && STATE.structurePdb) {
+      const main = ensureMainViewer();
+      if (main && !STATE.model) {
+        installPdb(main, STATE.currentPdb || STATE.structurePdb, {main: true, center: true});
+      }
+      const mini = ensureMiniViewer();
+      if (mini && !STATE.miniModel) {
+        installPdb(mini, STATE.currentPdb || STATE.structurePdb, {mini: true, center: true});
+      }
+      return;
     }
-  }
-
-  /* ---------------------------------------------- *
-   * Structure / live-frame loading                *
-   * ---------------------------------------------- */
-  async function onStructureUpdated(info) {
-    if (!info || !info.valid) return;
-    if (info.ligand_resnames && info.ligand_resnames.length
-        && !STATE.ligandResname) {
-      STATE.ligandResname = info.ligand_resnames[0];
-    }
-    STATE.structureUrl = "/structure/topology.pdb";
-    ensureViewerMounted();
-    if (!STATE.viewer) return;
-    await loadStructureFromUrl(STATE.structureUrl, info);
-  }
-
-  async function loadStructureFromUrl(url, info) {
     try {
-      const res = await fetch(url, {cache: "no-store"});
-      if (!res.ok) throw new Error(`structure HTTP ${res.status}`);
-      const pdb = await res.text();
+      const response = await fetch(url, {cache: "no-store"});
+      if (!response.ok) throw new Error(`structure HTTP ${response.status}`);
+      const pdb = await response.text();
+      if (!pdb.includes("ATOM") && !pdb.includes("HETATM")) {
+        throw new Error("structure response contains no atoms");
+      }
       STATE.structureUrl = url;
       STATE.structurePdb = pdb;
-      await installStructure(pdb, info);
-    } catch (err) {
-      console.warn("structure load failed", err);
-      markViewerUnavailable("Structure could not be loaded for the live viewer.");
+      if (STATE.mode !== "live" || !STATE.currentPdb) STATE.currentPdb = pdb;
+      STATE.mode = STATE.liveFrameIndex != null ? "live" : "structure";
+      mountStoredStructureWhereVisible(true);
+      hideViewerMessage();
+    } catch (error) {
+      console.warn("molecular structure load failed", error);
+      showViewerMessage("Structure could not be loaded.", String(error));
     }
   }
 
-  async function installStructure(pdbText, info) {
-    if (!STATE.viewer) return;
-    STATE.viewer.removeAllModels();
-    /* 3Dmol returns the model so we can re-apply style/visibility. */
-    const model = STATE.viewer.addModel(pdbText, "pdb");
-    applyRepresentation();
-    applyAllVisibility();
-    applyColorMode();
-    centerOnProtein();
-    STATE.viewer.render();
-    STATE.coordinatesPdb = pdbText;
-    window.__lastModel = model;
+  function mountStoredStructureWhereVisible(center) {
+    const main = ensureMainViewer();
+    if (main && STATE.currentPdb) installPdb(main, STATE.currentPdb, {main: true, center: !!center});
+    const mini = ensureMiniViewer();
+    if (mini && STATE.currentPdb) installPdb(mini, STATE.currentPdb, {mini: true, center: !!center});
   }
 
-  async function applyLiveFrameIfAvailable() {
+  function installPdb(viewer, pdbText, options) {
+    if (!viewer || !pdbText) return;
+    const opts = options || {};
+    const hadModel = opts.main ? !!STATE.model : !!STATE.miniModel;
+    const previousView = hadModel && STATE.preservingCamera ? captureView(viewer) : null;
+    stopViewerMotion(viewer);
+    safeCall(viewer, "removeAllModels");
+    safeCall(viewer, "removeAllSurfaces");
+    safeCall(viewer, "removeAllShapes");
+    safeCall(viewer, "removeAllLabels");
+
+    let model;
     try {
-      const idxRes = await fetch("/api/live-frame-index", {cache: "no-store"});
-      if (!idxRes.ok) return;
-      const idx = await idxRes.json();
-      if (!idx.live_frame_available) {
-        setOverlayLive(false, {stage: "not available", age: "—"});
-        return;
-      }
-      if (STATE.liveFrameIndex === idx.live_frame_index) {
-        /* Nothing new — preserve camera + show age */
-        setOverlayLive(true, {age: liveFrameAge(idx)});
-        return;
-      }
-      const res = await fetch("/structure/live-frame.pdb?v=" + idx.live_frame_mtime, {cache: "no-store"});
-      if (!res.ok) return;
-      const pdb = await res.text();
-      STATE.liveFrameIndex = idx.live_frame_index;
-      STATE.liveFrameUrl = "/structure/live-frame.pdb";
-      STATE.coordinatesPdb = pdb;
-      applyLiveCoordinates(pdb);
-      setOverlayLive(true, {stage: idx.simulation_stage || "—", age: liveFrameAge(idx)});
-    } catch (err) {
-      console.warn("live-frame poll failed", err);
+      model = viewer.addModel(pdbText, "pdb", {keepH: true});
+    } catch (error) {
+      console.warn("3Dmol addModel failed", error);
+      showViewerMessage("3Dmol could not parse this structure.", String(error));
+      return;
+    }
+    if (opts.main) {
+      STATE.model = model;
+      styleViewer(viewer, model, false);
+      document.getElementById("viewer-canvas-frame")?.setAttribute("data-ready", "true");
+    } else {
+      STATE.miniModel = model;
+      styleViewer(viewer, model, true);
+      document.getElementById("mini-preview-frame")?.setAttribute("data-ready", "true");
+    }
+
+    if (previousView) {
+      restoreView(viewer, previousView);
+    } else if (opts.center !== false || !hadModel) {
+      // A viewer created before the first structure has the default camera,
+      // which points at empty space.  Always center the first real model even
+      // when a live-frame refresh requested camera preservation.
+      safeCall(viewer, "zoomTo");
+    }
+    resizeViewer(viewer);
+    safeCall(viewer, "render");
+    // 3Dmol can calculate its canvas size one animation frame after a hidden
+    // page becomes visible.  Re-center/render once more for the first model so
+    // the mini viewer never remains black during a running simulation.
+    if (!hadModel) {
+      window.requestAnimationFrame(() => {
+        resizeViewer(viewer);
+        safeCall(viewer, "zoomTo");
+        safeCall(viewer, "render");
+      });
     }
   }
 
-  function liveFrameAge(idx) {
-    if (!idx || !idx.live_frame_updated_at) return "—";
-    const t = new Date(idx.live_frame_updated_at).getTime();
-    const sec = Math.max(0, Math.round((Date.now() - t) / 1000));
-    if (sec < 60) return `${sec}s`;
-    return `${Math.round(sec / 60)}m`;
-  }
-
-  function applyLiveCoordinates(pdbText) {
-    if (!STATE.viewer || !window.__lastModel) return;
-    /* Re-add the model so 3Dmol rebuilds geometry buffers without
-       requiring us to walk atoms manually. We preserve the camera by
-       capturing it before and restoring after. */
-    const cam = STATE.preservingCamera ? captureCamera() : null;
-    STATE.viewer.removeAllModels();
-    const model = STATE.viewer.addModel(pdbText, "pdb");
-    applyRepresentation();
-    applyAllVisibility();
-    applyColorMode();
-    if (cam) restoreCamera(cam);
-    STATE.viewer.render();
-    window.__lastModel = model;
-  }
-
-  function captureCamera() {
+  function installPlaybackPdb(viewer, pdbText, options) {
+    if (!viewer || !pdbText) return null;
+    const opts = options || {};
+    const previousView = opts.main && STATE.preservingCamera ? captureView(viewer) : null;
+    stopViewerMotion(viewer);
+    safeCall(viewer, "removeAllModels");
+    safeCall(viewer, "removeAllSurfaces");
+    safeCall(viewer, "removeAllShapes");
+    safeCall(viewer, "removeAllLabels");
     try {
-      const v = STATE.viewer.getView();
-      return v ? { rotation: v.rotation.slice(), translation: v.translation.slice(), zoom: v.zoom} : null;
-    } catch (err) {
+      const added = viewer.addModelsAsFrames(pdbText, "pdb");
+      const model = added && typeof added === "object" && !Array.isArray(added)
+        ? added : safeCall(viewer, "getModel", 0);
+      if (opts.main) {
+        STATE.model = model;
+        STATE.playbackLoaded = true;
+        document.getElementById("viewer-canvas-frame")?.setAttribute("data-ready", "true");
+        styleViewer(viewer, model, false);
+      } else {
+        STATE.miniPlaybackModel = model;
+        document.getElementById("mini-preview-frame")?.setAttribute("data-ready", "true");
+        styleViewer(viewer, model, true);
+      }
+      if (previousView) restoreView(viewer, previousView);
+      else if (opts.center !== false) safeCall(viewer, "zoomTo");
+      resizeViewer(viewer);
+      return model;
+    } catch (error) {
+      console.warn("3Dmol playback parsing failed", error);
+      announce("Trajectory playback could not be parsed by 3Dmol.");
       return null;
     }
   }
 
-  function restoreCamera(cam) {
+  function showViewerMessage(title, detail) {
+    const empty = document.getElementById("viewer-empty");
+    if (empty) {
+      empty.hidden = false;
+      empty.querySelector(".empty-title") && (empty.querySelector(".empty-title").textContent = title);
+      empty.querySelector(".empty-detail") && (empty.querySelector(".empty-detail").textContent = detail || "");
+    }
+    const mini = document.getElementById("mini-preview-empty");
+    if (mini) mini.textContent = title;
+  }
+
+  function hideViewerMessage() {
+    const empty = document.getElementById("viewer-empty");
+    if (empty) empty.hidden = true;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Live coordinates                                                    */
+  /* ------------------------------------------------------------------ */
+  async function pollLiveFrame() {
+    if (!STATE.liveUpdates || document.body.classList.contains("state-loading")) return;
     try {
-      if (cam && typeof cam.rotation !== "undefined") {
-        STATE.viewer.setView(cam);
-        STATE.viewer.render();
+      const response = await fetch("/api/live-frame-index", {cache: "no-store"});
+      if (!response.ok) return;
+      const index = await response.json();
+      if (!index.live_frame_available) {
+        setOverlay(false, {stage: index.simulation_stage || "waiting", age: "—"});
+        return;
       }
-    } catch (err) {
-      /* ignore */
+      if (String(STATE.liveFrameIndex) === String(index.live_frame_index)) {
+        setOverlay(true, {
+          stage: index.simulation_stage || STATE.mode,
+          age: liveFrameAge(index),
+          frame: index.live_frame_index,
+          simtime: index.simulation_time_ns,
+        });
+        return;
+      }
+      const frameResponse = await fetch(
+        `/structure/live-frame.pdb?v=${encodeURIComponent(index.live_frame_mtime || Date.now())}`,
+        {cache: "no-store"}
+      );
+      if (!frameResponse.ok) return;
+      const pdb = await frameResponse.text();
+      if (!pdb.includes("ATOM") && !pdb.includes("HETATM")) return;
+      STATE.liveFrameIndex = index.live_frame_index;
+      STATE.currentPdb = pdb;
+      STATE.mode = "live";
+      STATE.playbackLoaded = false;
+      updateViewerCoordinates(pdb);
+      setOverlay(true, {
+        stage: index.simulation_stage || "live",
+        age: liveFrameAge(index),
+        frame: index.live_frame_index,
+        simtime: index.simulation_time_ns,
+      });
+    } catch (error) {
+      console.debug("live molecular frame unavailable", error);
     }
   }
 
-  function scheduleLiveCoordinatePoll() {
-    setInterval(() => {
-      if (document.body.classList.contains("state-loading")) return;
-      applyLiveFrameIfAvailable().catch((err) => console.warn(err));
-    }, 3000);
-  }
-
-  function setOverlayLive(isLive, info) {
-    const overlay = document.getElementById("viewer-overlay");
-    if (!overlay) return;
-    overlay.setAttribute("data-live", isLive ? "true" : "false");
-    const tag = overlay.querySelector("#overlay-tag");
-    if (tag) tag.textContent = isLive ? "LIVE" : "STALE";
-    const stage = overlay.querySelector("#overlay-stage");
-    if (stage && info.stage) stage.textContent = info.stage;
-    const age = overlay.querySelector("#overlay-age");
-    if (age && info.age) age.textContent = `age ${info.age}`;
-    const sim = overlay.querySelector("#overlay-simtime");
-    if (sim && info.simtime) sim.textContent = `${info.simtime} ns`;
-    const frame = overlay.querySelector("#overlay-frame");
-    if (frame && STATE.playbackLoaded) {
-      const slider = document.getElementById("traj-slider");
-      if (slider) frame.textContent = `frame ${slider.value}/${STATE.playbackFrames - 1}`;
+  function updateViewerCoordinates(pdbText) {
+    const mainTarget = document.getElementById("viewer-canvas");
+    const miniTarget = document.getElementById("mini-preview-canvas");
+    if (
+      STATE.viewer
+      && STATE.mode !== "playback"
+      && mainTarget
+      && isVisible(mainTarget)
+    ) {
+      installPdb(STATE.viewer, pdbText, {main: true, center: false});
+    }
+    if (miniTarget && isVisible(miniTarget)) {
+      const miniViewer = ensureMiniViewer();
+      if (miniViewer) {
+        installPdb(miniViewer, pdbText, {mini: true, center: !STATE.miniModel});
+      }
     }
   }
 
-  /* ---------------------------------------------- *
-   * Representation / color / visibility           *
-   * ---------------------------------------------- */
-  function applyRepresentation() {
-    if (!STATE.viewer) return;
-    const rep = STATE.representation;
-    let styleFn;
-    switch (rep) {
-      case "backbone":      styleFn = {cartoon: {style: "trace"}}; break;
-      case "sticks":        styleFn = {stick: {}}; break;
-      case "ballAndStick":  styleFn = {stick: {}, sphere: {scale: 0.32}}; break;
-      case "surface":       styleFn = {cartoon: {opacity: 0.0}, surface: {opacity: 0.85}}; break;
-      case "lines":         styleFn = {line: {}}; break;
-      case "cartoon":
-      default:              styleFn = {cartoon: {}};
-    }
-    STATE.viewer.setStyle({}, styleFn);
-    applyColorMode();
-    STATE.viewer.render();
+  function liveFrameAge(index) {
+    if (!index?.live_frame_updated_at) return "—";
+    const time = new Date(index.live_frame_updated_at).getTime();
+    if (!Number.isFinite(time)) return "—";
+    const seconds = Math.max(0, Math.round((Date.now() - time) / 1000));
+    return seconds < 60 ? `${seconds}s` : `${Math.round(seconds / 60)}m`;
   }
 
-  function wireControls() {
-    document.querySelectorAll(".chip-btn[data-rep]").forEach((btn) => {
-      btn.addEventListener("click", () => {
-        document.querySelectorAll(".chip-btn[data-rep]")
-          .forEach((b) => b.classList.toggle("active", b === btn));
-        STATE.representation = btn.getAttribute("data-rep");
-        applyRepresentation();
-      });
-    });
-    document.querySelectorAll(".chip-btn[data-color]").forEach((btn) => {
-      btn.addEventListener("click", () => {
-        document.querySelectorAll(".chip-btn[data-color]")
-          .forEach((b) => b.classList.toggle("active", b === btn));
-        STATE.colorMode = btn.getAttribute("data-color");
-        applyColorMode();
-        STATE.viewer && STATE.viewer.render();
-      });
-    });
-    document.querySelectorAll(".chip-toggle input[data-vis]").forEach((cb) => {
-      cb.addEventListener("change", () => {
-        STATE.visibility[cb.getAttribute("data-vis")] = cb.checked;
-        applyAllVisibility();
-        STATE.viewer && STATE.viewer.render();
-      });
-    });
-    document.querySelectorAll(".chip-btn[data-cam]").forEach((btn) => {
-      btn.addEventListener("click", () => handleCameraAction(btn.getAttribute("data-cam")));
-    });
-    document.querySelectorAll(".chip-btn[data-ligand]").forEach((btn) => {
-      btn.addEventListener("click", () => handleLigandAction(btn.getAttribute("data-ligand")));
-    });
-    document.querySelectorAll(".ctl-btn[data-action]").forEach((btn) => {
-      btn.addEventListener("click", () => handleToolbarAction(btn.getAttribute("data-action")));
-    });
-  }
+  /* ------------------------------------------------------------------ */
+  /* Styling                                                             */
+  /* ------------------------------------------------------------------ */
+  function styleViewer(viewer, model, mini) {
+    if (!viewer || !model) return;
+    safeCall(viewer, "removeAllSurfaces");
+    try { viewer.setStyle({}, {}); } catch (error) { console.debug(error); }
 
-  function applyAllVisibility() {
-    if (!STATE.viewer) return;
-    const selection = {
-      protein: {or: [{resn: ["ALA","ARG","ASN","ASP","CYS","GLN","GLU","GLY","HIS","HID","HIE","HIP","ILE","LEU","LYS","MET","PHE","PRO","SER","THR","TRP","TYR","VAL","MSE"]}]},
-      ligand: {or: []},
-      pocket: {or: []},
-      water:  {or: [{resn: ["HOH","WAT","TIP","TIP3","SOL","H2O"]}]},
-      ions:   {or: [{resn: ["NA","K","CL","BR","I","F","MG","CA","ZN","MN","FE","CU","NI","CO","CD"]}]},
-      hydrogens: {or: [{elem: "H"}]},
-      box:    {or: [{resn: ["SYSTEM","BOX"]}]}
+    const ligandNames = ligandResnames();
+    const proteinSelection = resolveProteinSelection(model);
+    const ligandSelection = ligandNames.length ? {resn: ligandNames} : {resn: "__NO_LIGAND__"};
+    const waterSelection = {resn: WATERS};
+    const ionSelection = {resn: IONS};
+    const pocketSelection = {
+      byres: true,
+      within: {distance: STATE.pocketCutoff, sel: ligandSelection},
     };
-    /* Treat every observed non-amino-acid residue as ligand. */
-    if (STATE.structureInfo && STATE.structureInfo.ligand_resnames) {
-      selection.ligand.or = [{resn: STATE.structureInfo.ligand_resnames}];
-    } else if (STATE.ligandResname) {
-      selection.ligand.or = [{resn: STATE.ligandResname}];
+
+    if (STATE.isolateLigand && ligandNames.length) {
+      addStyle(viewer, ligandSelection, ligandStyle());
+    } else if (STATE.pocketOnly && ligandNames.length) {
+      addStyle(viewer, pocketSelection, proteinStyle());
+      if (STATE.visibility.ligand) addStyle(viewer, ligandSelection, ligandStyle());
+    } else {
+      if (STATE.visibility.protein) {
+        if (mini) {
+          // The line overlay guarantees a visible silhouette even when a PDB
+          // frame lacks HELIX/SHEET records and the cartoon representation is
+          // still being inferred by 3Dmol.
+          addStyle(viewer, proteinSelection, {
+            cartoon: {color: "spectrum", thickness: 0.5, opacity: 1.0},
+            line: {color: COLORS.silver, linewidth: 1.0, opacity: 0.55},
+          });
+        } else {
+          addStyle(viewer, proteinSelection, proteinStyle());
+        }
+      }
+      if (!mini && STATE.visibility.pocket && ligandNames.length) {
+        addStyle(viewer, pocketSelection, {
+          stick: {radius: 0.10, colorscheme: STATE.colorMode === "monochrome" ? undefined : "Jmol", color: STATE.colorMode === "monochrome" ? COLORS.violet : undefined},
+        });
+      }
+      if (STATE.visibility.ligand && ligandNames.length) {
+        addStyle(viewer, ligandSelection, ligandStyle());
+      }
+      if (!mini && STATE.visibility.water) {
+        addStyle(viewer, waterSelection, {line: {color: "#6ea8ff", opacity: 0.35}});
+      }
+      if (!mini && STATE.visibility.ions) {
+        addStyle(viewer, ionSelection, {sphere: {scale: 0.35, colorscheme: "Jmol"}});
+      }
     }
-    Object.keys(STATE.visibility).forEach((key) => {
-      STATE.viewer.setStyle(selection[key] || {}, STATE.visibility[key]
-        ? {cartoon: {opacity: 1}}
-        : {cartoon: {opacity: 0}, stick: {opacity: 0}, line: {opacity: 0}, sphere: {opacity: 0}});
-    });
-    STATE.viewer.render();
+
+    if (!STATE.visibility.hydrogens) {
+      try { viewer.setStyle({elem: "H"}, {}); } catch (error) { console.debug(error); }
+    }
+    if (!mini && STATE.representation === "surface" && STATE.visibility.protein) {
+      addSurface(viewer, proteinSelection, {opacity: 0.78, color: "#d8d8dd"});
+    }
+    if (!mini && STATE.pocketSurface && ligandNames.length) {
+      addSurface(viewer, pocketSelection, {opacity: 0.55, color: COLORS.violet});
+    }
+    if (!mini && STATE.visibility.box && typeof viewer.addUnitCell === "function") {
+      try { viewer.addUnitCell(model, {box: {color: COLORS.silver}}); } catch (error) { console.debug(error); }
+    }
+    safeCall(viewer, "render");
   }
 
-  function applyColorMode() {
-    if (!STATE.viewer) return;
-    const mode = STATE.colorMode;
-    const palette = paletteFor(mode);
-    /* Default-applied across the whole structure. Ligand gets a
-       dedicated colour in Monochrome mode for the visual hierarchy. */
-    if (mode === "monochrome") {
-      STATE.viewer.setStyle({},
-        {cartoon: {color: COLORS.white, opacity: 1}});
-      STATE.viewer.setStyle({resn: STATE.ligandResname || ""},
-        {stick: {colorscheme: "cyanCarbon", radius: 0.18}});
-      STATE.viewer.setStyle({byres: true, within: {distance: 5.0, sel: {resn: STATE.ligandResname || ""}}},
-        {cartoon: {color: COLORS.violet, opacity: 0.85}});
+  function resolveProteinSelection(model) {
+    const aminoSelection = {resn: AMINO_ACIDS};
+    try {
+      if (model && typeof model.selectedAtoms === "function") {
+        if (model.selectedAtoms(aminoSelection).length) return aminoSelection;
+        const atomRecords = {hetflag: false};
+        if (model.selectedAtoms(atomRecords).length) return atomRecords;
+      }
+    } catch (error) {
+      console.debug("protein selection fallback", error);
+    }
+    return aminoSelection;
+  }
+
+  function proteinStyle() {
+    const color = proteinColor();
+    switch (STATE.representation) {
+      case "backbone": return {cartoon: Object.assign({style: "trace", thickness: 0.3}, color)};
+      case "sticks": return {stick: Object.assign({radius: 0.13}, color)};
+      case "ballAndStick": return {
+        stick: Object.assign({radius: 0.12}, color),
+        sphere: Object.assign({scale: 0.25}, color),
+      };
+      case "lines": return {line: Object.assign({linewidth: 1.2}, color)};
+      case "surface": return {cartoon: Object.assign({opacity: 0.18}, color)};
+      case "cartoon":
+      default: return {cartoon: Object.assign({thickness: 0.35}, color)};
+    }
+  }
+
+  function proteinColor() {
+    if (STATE.colorMode === "monochrome") return {color: COLORS.white};
+    if (STATE.colorMode === "spectrum") return {color: "spectrum"};
+    const schemes = {
+      chain: "chain",
+      residue: "amino",
+      element: "Jmol",
+      secondary_structure: "ssPyMol",
+    };
+    return {colorscheme: schemes[STATE.colorMode] || "chain"};
+  }
+
+  function ligandStyle() {
+    if (STATE.colorMode === "monochrome") {
+      return {
+        stick: {color: COLORS.cyan, radius: 0.20},
+        sphere: {color: COLORS.cyan, scale: 0.26},
+      };
+    }
+    return {
+      stick: {colorscheme: "Jmol", radius: 0.20},
+      sphere: {colorscheme: "Jmol", scale: 0.26},
+    };
+  }
+
+  function addStyle(viewer, selection, style) {
+    try {
+      if (typeof viewer.addStyle === "function") viewer.addStyle(selection, style);
+      else viewer.setStyle(selection, style);
+    } catch (error) {
+      console.debug("3Dmol style skipped", error);
+    }
+  }
+
+  function addSurface(viewer, selection, style) {
+    if (typeof viewer.addSurface !== "function" || !window.$3Dmol?.SurfaceType) return;
+    try {
+      viewer.addSurface(window.$3Dmol.SurfaceType.VDW, style, selection);
+    } catch (error) {
+      console.debug("3Dmol surface skipped", error);
+    }
+  }
+
+  function restyleViewers() {
+    const mainTarget = document.getElementById("viewer-canvas");
+    const miniTarget = document.getElementById("mini-preview-canvas");
+    if (STATE.viewer && STATE.model && mainTarget && isVisible(mainTarget)) {
+      styleViewer(STATE.viewer, STATE.model, false);
+    }
+    const miniModel = STATE.mode === "playback"
+      ? STATE.miniPlaybackModel
+      : STATE.miniModel;
+    if (STATE.miniViewer && miniModel && miniTarget && isVisible(miniTarget)) {
+      styleViewer(STATE.miniViewer, miniModel, true);
+    }
+  }
+
+  function ligandResnames() {
+    const names = Array.isArray(STATE.structureInfo?.ligand_resnames)
+      ? STATE.structureInfo.ligand_resnames.filter(Boolean)
+      : [];
+    if (STATE.ligandResname && !names.includes(STATE.ligandResname)) names.unshift(STATE.ligandResname);
+    return names;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Controls                                                            */
+  /* ------------------------------------------------------------------ */
+  function wireControls() {
+    document.querySelectorAll(".chip-btn[data-rep]").forEach((button) => {
+      button.addEventListener("click", () => {
+        document.querySelectorAll(".chip-btn[data-rep]").forEach((item) => item.classList.toggle("active", item === button));
+        STATE.representation = button.getAttribute("data-rep") || "cartoon";
+        STATE.isolateLigand = false;
+        STATE.pocketOnly = false;
+        restyleViewers();
+      });
+    });
+    document.querySelectorAll(".chip-btn[data-color]").forEach((button) => {
+      button.addEventListener("click", () => {
+        document.querySelectorAll(".chip-btn[data-color]").forEach((item) => item.classList.toggle("active", item === button));
+        STATE.colorMode = button.getAttribute("data-color") || "spectrum";
+        restyleViewers();
+      });
+    });
+    document.querySelectorAll(".chip-toggle input[data-vis]").forEach((checkbox) => {
+      checkbox.addEventListener("change", () => {
+        STATE.visibility[checkbox.getAttribute("data-vis")] = checkbox.checked;
+        restyleViewers();
+      });
+    });
+    document.querySelectorAll(".chip-btn[data-cam]").forEach((button) => {
+      button.addEventListener("click", () => handleCameraAction(button.getAttribute("data-cam")));
+    });
+    document.querySelectorAll(".chip-btn[data-ligand]").forEach((button) => {
+      button.addEventListener("click", () => handleLigandAction(button.getAttribute("data-ligand")));
+    });
+    document.querySelectorAll(".ctl-btn[data-action]").forEach((button) => {
+      button.addEventListener("click", () => handleToolbarAction(button.getAttribute("data-action"), button));
+    });
+    document.getElementById("pocket-cutoff")?.addEventListener("change", (event) => {
+      STATE.pocketCutoff = clamp(Number(event.target.value), 3, 15, 5);
+      restyleViewers();
+    });
+  }
+
+  async function handleToolbarAction(action, button) {
+    if (action === "live-toggle") {
+      pausePlayback();
+      STATE.liveUpdates = true;
+      STATE.mode = STATE.liveFrameIndex != null ? "live" : "structure";
+      const viewer = ensureMainViewer();
+      if (STATE.currentPdb && viewer) installPdb(viewer, STATE.currentPdb, {main: true, center: false});
+      const mini = ensureMiniViewer();
+      if (STATE.currentPdb && mini) installPdb(mini, STATE.currentPdb, {mini: true, center: false});
+      button?.classList.add("active");
+      updatePlaybackButtons();
+      announce("Live molecular updates enabled.");
+      await pollLiveFrame();
       return;
     }
-    const map = {
-      chain: {colorscheme: "chain"},
-      residue: {colorscheme: "default"},
-      element: {colorscheme: "Jmol"},
-      secondary_structure: {colorscheme: "ssPyMOL"},
-      spectrum: {colorscheme: "spectrum"},
-    };
-    if (!map[mode]) return;
-    STATE.viewer.setStyle({}, {cartoon: map[mode]});
-    /* Reapply ligand-style sticks so ligand reads as bestätigen-bar against the cartoon. */
-    if (STATE.ligandResname) {
-      STATE.viewer.setStyle({resn: STATE.ligandResname},
-        {stick: {colorscheme: "default", radius: 0.18, opacity: 1}});
+    if (action === "pause-toggle") {
+      STATE.liveUpdates = !STATE.liveUpdates;
+      button?.classList.toggle("active", !STATE.liveUpdates);
+      if (button) button.textContent = STATE.liveUpdates ? "Pause Updates" : "Resume Updates";
+      announce(STATE.liveUpdates ? "Live molecular updates resumed." : "Live molecular updates paused.");
+      return;
     }
-  }
-
-  function paletteFor(mode) {
-    return null;
-  }
-
-  function handleCameraAction(name) {
-    if (!STATE.viewer) return;
-    switch (name) {
-      case "spin":
-        STATE.viewer.spin(true);
-        STATE.spinning = true;
-        return;
-      case "stop":
-        STATE.viewer.spin(false);
-        STATE.spinning = false;
-        return;
-      case "center-protein":
-        STATE.viewer.zoomTo(); STATE.viewer.render();
-        return;
-      case "center-ligand":
-        if (STATE.ligandResname) {
-          STATE.viewer.zoomTo({resn: STATE.ligandResname});
-          STATE.viewer.render();
-        }
-        return;
-      case "center-pocket":
-        if (!STATE.ligandResname) return;
-        STATE.viewer.zoomTo({byres: true, within: {distance: STATE.pocketCutoff, sel: {resn: STATE.ligandResname}}});
-        STATE.viewer.render();
-        return;
-      case "zoom-in":
-        STATE.viewer.zoom(1.2); STATE.viewer.render(); return;
-      case "zoom-out":
-        STATE.viewer.zoom(0.8); STATE.viewer.render(); return;
+    const viewer = ensureMainViewer();
+    if (!viewer) return;
+    if (action === "play-trajectory") {
+      if (STATE.playbackPlaying) pausePlayback();
+      else await startPlayback();
+      return;
     }
-  }
-
-  function handleLigandAction(name) {
-    if (!STATE.viewer || !STATE.ligandResname) return;
-    switch (name) {
-      case "center":
-        STATE.viewer.zoomTo({resn: STATE.ligandResname}); STATE.viewer.render(); return;
-      case "isolate":
-        STATE.viewer.removeAllModels();
-        const pdb = STATE.coordinatesPdb || STATE.structurePdb;
-        if (!pdb) return;
-        STATE.viewer.addModel(pdb, "pdb");
-        STATE.viewer.setStyle({resn: STATE.ligandResname}, {stick: {colorscheme: "default"}});
-        STATE.viewer.zoomTo({resn: STATE.ligandResname});
-        STATE.viewer.render();
-        return;
-      case "show-pocket":
-        STATE.viewer.setStyle({byres: true, within: {distance: STATE.pocketCutoff, sel: {resn: STATE.ligandResname}}},
-          {stick: {colorscheme: "default", radius: 0.10}});
-        STATE.viewer.render();
-        return;
-      case "show-pocket-surface":
-        if (!STATE.viewer.hasOwnProperty("addSurface")) return;
-        STATE.viewer.removeAllSurfaces();
-        STATE.viewer.addSurface(
-          $3Dmol.SurfaceType.VDW,
-          {opacity: 0.66, color: COLORS.violet},
-          {byres: true, within: {distance: STATE.pocketCutoff, sel: {resn: STATE.ligandResname}}});
-        STATE.viewer.render();
-        return;
-      case "hide-distant":
-        STATE.viewer.removeAllModels();
-        const pdb2 = STATE.coordinatesPdb || STATE.structurePdb;
-        if (!pdb2) return;
-        STATE.viewer.addModel(pdb2, "pdb");
-        STATE.viewer.setStyle({byres: true, within: {distance: STATE.pocketCutoff, sel: {resn: STATE.ligandResname}}},
-          {cartoon: {colorscheme: "spectrum"}});
-        STATE.viewer.setStyle({resn: STATE.ligandResname}, {stick: {colorscheme: "default"}});
-        STATE.viewer.zoomTo();
-        STATE.viewer.render();
-        return;
-      case "show-labels":
-        STATE.viewer.removeAllLabels();
-        STATE.viewer.addResLabels({resn: STATE.ligandResname});
-        STATE.viewer.render();
-        return;
-      case "show-contacts":
-        /* Geometric contacts within the cutoff. We do NOT claim
-           hydrogen bonds, salt bridges, or hydrophobic contacts from
-           raw distance; those require carefully calibrated geometric
-           rules. Surface them but in a separate analysis stage. */
-        STATE.viewer.removeAllShapes();
-        /* Polylines from each ligand atom to each nearby residue.
-           For visual clarity, only the closest 30 are drawn. */
-        return;
-      case "show-hbonds":
-        /* Without geometric H-bond detection implemented locally, we
-           don't pretend to draw hydrogen-bond arrows. The ligand
-           Interaction tab in the right panel surfaces the values from
-           geometric/calculation-based analyses if available. */
-        return;
+    if (action === "prev-frame") { await seekRelative(-1); return; }
+    if (action === "next-frame") { await seekRelative(1); return; }
+    if (action === "reset-view") {
+      safeCall(viewer, "spin", false);
+      safeCall(viewer, "zoomTo");
+      safeCall(viewer, "render");
+      return;
     }
+    if (action === "fullscreen") {
+      document.getElementById("viewer-canvas-frame")?.requestFullscreen?.();
+      return;
+    }
+    if (action === "screenshot") takeScreenshot();
   }
 
-  function handleToolbarAction(name) {
-    if (!STATE.viewer) return;
-    switch (name) {
-      case "live-toggle":
-        window.FastMDXDashboard && window.FastMDXDashboard.navigate("overview");
-        return;
-      case "pause-toggle":
-        /* Same as the dashboard-level pause; toggling browser refresh
-           does NOT pause OpenMM, which is the critical safety claim. */
-        const toggle = document.getElementById("pause-toggle");
-        if (toggle) toggle.click();
-        return;
-      case "play-trajectory":
-        if (STATE.playbackLoaded) playTrajectory();
-        return;
-      case "prev-frame":
-        seekTrajectoryBy(-1); return;
-      case "next-frame":
-        seekTrajectoryBy(+1); return;
-      case "reset-view":
-        STATE.viewer.spin(false);
-        STATE.viewer.zoomTo(); STATE.viewer.center();
-        STATE.viewer.render(); return;
-      case "fullscreen":
-        const frame = document.getElementById("viewer-canvas-frame");
-        if (frame && frame.requestFullscreen) frame.requestFullscreen();
-        return;
-      case "screenshot":
-        takeScreenshot(); return;
+  function handleCameraAction(action) {
+    const viewer = ensureMainViewer();
+    if (!viewer) return;
+    if (action === "spin") {
+      safeCall(viewer, "spin", true);
+      STATE.spinning = true;
+      return;
+    }
+    if (action === "stop") {
+      safeCall(viewer, "spin", false);
+      STATE.spinning = false;
+      return;
+    }
+    if (action === "center-protein") safeCall(viewer, "zoomTo", {resn: AMINO_ACIDS});
+    if (action === "center-ligand" && ligandResnames().length) safeCall(viewer, "zoomTo", {resn: ligandResnames()});
+    if (action === "center-pocket" && ligandResnames().length) {
+      safeCall(viewer, "zoomTo", {byres: true, within: {distance: STATE.pocketCutoff, sel: {resn: ligandResnames()}}});
+    }
+    if (action === "zoom-in") safeCall(viewer, "zoom", 1.2);
+    if (action === "zoom-out") safeCall(viewer, "zoom", 0.8);
+    safeCall(viewer, "render");
+  }
+
+  function handleLigandAction(action) {
+    const viewer = ensureMainViewer();
+    const ligands = ligandResnames();
+    if (!viewer || !ligands.length) {
+      announce("No ligand is available for this control.");
+      return;
+    }
+    if (action === "center") safeCall(viewer, "zoomTo", {resn: ligands});
+    if (action === "isolate") {
+      STATE.isolateLigand = !STATE.isolateLigand;
+      STATE.pocketOnly = false;
+      restyleViewers();
+      safeCall(viewer, "zoomTo", {resn: ligands});
+    }
+    if (action === "show-pocket") {
+      STATE.visibility.pocket = true;
+      STATE.isolateLigand = false;
+      restyleViewers();
+      safeCall(viewer, "zoomTo", {byres: true, within: {distance: STATE.pocketCutoff, sel: {resn: ligands}}});
+    }
+    if (action === "show-pocket-surface") {
+      STATE.pocketSurface = !STATE.pocketSurface;
+      restyleViewers();
+    }
+    if (action === "hide-distant") {
+      STATE.pocketOnly = !STATE.pocketOnly;
+      STATE.isolateLigand = false;
+      restyleViewers();
+      safeCall(viewer, "zoomTo");
+    }
+    if (action === "show-labels") {
+      safeCall(viewer, "removeAllLabels");
+      try { viewer.addResLabels({resn: ligands}, {fontColor: COLORS.white, backgroundColor: "#101012"}); } catch (error) { console.debug(error); }
+    }
+    if (action === "show-contacts") drawGeometricContacts();
+    if (action === "show-hbonds") announce("Hydrogen-bond overlays appear only when a dedicated interaction analysis provides them.");
+    safeCall(viewer, "render");
+  }
+
+  function drawGeometricContacts() {
+    const viewer = STATE.viewer;
+    const model = STATE.model;
+    const ligands = ligandResnames();
+    if (!viewer || !model || !ligands.length || typeof model.selectedAtoms !== "function") return;
+    safeCall(viewer, "removeAllShapes");
+    try {
+      const ligandAtoms = model.selectedAtoms({resn: ligands});
+      const pocketAtoms = model.selectedAtoms({
+        byres: true,
+        within: {distance: STATE.pocketCutoff, sel: {resn: ligands}},
+        invert: true,
+      });
+      const contacts = [];
+      ligandAtoms.forEach((ligandAtom) => {
+        let closest = null;
+        let closestDistance = Infinity;
+        pocketAtoms.forEach((atom) => {
+          if (ligands.includes(atom.resn)) return;
+          const dx = ligandAtom.x - atom.x;
+          const dy = ligandAtom.y - atom.y;
+          const dz = ligandAtom.z - atom.z;
+          const distance = Math.sqrt(dx * dx + dy * dy + dz * dz);
+          if (distance <= STATE.pocketCutoff && distance < closestDistance) {
+            closest = atom;
+            closestDistance = distance;
+          }
+        });
+        if (closest) contacts.push({ligandAtom, atom: closest, distance: closestDistance});
+      });
+      contacts.sort((a, b) => a.distance - b.distance).slice(0, 30).forEach((contact) => {
+        viewer.addLine({
+          start: {x: contact.ligandAtom.x, y: contact.ligandAtom.y, z: contact.ligandAtom.z},
+          end: {x: contact.atom.x, y: contact.atom.y, z: contact.atom.z},
+          color: COLORS.cyan,
+          dashed: true,
+          linewidth: 1,
+          opacity: 0.75,
+        });
+      });
+      announce(`Displayed ${Math.min(30, contacts.length)} geometric contacts within ${STATE.pocketCutoff} Å.`);
+    } catch (error) {
+      console.warn("geometric contact rendering failed", error);
+      announce("Geometric contacts could not be calculated for this structure.");
     }
   }
 
   function takeScreenshot() {
     if (!STATE.viewer || typeof STATE.viewer.pngURI !== "function") return;
-    STATE.viewer.render();
-    const data = STATE.viewer.pngURI();
-    const a = document.createElement("a");
-    a.href = data; a.download = "fastmdx-viewer.png";
-    document.body.appendChild(a); a.click(); a.remove();
+    safeCall(STATE.viewer, "render");
+    const anchor = document.createElement("a");
+    anchor.href = STATE.viewer.pngURI();
+    anchor.download = "fastmdxplora-molecular-viewer.png";
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
   }
 
-  /* ---------------------------------------------- *
-   * Trajectory playback                           *
-   * ---------------------------------------------- */
-  function loadPlayback(payload) {
-    if (!payload || !payload.playback_available) {
-      document.getElementById("trajectory-row")?.setAttribute("hidden", "");
-      return;
-    }
-    /* 3Dmol's mload() reads a multi-MODEL PDB and gives us a list of
-       models. Set the per-model style, then animate via setFrame. */
-    if (STATE.playbackLoaded) return;
-    if (!STATE.viewer) ensureViewerMounted();
-    if (!STATE.viewer) return;
-    const url = "/structure/playback.pdb?v=" + (payload.compiled_at || Date.now());
-    STATE.viewer.removeAllModels();
-    fetch(url, {cache: "no-store"}).then(async (res) => {
-      if (!res.ok) throw new Error("playback HTTP " + res.status);
-      const pdb = await res.text();
-      STATE.viewer.removeAllModels();
-      STATE.viewer.addModelsAsFrames(pdb, "pdb");
-      STATE.playbackFrames = STATE.viewer.getModel().length || payload.n_frames_browser;
-      STATE.playbackLoaded = true;
-      applyRepresentation();
-      applyAllVisibility();
-      applyColorMode();
-      const slider = document.getElementById("traj-slider");
-      if (slider) {
-        slider.min = 0;
-        slider.max = String(Math.max(0, STATE.playbackFrames - 1));
-        slider.value = 0;
+  /* ------------------------------------------------------------------ */
+  /* Playback                                                            */
+  /* ------------------------------------------------------------------ */
+  function onPlaybackReady(payload) {
+    const signature = payload?.source_signature || payload?.compiled_at || null;
+    const changed = !!(STATE.playbackSignature && signature && STATE.playbackSignature !== signature);
+    STATE.playbackPayload = payload || null;
+    STATE.playbackSignature = signature;
+    STATE.playbackFrameTimes = Array.isArray(payload?.frame_times_ns) ? payload.frame_times_ns : [];
+    STATE.playbackFrames = Number(payload?.n_frames_browser || 0);
+    if (changed) {
+      STATE.playbackLoaded = false;
+      STATE.playbackPdb = null;
+      STATE.miniPlaybackModel = null;
+      if (STATE.mode === "playback") {
+        pausePlayback();
+        announce("New trajectory frames are available. Press Play Trajectory to reload them.");
       }
-      document.getElementById("trajectory-row")?.removeAttribute("hidden");
-    }).catch((err) => console.warn("playback load failed", err));
+    }
+    updatePlaybackButtons();
+  }
+
+  async function requestPlaybackPayload(force) {
+    try {
+      const response = await fetch(`/api/playback-info${force ? "?force=1" : ""}`, {cache: "no-store"});
+      if (!response.ok) throw new Error(`playback info HTTP ${response.status}`);
+      const payload = await response.json();
+      onPlaybackReady(payload);
+      return payload;
+    } catch (error) {
+      console.warn("playback information request failed", error);
+      return null;
+    }
+  }
+
+  async function ensurePlaybackPayload() {
+    if (STATE.playbackPayload?.playback_available) return STATE.playbackPayload;
+    const payload = await requestPlaybackPayload(true);
+    if (!payload?.playback_available) {
+      const reason = String(payload?.reason || "not enough frames yet").replaceAll("-", " ");
+      announce(`Trajectory playback is not ready: ${reason}. Live molecular updates remain active.`);
+      return null;
+    }
+    return payload;
+  }
+
+  async function loadPlayback(payload) {
+    const available = payload?.playback_available ? payload : await ensurePlaybackPayload();
+    if (!available) return false;
+    const signature = available.source_signature || available.compiled_at || null;
+    if (STATE.playbackLoaded && STATE.playbackPdb && STATE.playbackSignature === signature) return true;
+    if (STATE.playbackLoadPromise) return STATE.playbackLoadPromise;
+
+    const viewer = ensureMainViewer();
+    if (!viewer) return false;
+    STATE.playbackLoadPromise = (async () => {
+      try {
+        const response = await fetch(`/structure/playback.pdb?v=${encodeURIComponent(available.compiled_at || Date.now())}`, {cache: "no-store"});
+        if (!response.ok) throw new Error(`playback HTTP ${response.status}`);
+        const pdb = await response.text();
+        if (!pdb.includes("MODEL") || (!pdb.includes("ATOM") && !pdb.includes("HETATM"))) {
+          throw new Error("playback PDB contains no model frames");
+        }
+        STATE.playbackPdb = pdb;
+        STATE.playbackSignature = signature;
+        STATE.playbackFrames = Number(available.n_frames_browser || 0);
+        STATE.playbackFrameTimes = Array.isArray(available.frame_times_ns) ? available.frame_times_ns : [];
+        STATE.mode = "playback";
+        const model = installPlaybackPdb(viewer, pdb, {main: true, center: false});
+        if (!model) throw new Error("3Dmol did not create a playback model");
+
+        const mini = ensureMiniViewer();
+        if (mini) installPlaybackPdb(mini, pdb, {mini: true, center: false});
+        STATE.playbackLoaded = true;
+        document.getElementById("trajectory-row")?.removeAttribute("hidden");
+        await setPlaybackFrame(Number(document.getElementById("traj-slider")?.value || 0));
+        updatePlaybackButtons();
+        return true;
+      } catch (error) {
+        console.warn("trajectory playback load failed", error);
+        announce("Trajectory playback could not be loaded. Live molecular updates still work.");
+        STATE.playbackLoaded = false;
+        return false;
+      } finally {
+        STATE.playbackLoadPromise = null;
+      }
+    })();
+    return STATE.playbackLoadPromise;
   }
 
   function wireTrajectoryControls() {
-    /* See dashboard.js for slider + button wiring. */
-  }
-
-  let playbackInterval = null;
-  function playTrajectory() {
-    if (!STATE.playbackLoaded) return;
-    STATE.playbackPlaying = true;
-    if (playbackInterval) clearInterval(playbackInterval);
-    const stepMs = Math.max(60, 800 / Math.max(0.25, STATE.playbackSpeed));
-    playbackInterval = setInterval(() => {
-      if (!STATE.playbackPlaying) {
-        clearInterval(playbackInterval);
-        playbackInterval = null;
-        return;
+    window.addEventListener("dashboard:trajectory-action", async (event) => {
+      const action = event.detail?.action;
+      if (action === "play") await startPlayback();
+      if (action === "pause") pausePlayback();
+      if (action === "reverse") {
+        STATE.playbackReverse = !STATE.playbackReverse;
+        await startPlayback();
       }
-      advanceTrajectory(STATE.playbackReverse ? -1 : +1);
-    }, stepMs);
+      if (action === "prev") await seekRelative(-1);
+      if (action === "next") await seekRelative(1);
+      if (action === "first") {
+        if (await loadPlayback(STATE.playbackPayload)) await setPlaybackFrame(0);
+      }
+      if (action === "last") {
+        if (await loadPlayback(STATE.playbackPayload)) await setPlaybackFrame(Math.max(0, STATE.playbackFrames - 1));
+      }
+    });
+    window.addEventListener("dashboard:trajectory-seek", async (event) => {
+      if (await loadPlayback(STATE.playbackPayload)) await setPlaybackFrame(event.detail?.frame || 0);
+    });
+    document.getElementById("traj-speed")?.addEventListener("change", async (event) => {
+      STATE.playbackSpeed = Number(event.target.value) || 1;
+      if (STATE.playbackPlaying) await startPlayback();
+    });
+    document.getElementById("traj-loop")?.addEventListener("change", (event) => {
+      STATE.playbackLoop = !!event.target.checked;
+    });
   }
 
-  function advanceTrajectory(direction) {
-    if (!STATE.playbackLoaded) return;
+  async function startPlayback() {
+    const payload = await ensurePlaybackPayload();
+    if (!payload || !(await loadPlayback(payload))) return;
+    STATE.playbackPlaying = true;
+    STATE.liveUpdates = false;
+    clearPlaybackTimer();
+    updatePlaybackButtons();
+    const interval = Math.max(50, Math.round(700 / Math.max(0.25, STATE.playbackSpeed)));
+    STATE.playbackTimer = window.setInterval(() => {
+      if (!STATE.playbackPlaying) return clearPlaybackTimer();
+      seekRelative(STATE.playbackReverse ? -1 : 1, true);
+    }, interval);
+  }
+
+  function pausePlayback() {
+    STATE.playbackPlaying = false;
+    clearPlaybackTimer();
+    updatePlaybackButtons();
+  }
+
+  function clearPlaybackTimer() {
+    if (STATE.playbackTimer) window.clearInterval(STATE.playbackTimer);
+    STATE.playbackTimer = null;
+  }
+
+  async function seekRelative(delta, fromTimer) {
+    if (!STATE.playbackLoaded && !(await loadPlayback(STATE.playbackPayload))) return;
     const slider = document.getElementById("traj-slider");
-    if (!slider) return;
-    let next = parseInt(slider.value, 10) + direction;
-    if (next < 0) {
-      if (STATE.playbackLoop) next = STATE.playbackFrames - 1;
-      else {STATE.playbackPlaying = false; return;}
+    const current = Number(slider?.value || 0);
+    let next = current + delta;
+    if (next < 0 || next >= STATE.playbackFrames) {
+      if (STATE.playbackLoop) next = next < 0 ? STATE.playbackFrames - 1 : 0;
+      else {
+        if (fromTimer) pausePlayback();
+        next = clamp(next, 0, Math.max(0, STATE.playbackFrames - 1), 0);
+      }
     }
-    if (next >= STATE.playbackFrames) {
-      if (STATE.playbackLoop) next = 0;
-      else {STATE.playbackPlaying = false; return;}
-    }
-    slider.value = String(next);
-    STATE.viewer.setFrame(next);
-    STATE.viewer.render();
-    document.getElementById("traj-current").textContent = String(next);
-      /* Update sim time label from the playback payload if available. */
-    const t = (STATE.playbackFrameTimes && STATE.playbackFrameTimes[next]) || null;
-    document.getElementById("traj-simtime").textContent = t != null
-      ? Number(t).toFixed(3) : "—";
+    await setPlaybackFrame(next);
   }
 
-  function seekTrajectoryBy(delta) {
-    advanceTrajectory(delta);
+  async function setPlaybackFrame(frame) {
+    if (!STATE.viewer || !STATE.playbackLoaded) return;
+    const index = clamp(Math.round(Number(frame)), 0, Math.max(0, STATE.playbackFrames - 1), 0);
+    await setViewerFrame(STATE.viewer, index);
+    if (STATE.miniViewer && STATE.miniPlaybackModel) await setViewerFrame(STATE.miniViewer, index);
+    const slider = document.getElementById("traj-slider");
+    if (slider) slider.value = String(index);
+    setText("traj-current", String(index));
+    setText("traj-total", String(STATE.playbackFrames));
+    const time = STATE.playbackFrameTimes[index];
+    setText("traj-simtime", time != null ? Number(time).toFixed(3) : "—");
+    setOverlay(false, {stage: "playback", frame: index, simtime: time});
   }
 
-  /* ---------------------------------------------- *
-   * Settings / callback wiring                    *
-   * ---------------------------------------------- */
-  function onSettingsUpdated(s) {
-    if (s.ligand) STATE.ligandResname = s.ligand;
-    if (typeof s.pocketCutoff === "number") {
-      STATE.pocketCutoff = s.pocketCutoff;
-      const inp = document.getElementById("pocket-cutoff");
-      if (inp) inp.value = String(STATE.pocketCutoff);
+  async function setViewerFrame(viewer, index) {
+    if (!viewer || typeof viewer.setFrame !== "function") return;
+    try {
+      await Promise.resolve(viewer.setFrame(index));
+      viewer.render();
+    } catch (error) {
+      console.debug("3Dmol setFrame failed", error);
     }
-    window.FastMDXDashboard &&
-      window.FastMDXDashboard.on("structure-updated", (info) => onStructureUpdated(info));
+  }
+
+  function updatePlaybackButtons() {
+    const toolbar = document.querySelector('[data-action="play-trajectory"]');
+    if (toolbar) {
+      toolbar.textContent = STATE.playbackPlaying ? "Pause Trajectory" : "Play Trajectory";
+      toolbar.classList.toggle("active", STATE.playbackPlaying);
+      toolbar.title = STATE.playbackPayload?.playback_available
+        ? `${STATE.playbackFrames} browser playback frames available`
+        : "Playback becomes available after at least two live coordinate snapshots";
+    }
+    document.querySelectorAll('[data-action="prev-frame"], [data-action="next-frame"]').forEach((button) => {
+      button.setAttribute("aria-disabled", String(!STATE.playbackPayload?.playback_available));
+    });
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Settings, status, selections                                        */
+  /* ------------------------------------------------------------------ */
+  function onSettingsUpdated(settings) {
+    if (settings.ligand) STATE.ligandResname = String(settings.ligand).toUpperCase();
+    if (Number.isFinite(settings.pocketCutoff)) STATE.pocketCutoff = settings.pocketCutoff;
+    if (settings.proteinRepresentation) STATE.representation = settings.proteinRepresentation;
+    STATE.visibility.water = !!settings.showWater;
+    STATE.visibility.ions = !!settings.showIons;
+    STATE.preservingCamera = settings.preserveCamera !== false;
+    if (STATE.viewer && typeof STATE.viewer.setBackgroundColor === "function") {
+      const background = settings.background === "charcoal" ? "#101012" : COLORS.black;
+      STATE.viewer.setBackgroundColor(background);
+    }
+    if (STATE.miniViewer && typeof STATE.miniViewer.setBackgroundColor === "function") {
+      STATE.miniViewer.setBackgroundColor(COLORS.black);
+    }
+    if (settings.spin && STATE.viewer) safeCall(STATE.viewer, "spin", true);
+    const cutoff = document.getElementById("pocket-cutoff");
+    if (cutoff) cutoff.value = String(STATE.pocketCutoff);
+    restyleViewers();
   }
 
   function onStatusUpdated(status) {
+    const running = String(status?.status || "").toLowerCase() === "running";
+    setOverlay(running, {
+      stage: status?.stage || "—",
+      simtime: status?.simulation_time_completed_ns,
+      frame: status?.current_frame_count,
+    });
+  }
+
+  function onHoverAtom(atom) {
+    if (!atom) return;
+    updateSelectionPanel(atom);
+  }
+
+  function clearHoverAtom() {
+    // Keep the last selection visible; hover-out should not erase useful data.
+  }
+
+  function onClickAtom(atom) {
+    if (!atom) return;
+    updateSelectionPanel(atom);
+  }
+
+  function updateSelectionPanel(atom) {
+    const body = document.getElementById("selection-tab-tbody");
+    if (!body) return;
+    body.innerHTML = `
+      <tr><th>Residue</th><td>${escapeHTML(atom.resn || "—")} ${escapeHTML(atom.resi ?? "")}</td></tr>
+      <tr><th>Chain</th><td>${escapeHTML(atom.chain || "—")}</td></tr>
+      <tr><th>Atom</th><td>${escapeHTML(atom.atom || atom.name || "—")}</td></tr>
+      <tr><th>Element</th><td>${escapeHTML(atom.elem || atom.element || "—")}</td></tr>
+      <tr><th>Coordinates</th><td>${coordinate(atom.x)}, ${coordinate(atom.y)}, ${coordinate(atom.z)}</td></tr>`;
+  }
+
+  function setOverlay(live, info) {
     const overlay = document.getElementById("viewer-overlay");
     if (!overlay) return;
-    overlay.setAttribute("data-live", status.status === "running" ? "true" : "false");
-    const stage = overlay.querySelector("#overlay-stage");
-    if (stage) stage.textContent = status.stage || "—";
-    const simtime = overlay.querySelector("#overlay-simtime");
-    if (simtime && status.simulation_time_completed_ns)
-      simtime.textContent = `${Number(status.simulation_time_completed_ns).toFixed(3)} ns`;
+    overlay.setAttribute("data-live", live ? "true" : "false");
+    setText("overlay-tag", live ? "LIVE" : (STATE.mode === "playback" ? "PLAYBACK" : "STATIC"));
+    if (info?.stage != null) setText("overlay-stage", info.stage);
+    if (info?.frame != null) setText("overlay-frame", `frame ${info.frame}`);
+    if (info?.age != null) setText("overlay-age", `age ${info.age}`);
+    if (info?.simtime != null) setText("overlay-simtime", `${Number(info.simtime).toFixed(3)} ns`);
   }
 
-  function onHoverAtom(atom, viewer, event) {
-    const sel = document.getElementById("selection-tab-tbody");
-    if (!sel) return;
-    sel.innerHTML = `
-      <tr><th>Residue</th><td>${escapeHTML(atom.resn || "—")} ${atom.resi || ""}</td></tr>
-      <tr><th>Chain</th><td>${escapeHTML(atom.chain || "—")}</td></tr>
-      <tr><th>Atom</th><td>${escapeHTML(atom.atom || "—")}</td></tr>
-      <tr><th>Element</th><td>${escapeHTML(atom.element || "—")}</td></tr>
-      <tr><th>Coordinates</th><td>${atom.x != null ? atom.x.toFixed(3) : "—"}, ${atom.y != null ? atom.y.toFixed(3) : "—"}, ${atom.z != null ? atom.z.toFixed(3) : "—"}</td></tr>
-    `;
+  /* ------------------------------------------------------------------ */
+  /* Generic helpers                                                     */
+  /* ------------------------------------------------------------------ */
+  function captureView(viewer) {
+    try {
+      const view = viewer.getView();
+      if (Array.isArray(view)) return view.slice();
+      return view ? JSON.parse(JSON.stringify(view)) : null;
+    } catch (error) {
+      return null;
+    }
   }
 
-  function escapeHTML(s) {
-    return String(s).replace(/[&<>"']/g, (c) => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));
+  function restoreView(viewer, view) {
+    try { viewer.setView(view); } catch (error) { console.debug(error); }
   }
 
-  function centerOnProtein() {
-    if (STATE.viewer) { STATE.viewer.zoomTo(); STATE.viewer.render(); }
+  function resizeViewers() {
+    const mainTarget = document.getElementById("viewer-canvas");
+    const miniTarget = document.getElementById("mini-preview-canvas");
+    if (mainTarget && isVisible(mainTarget)) resizeViewer(STATE.viewer);
+    if (miniTarget && isVisible(miniTarget)) resizeViewer(STATE.miniViewer);
   }
 
-  document.addEventListener("DOMContentLoaded", init);
-  window.FastMDXMoleculeViewer = { STATE, applyLiveCoordinates, loadPlayback };
-})();
+  function resizeViewer(viewer) {
+    if (!viewer) return;
+    try {
+      if (typeof viewer.resize === "function") viewer.resize();
+      viewer.render();
+    } catch (error) {
+      console.debug("viewer resize skipped", error);
+    }
+  }
+
+  function stopViewerMotion(viewer) {
+    try { viewer.spin(false); } catch (error) { console.debug(error); }
+  }
+
+  function safeCall(object, method, ...args) {
+    try {
+      if (object && typeof object[method] === "function") return object[method](...args);
+    } catch (error) {
+      console.debug(`3Dmol ${method} skipped`, error);
+    }
+    return undefined;
+  }
+
+  function isVisible(element) {
+    return !!(element.offsetWidth || element.offsetHeight || element.getClientRects().length);
+  }
+
+  function announce(message) {
+    const live = document.getElementById("sr-live");
+    if (live) live.textContent = message;
+    console.info(message);
+  }
+
+  function setText(id, value) {
+    const element = document.getElementById(id);
+    if (element) element.textContent = value == null ? "" : String(value);
+  }
+
+  function coordinate(value) {
+    return Number.isFinite(Number(value)) ? Number(value).toFixed(3) : "—";
+  }
+
+  function clamp(value, low, high, fallback) {
+    const number = Number(value);
+    if (!Number.isFinite(number)) return fallback;
+    return Math.max(low, Math.min(high, number));
+  }
+
+  function escapeHTML(value) {
+    return String(value == null ? "" : value).replace(/[&<>"']/g, (character) => ({
+      "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
+    })[character]);
+  }
+
+  window.FastMDXMoleculeViewer = {
+    STATE,
+    onStructureUpdated,
+    pollLiveFrame,
+    loadPlayback,
+    resize: resizeViewers,
+  };
+}());

--- a/src/fastmdxplora/live/static/simulation-builder.js
+++ b/src/fastmdxplora/live/static/simulation-builder.js
@@ -1,0 +1,432 @@
+/* FastMDXplora dashboard-first simulation builder.
+ *
+ * This module only collects and validates options.  The Python backend
+ * launches the canonical CLI in a separate process, so the scientific
+ * workflow remains identical to a normal `fastmdx explore` command.
+ */
+(function () {
+  "use strict";
+
+  const byId = (id) => document.getElementById(id);
+  const $$ = (selector, root) => Array.from((root || document).querySelectorAll(selector));
+
+  const builder = {
+    defaults: null,
+    appState: {},
+    initialized: false,
+    lastValidation: null,
+  };
+
+  document.addEventListener("DOMContentLoaded", init);
+
+  async function init() {
+    const form = byId("simulation-builder-form");
+    if (!form) return;
+    wireForm();
+    try {
+      builder.defaults = await requestJSON("/api/launcher/defaults");
+      populateDefaults(builder.defaults);
+      builder.initialized = true;
+      updateSummary();
+      await refreshAppState();
+    } catch (error) {
+      setMessage(`Could not load simulation defaults: ${error.message}`, "error");
+    }
+
+    window.FastMDXDashboard?.on("app-state", (payload) => applyAppState(payload || {}));
+    window.setInterval(refreshAppState, 2000);
+  }
+
+  function wireForm() {
+    const pairs = [
+      ["builder-ph-range", "builder-ph"],
+      ["builder-ion-range", "builder-ion"],
+      ["builder-padding-range", "builder-padding"],
+      ["builder-nvt-range", "builder-nvt"],
+      ["builder-npt-range", "builder-npt"],
+      ["builder-production-range", "builder-production"],
+      ["builder-temperature-range", "builder-temperature"],
+      ["builder-timestep-range", "builder-timestep"],
+      ["builder-friction-range", "builder-friction"],
+    ];
+    pairs.forEach(([rangeId, numberId]) => syncPair(rangeId, numberId));
+
+    byId("simulation-builder-form")?.addEventListener("input", () => {
+      clearFieldErrors();
+      updateSummary();
+    });
+    byId("simulation-builder-form")?.addEventListener("change", updateSummary);
+    byId("simulation-builder-form")?.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      await launchSimulation();
+    });
+    byId("builder-validate")?.addEventListener("click", validateForm);
+    byId("builder-reset")?.addEventListener("click", () => {
+      if (builder.defaults) populateDefaults(builder.defaults);
+      clearFieldErrors();
+      setMessage("Defaults restored.", "ok");
+    });
+    byId("builder-stop")?.addEventListener("click", stopWorkflow);
+  }
+
+  function syncPair(rangeId, numberId) {
+    const range = byId(rangeId);
+    const number = byId(numberId);
+    if (!range || !number) return;
+    range.addEventListener("input", () => {
+      number.value = range.value;
+      updateSummary();
+    });
+    number.addEventListener("input", () => {
+      const numeric = Number(number.value);
+      const min = Number(range.min);
+      const max = Number(range.max);
+      if (Number.isFinite(numeric)) {
+        range.value = String(Math.max(min, Math.min(max, numeric)));
+      }
+      updateSummary();
+    });
+  }
+
+  function populateDefaults(payload) {
+    const setup = payload.setup || {};
+    const sim = payload.simulation || {};
+    const workflow = payload.workflow || {};
+    const choices = payload.choices || {};
+
+    byId("builder-system").value = payload.system || "1L2Y";
+    byId("builder-run-name").value = payload.run_name || "";
+    fillSelect("builder-forcefield", choices.forcefields || [], setup.forcefield);
+    fillSelect("builder-integrator", choices.integrators || [], sim.integrator);
+    fillSelect("builder-platform", choices.platforms || [], sim.platform);
+    fillSelect("builder-precision", choices.precisions || [], sim.precision);
+
+    setPair("builder-ph-range", "builder-ph", setup.ph);
+    setPair("builder-ion-range", "builder-ion", setup.ion_concentration_M);
+    setPair("builder-padding-range", "builder-padding", setup.solvent_padding_nm);
+    setPair("builder-nvt-range", "builder-nvt", sim.nvt_steps);
+    setPair("builder-npt-range", "builder-npt", sim.npt_steps);
+    setPair("builder-production-range", "builder-production", sim.production_steps);
+    setPair("builder-temperature-range", "builder-temperature", sim.temperature_K);
+    setPair("builder-timestep-range", "builder-timestep", sim.timestep_fs);
+    setPair("builder-friction-range", "builder-friction", sim.friction_per_ps);
+
+    byId("builder-water-model").value = setup.water_model || "auto";
+    byId("builder-keep-heterogens").checked = !!setup.keep_heterogens;
+    byId("builder-keep-water").checked = !!setup.keep_water;
+    byId("builder-minimize").checked = sim.minimize !== false;
+    byId("builder-trajectory-interval").value = sim.trajectory_interval_steps;
+    byId("builder-telemetry-interval").value = sim.telemetry_interval;
+    byId("builder-checkpoint-interval").value = sim.checkpoint_interval_steps;
+
+    byId("builder-run-analysis").checked = workflow.run_analysis !== false;
+    byId("builder-run-report").checked = workflow.run_report !== false;
+    byId("builder-report-document").checked = workflow.report_document !== false;
+    byId("builder-report-slides").checked = workflow.report_slides !== false;
+    byId("builder-report-bundle").checked = workflow.report_bundle !== false;
+    renderAnalysisChoices(choices.analyses || [], workflow.analyses || []);
+    updateSummary();
+  }
+
+  function fillSelect(id, values, selected) {
+    const element = byId(id);
+    if (!element) return;
+    element.innerHTML = "";
+    values.forEach((value) => {
+      const option = document.createElement("option");
+      option.value = value;
+      option.textContent = humanize(value);
+      option.selected = value === selected;
+      element.appendChild(option);
+    });
+  }
+
+  function renderAnalysisChoices(analyses, selected) {
+    const root = byId("builder-analysis-choices");
+    if (!root) return;
+    const chosen = new Set(selected);
+    root.innerHTML = analyses.map((name) => `
+      <label class="analysis-choice">
+        <input type="checkbox" value="${escapeAttr(name)}" ${chosen.has(name) ? "checked" : ""}>
+        <span>${escapeHTML(humanize(name))}</span>
+      </label>`).join("");
+  }
+
+  function setPair(rangeId, numberId, value) {
+    const range = byId(rangeId);
+    const number = byId(numberId);
+    if (range) {
+      const min = Number(range.min);
+      const max = Number(range.max);
+      range.value = String(Math.max(min, Math.min(max, Number(value))));
+    }
+    if (number) number.value = String(value);
+  }
+
+  function collectPayload() {
+    return {
+      system: byId("builder-system")?.value.trim() || "",
+      run_name: byId("builder-run-name")?.value.trim() || "",
+      setup: {
+        forcefield: byId("builder-forcefield")?.value || "charmm36",
+        water_model: byId("builder-water-model")?.value.trim() || "auto",
+        ph: numberValue("builder-ph", 7),
+        ion_concentration_M: numberValue("builder-ion", 0.15),
+        solvent_padding_nm: numberValue("builder-padding", 1),
+        keep_heterogens: !!byId("builder-keep-heterogens")?.checked,
+        keep_water: !!byId("builder-keep-water")?.checked,
+      },
+      simulation: {
+        minimize: !!byId("builder-minimize")?.checked,
+        nvt_steps: integerValue("builder-nvt", 250000),
+        npt_steps: integerValue("builder-npt", 500000),
+        production_steps: integerValue("builder-production", 1000000),
+        timestep_fs: numberValue("builder-timestep", 2),
+        temperature_K: numberValue("builder-temperature", 300),
+        friction_per_ps: numberValue("builder-friction", 1),
+        integrator: byId("builder-integrator")?.value || "langevin_middle",
+        platform: byId("builder-platform")?.value || "auto",
+        precision: byId("builder-precision")?.value || "mixed",
+        trajectory_interval_steps: integerValue("builder-trajectory-interval", 1000),
+        telemetry_interval: integerValue("builder-telemetry-interval", 1000),
+        checkpoint_interval_steps: integerValue("builder-checkpoint-interval", 10000),
+      },
+      workflow: {
+        run_analysis: !!byId("builder-run-analysis")?.checked,
+        run_report: !!byId("builder-run-report")?.checked,
+        report_document: !!byId("builder-report-document")?.checked,
+        report_slides: !!byId("builder-report-slides")?.checked,
+        report_bundle: !!byId("builder-report-bundle")?.checked,
+        analyses: $$("#builder-analysis-choices input:checked").map((input) => input.value),
+      },
+    };
+  }
+
+  function updateSummary() {
+    const payload = collectPayload();
+    const sim = payload.simulation;
+    const timestep = Number(sim.timestep_fs) || 0;
+    const duration = (steps) => Number(steps || 0) * timestep / 1_000_000;
+    const nvt = duration(sim.nvt_steps);
+    const npt = duration(sim.npt_steps);
+    const production = duration(sim.production_steps);
+    const total = nvt + npt + production;
+    const interval = Math.max(1, Number(sim.trajectory_interval_steps) || 1);
+    const frames = Math.ceil(Math.max(0, sim.production_steps) / interval);
+
+    setText("builder-nvt-duration", `${formatNumber(nvt)} ns`);
+    setText("builder-npt-duration", `${formatNumber(npt)} ns`);
+    setText("builder-production-duration", `${formatNumber(production)} ns`);
+    setText("builder-summary-system", payload.system || "—");
+    setText("builder-summary-output", payload.run_name || "auto-generated");
+    setText("builder-summary-nvt", `${formatInteger(sim.nvt_steps)} steps · ${formatNumber(nvt)} ns`);
+    setText("builder-summary-npt", `${formatInteger(sim.npt_steps)} steps · ${formatNumber(npt)} ns`);
+    setText("builder-summary-production", `${formatInteger(sim.production_steps)} steps · ${formatNumber(production)} ns`);
+    setText("builder-summary-total", `${formatNumber(total)} ns`);
+    setText("builder-summary-frames", formatInteger(frames));
+    setText("builder-summary-platform", `${sim.platform} · ${sim.precision}`);
+  }
+
+  async function validateForm() {
+    clearFieldErrors();
+    setMessage("Validating configuration…", "working");
+    try {
+      const result = await postJSON("/api/launcher/validate", collectPayload());
+      builder.lastValidation = result;
+      applyValidation(result);
+      if (result.valid) setMessage("Configuration is valid and ready to launch.", "ok");
+      return result;
+    } catch (error) {
+      const payload = error.payload || {};
+      applyValidation(payload);
+      setMessage(payload.error || "Please correct the highlighted fields.", "error");
+      return payload;
+    }
+  }
+
+  function applyValidation(result) {
+    clearFieldErrors();
+    Object.entries(result.errors || {}).forEach(([key, message]) => {
+      const target = document.querySelector(`[data-error-for="${cssEscape(key)}"]`);
+      if (target) target.textContent = message;
+    });
+    const warnings = result.warnings || [];
+    const warningRoot = byId("builder-warning-list");
+    if (warningRoot) {
+      warningRoot.hidden = warnings.length === 0;
+      warningRoot.innerHTML = warnings.map((warning) => `<div>${escapeHTML(warning)}</div>`).join("");
+    }
+    if (result.output) setText("builder-summary-output", result.output);
+    if (Array.isArray(result.command)) {
+      setText("builder-command-preview", formatCommand(result.command));
+    }
+  }
+
+  async function launchSimulation() {
+    if (builder.appState.process_running) {
+      setMessage("A workflow is already running.", "error");
+      return;
+    }
+    clearFieldErrors();
+    setBusy(true);
+    setMessage("Launching FastMDXplora…", "working");
+    try {
+      const result = await postJSON("/api/launcher/launch", collectPayload());
+      applyValidation(result);
+      if (!result.launched) throw makeRequestError("Launch was not accepted.", result);
+      setMessage(`Workflow launched in ${result.output}`, "ok");
+      applyAppState(result.state || {});
+      window.FastMDXDashboard?.navigate("overview");
+    } catch (error) {
+      const payload = error.payload || {};
+      applyValidation(payload);
+      setMessage(payload.error || error.message || "Could not launch the workflow.", "error");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function stopWorkflow() {
+    if (!window.confirm("Request termination of the running FastMDXplora workflow?")) return;
+    try {
+      const result = await postJSON("/api/launcher/stop", {});
+      applyAppState(result.state || {});
+      setMessage(result.detail || "Termination requested.", result.stopped ? "warning" : "error");
+    } catch (error) {
+      setMessage(error.message || "Could not stop the workflow.", "error");
+    }
+  }
+
+  async function refreshAppState() {
+    try {
+      applyAppState(await requestJSON("/api/app-state"));
+    } catch (_) {
+      // The main dashboard controller owns global connection reporting.
+    }
+  }
+
+  function applyAppState(payload) {
+    builder.appState = payload || {};
+    const running = !!payload.process_running;
+    const status = payload.status || (payload.active_run ? "run" : "idle");
+    const stateRoot = byId("builder-run-state");
+    if (stateRoot) stateRoot.dataset.state = status;
+    setText("builder-state-text", stateLabel(payload));
+    const dot = byId("builder-state-dot");
+    if (dot) {
+      dot.className = `status-dot ${running ? "status-dot-live" : status === "failed" ? "status-dot-error" : status === "completed" ? "status-dot-completed" : "status-dot-waiting"}`;
+    }
+    byId("builder-stop")?.toggleAttribute("hidden", !running);
+    byId("builder-launch")?.toggleAttribute("disabled", running);
+    if (payload.active_run) setText("builder-summary-output", payload.active_run);
+  }
+
+  function stateLabel(payload) {
+    if (payload.process_running) return "Workflow running";
+    if (payload.status === "completed") return "Workflow completed";
+    if (payload.status === "failed") return `Workflow failed${payload.returncode != null ? ` (code ${payload.returncode})` : ""}`;
+    if (payload.active_run) return "Run selected";
+    return "No active workflow";
+  }
+
+  function setBusy(busy) {
+    byId("builder-launch")?.toggleAttribute("disabled", busy || builder.appState.process_running);
+    byId("builder-validate")?.toggleAttribute("disabled", busy);
+  }
+
+  function clearFieldErrors() {
+    $$(".field-error").forEach((element) => { element.textContent = ""; });
+  }
+
+  function setMessage(message, kind) {
+    const element = byId("builder-message");
+    if (!element) return;
+    element.textContent = message || "";
+    element.dataset.kind = kind || "";
+  }
+
+  async function requestJSON(url) {
+    const response = await fetch(url, {cache: "no-store", headers: {"X-FastMDX": "launcher"}});
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) throw makeRequestError(payload.error || `HTTP ${response.status}`, payload);
+    return payload;
+  }
+
+  async function postJSON(url, data) {
+    const response = await fetch(url, {
+      method: "POST",
+      cache: "no-store",
+      headers: {"Content-Type": "application/json", "X-FastMDX": "launcher"},
+      body: JSON.stringify(data),
+    });
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) throw makeRequestError(payload.error || `HTTP ${response.status}`, payload);
+    return payload;
+  }
+
+  function makeRequestError(message, payload) {
+    const error = new Error(message);
+    error.payload = payload;
+    return error;
+  }
+
+  function formatCommand(command) {
+    return command.map((part) => {
+      const value = String(part);
+      return /[\s"']/u.test(value) ? `"${value.replace(/"/g, '\\"')}"` : value;
+    }).join(" ");
+  }
+
+  function numberValue(id, fallback) {
+    const value = Number(byId(id)?.value);
+    return Number.isFinite(value) ? value : fallback;
+  }
+
+  function integerValue(id, fallback) {
+    const value = parseInt(byId(id)?.value, 10);
+    return Number.isFinite(value) ? value : fallback;
+  }
+
+  function formatNumber(value) {
+    const number = Number(value);
+    if (!Number.isFinite(number)) return "—";
+    if (number === 0) return "0";
+    if (Math.abs(number) < 0.001) return number.toExponential(3);
+    return number.toLocaleString(undefined, {maximumFractionDigits: 6});
+  }
+
+  function formatInteger(value) {
+    const number = Number(value);
+    return Number.isFinite(number) ? Math.round(number).toLocaleString() : "—";
+  }
+
+  function humanize(value) {
+    return String(value || "").replace(/[_-]+/g, " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
+  }
+
+  function setText(id, value) {
+    const element = byId(id);
+    if (element) element.textContent = value == null ? "" : String(value);
+  }
+
+  function escapeHTML(value) {
+    return String(value == null ? "" : value).replace(/[&<>"']/g, (character) => ({
+      "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
+    })[character]);
+  }
+
+  function escapeAttr(value) {
+    return escapeHTML(value);
+  }
+
+  function cssEscape(value) {
+    return String(value).replace(/["\\]/g, "\\$&");
+  }
+
+  window.FastMDXBuilder = {
+    collectPayload,
+    validate: validateForm,
+    launch: launchSimulation,
+    refresh: refreshAppState,
+  };
+}());

--- a/src/fastmdxplora/live/structure_info.py
+++ b/src/fastmdxplora/live/structure_info.py
@@ -1,17 +1,15 @@
 """Structure metadata helpers for the live dashboard.
 
-Counts chains, residues, atoms, water molecules, ions, and likely non-protein
-ligands from a PDB file. Designed to be safe for the dashboard: it never
-raises and returns a JSON-serialisable dictionary with sensible fallbacks.
-
-The water/ion/amino-acid residue sets are the canonical copies in
-:mod:`fastmdxplora.live.ligand_detection`; re-imported here so a
-change to one place updates both modules.
+The dashboard needs lightweight, failure-isolated metadata for whichever PDB
+is being displayed.  The helpers in this module deliberately avoid optional
+scientific dependencies: they parse fixed-width PDB records, cache the result
+by file modification time, and always return JSON-serialisable dictionaries.
 """
 
 from __future__ import annotations
 
 from collections import Counter
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -22,144 +20,159 @@ from fastmdxplora.live.ligand_detection import (
     detect_ligands,
 )
 
-# Maximum PDB size the dashboard will scan inline. Anything larger may
-# be a viral capsid or a poorly-prepared system; rather than stall the
-# polling loop we report "too-large" and let the user pre-render.
-_MAX_PDB_BYTES_FOR_INLINE_SCAN = 8 * 1024 * 1024  # 8 MB
-
-# Wide guard against corrupt numeric columns parsing into absurd values
-# (PDB row chunks occasionally misalign on weird lines).
+# Keep the lightweight metadata scanner bounded. The viewer now prefers the
+# prepared solute PDB, so normal dashboard runs avoid parsing a full solvated
+# topology while retaining the original safety limit for unusually large files.
+_MAX_PDB_BYTES_FOR_INLINE_SCAN = 8 * 1024 * 1024
 _COORD_SANITY_LIMIT = 1_000_000.0  # angstrom
 
 
 def count_structure(path: str | Path) -> dict[str, Any]:
-    """Walk a PDB and return chain / residue / atom / ligand counters.
+    """Return chain/residue/atom/ligand counters for a PDB file.
 
-    The returned dictionary is JSON-friendly: every numeric field is int,
-    every list field is a list of strings. Any IO / parse failure yields
-    a ``{"valid": False}`` envelope so the dashboard can render an honest
-    "structure could not be read" state instead of crashing.
+    Results are cached by absolute path, file size, and nanosecond mtime.  A
+    fresh dictionary is returned to callers so API code may safely enrich the
+    payload without mutating the cached value.
     """
+
     p = Path(path)
     if not p.is_file():
         return {"valid": False, "reason": "missing", "path": p.as_posix()}
     try:
-        file_size = p.stat().st_size
+        stat = p.stat()
     except OSError as exc:
         return {"valid": False, "reason": f"stat-error: {exc}", "path": p.as_posix()}
-    if file_size > _MAX_PDB_BYTES_FOR_INLINE_SCAN:
+    if stat.st_size > _MAX_PDB_BYTES_FOR_INLINE_SCAN:
         return {
             "valid": False,
             "reason": "too-large",
             "path": p.as_posix(),
-            "size": file_size,
+            "size": stat.st_size,
+            "max_inline_bytes": _MAX_PDB_BYTES_FOR_INLINE_SCAN,
         }
+    result = _count_structure_cached(
+        str(p.resolve()),
+        int(stat.st_mtime_ns),
+        int(stat.st_size),
+    )
+    return dict(result)
 
-    chains: set[str] = set()
+
+@lru_cache(maxsize=32)
+def _count_structure_cached(
+    path_string: str,
+    _mtime_ns: int,
+    file_size: int,
+) -> dict[str, Any]:
+    p = Path(path_string)
+    protein_chains: set[str] = set()
+    all_chains: set[str] = set()
     protein_residue_keys: set[tuple[str, str, str]] = set()
     non_protein_residue_keys: set[tuple[str, str, str]] = set()
-    waters = 0
-    ions = 0
+    water_residue_keys: set[tuple[str, str, str]] = set()
+    ion_residue_keys: set[tuple[str, str, str]] = set()
+
     atoms = 0
     protein_atoms = 0
     hetatm_atoms = 0
+    water_atoms = 0
+    ion_atoms = 0
     min_coords = [float("inf"), float("inf"), float("inf")]
     max_coords = [float("-inf"), float("-inf"), float("-inf")]
 
     try:
         with p.open("r", encoding="utf-8", errors="ignore") as fh:
             for line in fh:
-                if not (line.startswith("ATOM") or line.startswith("HETATM")):
+                if not line.startswith(("ATOM", "HETATM")):
                     continue
+
                 atoms += 1
-                is_atom = line.startswith("ATOM")
-                if is_atom:
-                    protein_atoms += 1
-                else:
+                is_hetatm = line.startswith("HETATM")
+                if is_hetatm:
                     hetatm_atoms += 1
+
                 chain_id = line[21:22].strip() or "A"
                 resname = line[17:20].strip().upper()
-                resi = line[22:26].strip()
-                chains.add(chain_id)
-
-                # Many PDBs list crystallographic waters/ions as ATOM.
-                # Decide by residue name first so they aren't double
-                # counted as protein, regardless of the record type.
-                if resname in WATER_RESNAMES:
-                    waters += 1
-                    continue
-                if resname in ION_RESNAMES:
-                    ions += 1
-                    continue
-
+                resi = line[22:27].strip()
                 key = (chain_id, resname, resi)
-                if resname in AMINO_ACID_RESNAMES:
-                    protein_residue_keys.add(key)
-                elif is_atom:
-                    # Genuinely a non-water, non-ion ATOM record — rare,
-                    # but found in some ligand-flavoured PDBs. Treat as
-                    # non-protein residue so ligand detection picks it up.
-                    non_protein_residue_keys.add(key)
-                else:
-                    non_protein_residue_keys.add(key)
+                all_chains.add(chain_id)
 
-                # Coordinate parsing (PDB column widths). _COORD_SANITY_LIMIT
-                # only guards against parsing-broken columns; it does not
-                # silently drop otherwise valid coordinates.
+                # Parse coordinates before classifying so the overall extent
+                # remains meaningful even for solvated structures.
                 try:
                     x = float(line[30:38])
                     y = float(line[38:46])
                     z = float(line[46:54])
-                    if all(-_COORD_SANITY_LIMIT <= v <= _COORD_SANITY_LIMIT
-                           for v in (x, y, z)):
-                        min_coords[0] = min(min_coords[0], x)
-                        min_coords[1] = min(min_coords[1], y)
-                        min_coords[2] = min(min_coords[2], z)
-                        max_coords[0] = max(max_coords[0], x)
-                        max_coords[1] = max(max_coords[1], y)
-                        max_coords[2] = max(max_coords[2], z)
+                    if all(
+                        -_COORD_SANITY_LIMIT <= value <= _COORD_SANITY_LIMIT
+                        for value in (x, y, z)
+                    ):
+                        for idx, value in enumerate((x, y, z)):
+                            min_coords[idx] = min(min_coords[idx], value)
+                            max_coords[idx] = max(max_coords[idx], value)
                 except (ValueError, IndexError):
                     pass
+
+                if resname in WATER_RESNAMES:
+                    water_atoms += 1
+                    water_residue_keys.add(key)
+                    continue
+                if resname in ION_RESNAMES:
+                    ion_atoms += 1
+                    ion_residue_keys.add(key)
+                    continue
+                if resname in AMINO_ACID_RESNAMES:
+                    protein_atoms += 1
+                    protein_chains.add(chain_id)
+                    protein_residue_keys.add(key)
+                    continue
+
+                # Any remaining residue is a ligand/cofactor candidate.  The
+                # detector applies its own cofactor exclusions.
+                non_protein_residue_keys.add(key)
     except OSError as exc:
         return {"valid": False, "reason": f"read-error: {exc}", "path": p.as_posix()}
 
-    # Ligand detection consumes *non-protein* residue keys so amino-acid
-    # counts never get mixed into the ligand panel.
     ligand_info = detect_ligands(non_protein_residue_keys)
-    bounding_extent = (
-        [max_coords[i] - min_coords[i] if min_coords[i] != float("inf") else 0.0
-         for i in range(3)]
-        if min_coords[0] != float("inf")
-        else [0.0, 0.0, 0.0]
-    )
+    if min_coords[0] == float("inf"):
+        bounding_extent = [0.0, 0.0, 0.0]
+        centroid: list[float | None] = [None, None, None]
+    else:
+        bounding_extent = [max_coords[i] - min_coords[i] for i in range(3)]
+        centroid = [(min_coords[i] + max_coords[i]) / 2 for i in range(3)]
+
     return {
         "valid": True,
         "path": p.as_posix(),
+        "size": file_size,
         "atoms": atoms,
         "protein_atoms": protein_atoms,
         "hetatm_atoms": hetatm_atoms,
-        "chains": sorted(chains),
-        "n_chains": len(chains),
+        "water_atoms": water_atoms,
+        "ion_atoms": ion_atoms,
+        "chains": sorted(protein_chains or all_chains),
+        "all_chains": sorted(all_chains),
+        "n_chains": len(protein_chains or all_chains),
         "protein_residues": len(protein_residue_keys),
-        "water_residues": waters,
-        "ions": ions,
+        "water_residues": len(water_residue_keys),
+        "ions": len(ion_residue_keys),
         "ligand_residues_total": len(ligand_info["instances"]),
         "ligand_resnames": ligand_info["resnames"],
         "ligand_instances": ligand_info["instances"],
-        "extents_angstrom": [round(v, 2) for v in bounding_extent],
+        "extents_angstrom": [round(value, 2) for value in bounding_extent],
         "centroid_angstrom": [
-            round((min_coords[i] + max_coords[i]) / 2, 2) if min_coords[i] != float("inf") else None
-            for i in range(3)
+            round(value, 2) if value is not None else None for value in centroid
         ],
     }
 
 
 def ligand_atom_counts(path: str | Path) -> dict[str, int]:
-    """Return a Counter of ligand residue names → atom count.
+    """Return ligand residue-name to atom-count mappings.
 
-    Useful for the ligand tools pane of the molecular viewer. Returns an
-    empty dict if the path doesn't exist or can't be read.
+    Both ``ATOM`` and ``HETATM`` records are considered because some input
+    generators encode small molecules using ``ATOM`` records.
     """
+
     p = Path(path)
     if not p.is_file():
         return {}
@@ -167,10 +180,14 @@ def ligand_atom_counts(path: str | Path) -> dict[str, int]:
     try:
         with p.open("r", encoding="utf-8", errors="ignore") as fh:
             for line in fh:
-                if not line.startswith("HETATM"):
+                if not line.startswith(("ATOM", "HETATM")):
                     continue
                 resname = line[17:20].strip().upper()
-                if resname in WATER_RESNAMES or resname in ION_RESNAMES:
+                if (
+                    resname in WATER_RESNAMES
+                    or resname in ION_RESNAMES
+                    or resname in AMINO_ACID_RESNAMES
+                ):
                     continue
                 counts[resname] += 1
     except OSError:

--- a/src/fastmdxplora/live/structure_info.py
+++ b/src/fastmdxplora/live/structure_info.py
@@ -1,0 +1,178 @@
+"""Structure metadata helpers for the live dashboard.
+
+Counts chains, residues, atoms, water molecules, ions, and likely non-protein
+ligands from a PDB file. Designed to be safe for the dashboard: it never
+raises and returns a JSON-serialisable dictionary with sensible fallbacks.
+
+The water/ion/amino-acid residue sets are the canonical copies in
+:mod:`fastmdxplora.live.ligand_detection`; re-imported here so a
+change to one place updates both modules.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from fastmdxplora.live.ligand_detection import (
+    AMINO_ACID_RESNAMES,
+    ION_RESNAMES,
+    WATER_RESNAMES,
+    detect_ligands,
+)
+
+# Maximum PDB size the dashboard will scan inline. Anything larger may
+# be a viral capsid or a poorly-prepared system; rather than stall the
+# polling loop we report "too-large" and let the user pre-render.
+_MAX_PDB_BYTES_FOR_INLINE_SCAN = 8 * 1024 * 1024  # 8 MB
+
+# Wide guard against corrupt numeric columns parsing into absurd values
+# (PDB row chunks occasionally misalign on weird lines).
+_COORD_SANITY_LIMIT = 1_000_000.0  # angstrom
+
+
+def count_structure(path: str | Path) -> dict[str, Any]:
+    """Walk a PDB and return chain / residue / atom / ligand counters.
+
+    The returned dictionary is JSON-friendly: every numeric field is int,
+    every list field is a list of strings. Any IO / parse failure yields
+    a ``{"valid": False}`` envelope so the dashboard can render an honest
+    "structure could not be read" state instead of crashing.
+    """
+    p = Path(path)
+    if not p.is_file():
+        return {"valid": False, "reason": "missing", "path": p.as_posix()}
+    try:
+        file_size = p.stat().st_size
+    except OSError as exc:
+        return {"valid": False, "reason": f"stat-error: {exc}", "path": p.as_posix()}
+    if file_size > _MAX_PDB_BYTES_FOR_INLINE_SCAN:
+        return {
+            "valid": False,
+            "reason": "too-large",
+            "path": p.as_posix(),
+            "size": file_size,
+        }
+
+    chains: set[str] = set()
+    protein_residue_keys: set[tuple[str, str, str]] = set()
+    non_protein_residue_keys: set[tuple[str, str, str]] = set()
+    waters = 0
+    ions = 0
+    atoms = 0
+    protein_atoms = 0
+    hetatm_atoms = 0
+    min_coords = [float("inf"), float("inf"), float("inf")]
+    max_coords = [float("-inf"), float("-inf"), float("-inf")]
+
+    try:
+        with p.open("r", encoding="utf-8", errors="ignore") as fh:
+            for line in fh:
+                if not (line.startswith("ATOM") or line.startswith("HETATM")):
+                    continue
+                atoms += 1
+                is_atom = line.startswith("ATOM")
+                if is_atom:
+                    protein_atoms += 1
+                else:
+                    hetatm_atoms += 1
+                chain_id = line[21:22].strip() or "A"
+                resname = line[17:20].strip().upper()
+                resi = line[22:26].strip()
+                chains.add(chain_id)
+
+                # Many PDBs list crystallographic waters/ions as ATOM.
+                # Decide by residue name first so they aren't double
+                # counted as protein, regardless of the record type.
+                if resname in WATER_RESNAMES:
+                    waters += 1
+                    continue
+                if resname in ION_RESNAMES:
+                    ions += 1
+                    continue
+
+                key = (chain_id, resname, resi)
+                if resname in AMINO_ACID_RESNAMES:
+                    protein_residue_keys.add(key)
+                elif is_atom:
+                    # Genuinely a non-water, non-ion ATOM record — rare,
+                    # but found in some ligand-flavoured PDBs. Treat as
+                    # non-protein residue so ligand detection picks it up.
+                    non_protein_residue_keys.add(key)
+                else:
+                    non_protein_residue_keys.add(key)
+
+                # Coordinate parsing (PDB column widths). _COORD_SANITY_LIMIT
+                # only guards against parsing-broken columns; it does not
+                # silently drop otherwise valid coordinates.
+                try:
+                    x = float(line[30:38])
+                    y = float(line[38:46])
+                    z = float(line[46:54])
+                    if all(-_COORD_SANITY_LIMIT <= v <= _COORD_SANITY_LIMIT
+                           for v in (x, y, z)):
+                        min_coords[0] = min(min_coords[0], x)
+                        min_coords[1] = min(min_coords[1], y)
+                        min_coords[2] = min(min_coords[2], z)
+                        max_coords[0] = max(max_coords[0], x)
+                        max_coords[1] = max(max_coords[1], y)
+                        max_coords[2] = max(max_coords[2], z)
+                except (ValueError, IndexError):
+                    pass
+    except OSError as exc:
+        return {"valid": False, "reason": f"read-error: {exc}", "path": p.as_posix()}
+
+    # Ligand detection consumes *non-protein* residue keys so amino-acid
+    # counts never get mixed into the ligand panel.
+    ligand_info = detect_ligands(non_protein_residue_keys)
+    bounding_extent = (
+        [max_coords[i] - min_coords[i] if min_coords[i] != float("inf") else 0.0
+         for i in range(3)]
+        if min_coords[0] != float("inf")
+        else [0.0, 0.0, 0.0]
+    )
+    return {
+        "valid": True,
+        "path": p.as_posix(),
+        "atoms": atoms,
+        "protein_atoms": protein_atoms,
+        "hetatm_atoms": hetatm_atoms,
+        "chains": sorted(chains),
+        "n_chains": len(chains),
+        "protein_residues": len(protein_residue_keys),
+        "water_residues": waters,
+        "ions": ions,
+        "ligand_residues_total": len(ligand_info["instances"]),
+        "ligand_resnames": ligand_info["resnames"],
+        "ligand_instances": ligand_info["instances"],
+        "extents_angstrom": [round(v, 2) for v in bounding_extent],
+        "centroid_angstrom": [
+            round((min_coords[i] + max_coords[i]) / 2, 2) if min_coords[i] != float("inf") else None
+            for i in range(3)
+        ],
+    }
+
+
+def ligand_atom_counts(path: str | Path) -> dict[str, int]:
+    """Return a Counter of ligand residue names → atom count.
+
+    Useful for the ligand tools pane of the molecular viewer. Returns an
+    empty dict if the path doesn't exist or can't be read.
+    """
+    p = Path(path)
+    if not p.is_file():
+        return {}
+    counts: Counter[str] = Counter()
+    try:
+        with p.open("r", encoding="utf-8", errors="ignore") as fh:
+            for line in fh:
+                if not line.startswith("HETATM"):
+                    continue
+                resname = line[17:20].strip().upper()
+                if resname in WATER_RESNAMES or resname in ION_RESNAMES:
+                    continue
+                counts[resname] += 1
+    except OSError:
+        return {}
+    return dict(counts)

--- a/src/fastmdxplora/live/telemetry.py
+++ b/src/fastmdxplora/live/telemetry.py
@@ -16,6 +16,16 @@ STATUS_FILE = "live_status.json"
 METRICS_FILE = "live_metrics.csv"
 EVENTS_FILE = "live_events.log"
 
+STAGE_ORDER = (
+    "setup",
+    "minimization",
+    "nvt",
+    "npt",
+    "production",
+    "analysis",
+    "report",
+)
+
 METRIC_FIELDS = [
     "timestamp",
     "stage",
@@ -27,6 +37,9 @@ METRIC_FIELDS = [
     "temperature",
     "volume",
     "density",
+    "speed",
+    "pressure",
+    "current_frame_count",
     "progress_percent",
 ]
 
@@ -101,11 +114,20 @@ class TelemetryWriter:
         return self.root / EVENTS_FILE
 
     def write_status(self, **updates: Any) -> None:
+        """Atomically update the shared live-status document.
+
+        The project orchestrator and the OpenMM runner use separate writer
+        instances.  Reading the on-disk document before every update keeps
+        phase and sub-stage history intact when control moves from setup to
+        simulation to analysis/report.  The file is dashboard-only telemetry;
+        none of these values are read back into OpenMM.
+        """
         if not self.enabled:
             return
         try:
             self.root.mkdir(parents=True, exist_ok=True)
             now = datetime.now(timezone.utc)
+            persisted = _read_status_path(self.status_path)
             status = {
                 "stage": "not available",
                 "status": "running",
@@ -113,19 +135,34 @@ class TelemetryWriter:
                 "total_planned_steps": self.total_steps,
                 "current_frame_count": None,
                 "planned_frame_count": self.planned_frames,
-                "elapsed_wall_time_s": round((now - self.start_time).total_seconds(), 3),
                 "simulation_time_completed_ns": None,
                 "timestep_fs": self.timestep_fs,
                 "platform": self.platform,
                 "target_temperature_K": self.target_temperature_K,
-                "last_update_timestamp": _utc_now(),
                 "current_checkpoint_path": None,
                 "latest_warning": None,
                 "latest_error": None,
+                "stage_states": {name: "waiting" for name in STAGE_ORDER},
+                "run_started_at": self.start_time.isoformat(),
             }
             status.update(self._last_status)
+            # On-disk data may have been written by the simulation runner or
+            # orchestrator since this instance last wrote. It is therefore
+            # newer than this instance's cache.
+            status.update(persisted)
             status.update({k: v for k, v in updates.items() if v is not None})
-            status["elapsed_wall_time_s"] = round((now - self.start_time).total_seconds(), 3)
+
+            states = status.get("stage_states")
+            if not isinstance(states, dict):
+                states = {}
+            status["stage_states"] = {
+                name: str(states.get(name, "waiting")).lower()
+                for name in STAGE_ORDER
+            }
+
+            started = _parse_iso_datetime(status.get("run_started_at")) or self.start_time
+            status["run_started_at"] = started.isoformat()
+            status["elapsed_wall_time_s"] = round((now - started).total_seconds(), 3)
             status["last_update_timestamp"] = _utc_now()
             self._last_status = dict(status)
             tmp = self.status_path.with_suffix(".json.tmp")
@@ -133,6 +170,33 @@ class TelemetryWriter:
             os.replace(tmp, self.status_path)
         except Exception:
             return
+
+    def mark_stage(
+        self,
+        stage: str,
+        state: str,
+        *,
+        status: str | None = None,
+        **updates: Any,
+    ) -> None:
+        """Record one timeline stage without erasing the other stages."""
+        name = str(stage or "").strip().lower()
+        if name not in STAGE_ORDER:
+            return
+        persisted = _read_status_path(self.status_path)
+        states = persisted.get("stage_states")
+        if not isinstance(states, dict):
+            states = {}
+        merged = {item: str(states.get(item, "waiting")).lower() for item in STAGE_ORDER}
+        merged[name] = str(state or "waiting").lower()
+        payload = dict(updates)
+        payload.update({
+            "stage": name,
+            "stage_states": merged,
+        })
+        if status is not None:
+            payload["status"] = status
+        self.write_status(**payload)
 
     def append_metric(self, **row: Any) -> None:
         if not self.enabled:
@@ -161,6 +225,26 @@ class TelemetryWriter:
             return
 
 
+def _read_status_path(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _parse_iso_datetime(value: Any) -> datetime | None:
+    if value in (None, ""):
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
 def read_status(project_root: str | Path) -> dict[str, Any]:
     path = _simulation_dir(project_root) / STATUS_FILE
     try:
@@ -171,13 +255,96 @@ def read_status(project_root: str | Path) -> dict[str, Any]:
 
 
 def read_metrics(project_root: str | Path, *, limit: int = 500) -> list[dict[str, Any]]:
-    path = _simulation_dir(project_root) / METRICS_FILE
+    """Read dashboard metrics, enriching them from OpenMM's ``energy.csv``.
+
+    Older runs and very short smoke tests may have only one of the two files.
+    The live CSV has stable FastMDX field names, while OpenMM's reporter uses
+    human-readable headings that vary slightly by version.  Normalising and
+    merging both sources keeps the dashboard useful for live and completed
+    runs without changing the scientific output files.
+    """
+
+    simulation_dir = _simulation_dir(project_root)
+    live_rows = _read_csv_rows(simulation_dir / METRICS_FILE)
+    energy_rows = _read_energy_rows(simulation_dir / "energy.csv")
+
+    if live_rows and energy_rows:
+        energy_by_step = {
+            str(row.get("step")): row
+            for row in energy_rows
+            if row.get("step") not in (None, "")
+        }
+        merged: list[dict[str, Any]] = []
+        for row in live_rows:
+            item = dict(row)
+            fallback = energy_by_step.get(str(item.get("step")), {})
+            for key, value in fallback.items():
+                if item.get(key) in (None, "") and value not in (None, ""):
+                    item[key] = value
+            merged.append(item)
+        rows = merged
+    else:
+        rows = live_rows or energy_rows
+
+    # The frame count is status-level information in older telemetry schemas.
+    # Attach it to the latest sample so overview metric cards can still render.
+    if rows:
+        status = read_status(project_root)
+        frame_count = status.get("current_frame_count")
+        if frame_count is not None and rows[-1].get("current_frame_count") in (None, ""):
+            rows[-1]["current_frame_count"] = str(frame_count)
+    return rows[-limit:]
+
+
+def _read_csv_rows(path: Path) -> list[dict[str, Any]]:
     try:
         with path.open(newline="", encoding="utf-8") as fh:
-            rows = list(csv.DictReader(fh))
+            return list(csv.DictReader(fh))
     except OSError:
         return []
-    return rows[-limit:]
+
+
+def _read_energy_rows(path: Path) -> list[dict[str, Any]]:
+    raw_rows = _read_csv_rows(path)
+    result: list[dict[str, Any]] = []
+    for raw in raw_rows:
+        row: dict[str, Any] = {}
+        for original_key, value in raw.items():
+            if original_key is None:
+                continue
+            key = _normalise_energy_header(original_key)
+            if key:
+                row[key] = value
+        time_ps = _safe_float(row.pop("time_ps", None))
+        if time_ps is not None:
+            row["simulation_time_ns"] = str(time_ps / 1000.0)
+        if row:
+            row.setdefault("stage", "production")
+            row.setdefault("timestamp", "")
+            result.append(row)
+    return result
+
+
+def _normalise_energy_header(header: str) -> str | None:
+    cleaned = header.strip().lstrip("\ufeff#").strip().strip('"')
+    key = " ".join(cleaned.lower().split())
+    aliases = {
+        "step": "step",
+        "time (ps)": "time_ps",
+        "potential energy (kj/mole)": "potential_energy",
+        "potential energy (kj/mol)": "potential_energy",
+        "kinetic energy (kj/mole)": "kinetic_energy",
+        "kinetic energy (kj/mol)": "kinetic_energy",
+        "total energy (kj/mole)": "total_energy",
+        "total energy (kj/mol)": "total_energy",
+        "temperature (k)": "temperature",
+        "box volume (nm^3)": "volume",
+        "volume (nm^3)": "volume",
+        "density (g/ml)": "density",
+        "speed (ns/day)": "speed",
+        "progress (%)": "progress_percent",
+    }
+    return aliases.get(key)
 
 
 def read_events(project_root: str | Path, *, limit: int = 100) -> list[dict[str, str]]:

--- a/src/fastmdxplora/live/templates/dashboard.html
+++ b/src/fastmdxplora/live/templates/dashboard.html
@@ -1,0 +1,676 @@
+<!doctype html>
+<html lang="en" data-page="overview">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="dark">
+  <title>FastMDXplora Live Dashboard</title>
+  <link rel="icon" type="image/svg+xml" href="/static/aai-research-mark.svg">
+  <link rel="stylesheet" href="/static/dashboard.css">
+  <meta name="fastmdx-expansion" content="Fully Automated SysTem for Molecular Dynamics eXploration">
+</head>
+<body class="state-loading">
+  <!-- Loading screen -->
+  <div id="loading-screen" class="loading-screen" aria-hidden="false">
+    <div class="loading-shell">
+      <img class="loading-logo" src="/static/aai-research-logo.svg" alt="AAI Research Lab">
+      <div class="loading-product">FastMDXplora</div>
+      <div class="loading-tagline">Fully Automated SysTem for Molecular Dynamics eXploration</div>
+      <div class="loading-status" id="loading-status">
+        <div class="loading-step" data-step="telemetry">
+          <span class="loading-bullet"></span>
+          <span class="loading-label">Connecting to telemetry</span>
+        </div>
+        <div class="loading-step" data-step="structure">
+          <span class="loading-bullet"></span>
+          <span class="loading-label">Loading molecular structure</span>
+        </div>
+        <div class="loading-step" data-step="metrics">
+          <span class="loading-bullet"></span>
+          <span class="loading-label">Preparing simulation metrics</span>
+        </div>
+      </div>
+      <div class="loading-particles" aria-hidden="true"></div>
+      <div class="loading-watermark" aria-hidden="true"></div>
+    </div>
+  </div>
+
+  <!-- Empty state (AAI watermark fallback for terminal states without data) -->
+  <div id="empty-watermark-template" hidden aria-hidden="true">
+    <svg class="empty-watermark" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+      <use href="/static/aai-research-mark.svg#mark"/>
+    </svg>
+  </div>
+
+  <div class="app-shell">
+    <!-- Sidebar -->
+    <aside class="sidebar" aria-label="Dashboard navigation">
+      <div class="sidebar-brand">
+        <img class="brand-logo" src="/static/aai-research-logo.svg" alt="AAI Research Lab">
+        <div class="brand-text">
+          <div class="brand-product">FastMDXplora</div>
+          <div class="brand-tagline">Fully Automated SysTem for Molecular Dynamics eXploration</div>
+        </div>
+      </div>
+      <nav class="sidebar-nav" role="navigation" aria-label="Dashboard sections">
+        <div class="nav-heading">Workspace</div>
+        <a href="#" class="nav-link" data-view-link="overview">
+          <span class="nav-icon" aria-hidden="true"></span>
+          <span>Overview</span>
+        </a>
+        <a href="#" class="nav-link" data-view-link="live">
+          <span class="nav-icon" aria-hidden="true"></span>
+          <span>Live Simulation</span>
+        </a>
+        <a href="#" class="nav-link" data-view-link="viewer">
+          <span class="nav-icon" aria-hidden="true"></span>
+          <span>Molecular Viewer</span>
+        </a>
+        <a href="#" class="nav-link" data-view-link="analysis">
+          <span class="nav-icon" aria-hidden="true"></span>
+          <span>Analysis</span>
+        </a>
+        <a href="#" class="nav-link" data-view-link="files">
+          <span class="nav-icon" aria-hidden="true"></span>
+          <span>Files &amp; Reports</span>
+        </a>
+        <div class="nav-heading">Tools</div>
+        <a href="#" class="nav-link" data-view-link="settings">
+          <span class="nav-icon" aria-hidden="true"></span>
+          <span>Settings</span>
+        </a>
+        <a href="https://fastmdxplora.readthedocs.io/en/latest/live_dashboard.html"
+           class="nav-link" target="_blank" rel="noopener">
+          <span class="nav-icon" aria-hidden="true"></span>
+          <span>Documentation</span>
+        </a>
+        <a href="https://github.com/aai-research-lab/FastMDXplora"
+           class="nav-link" target="_blank" rel="noopener">
+          <span class="nav-icon" aria-hidden="true"></span>
+          <span>GitHub</span>
+        </a>
+      </nav>
+      <div class="sidebar-footer">
+        <div class="footer-row">
+          <div class="footer-label">Connection</div>
+          <div class="footer-value">
+            <span class="status-dot status-dot-live" id="sidebar-status-dot"></span>
+            <span id="sidebar-connection-state">Live</span>
+          </div>
+        </div>
+        <div class="footer-row">
+          <div class="footer-label">Run</div>
+          <div class="footer-value" id="sidebar-run-name">not available</div>
+        </div>
+        <div class="footer-row">
+          <div class="footer-label">Platform</div>
+          <div class="footer-value" id="sidebar-platform">not available</div>
+        </div>
+      </div>
+    </aside>
+
+    <!-- Main content -->
+    <div class="main">
+      <!-- Top bar -->
+      <header class="top-bar">
+        <div class="top-bar-left">
+          <div class="run-id" id="topbar-run-id">system</div>
+          <div class="run-title" id="topbar-run-title">FastMDXplora Live</div>
+        </div>
+        <div class="top-bar-center">
+          <div class="status-cluster" role="status" aria-live="polite">
+            <span class="status-dot status-dot-live" id="topbar-status-dot"></span>
+            <span class="status-text" id="topbar-status-text">live</span>
+            <span class="status-divider" aria-hidden="true">·</span>
+            <span class="status-text-muted" id="topbar-stage">not available</span>
+          </div>
+          <div class="metric-cluster">
+            <div class="metric"><span class="metric-label">Step</span><span class="metric-value mono" id="topbar-step">—</span></div>
+            <div class="metric"><span class="metric-label">Total</span><span class="metric-value mono" id="topbar-total">—</span></div>
+            <div class="metric"><span class="metric-label">Platform</span><span class="metric-value mono" id="topbar-platform">—</span></div>
+            <div class="metric"><span class="metric-label">Temp</span><span class="metric-value mono" id="topbar-temperature">—</span></div>
+          </div>
+        </div>
+        <div class="top-bar-right">
+          <button class="ghost-btn" type="button" id="pause-toggle" aria-pressed="false" title="Pause browser updates only (does not pause the OpenMM simulation)">
+            <span id="pause-label">Pause Updates</span>
+          </button>
+          <button class="ghost-btn" type="button" id="refresh-now" title="Refresh now">
+            Refresh
+          </button>
+          <button class="ghost-btn" type="button" id="open-output" title="Open output folder">
+            Open Output
+          </button>
+          <span class="muted" id="refreshed-indicator">Last refreshed: <span id="refreshed-at">just now</span></span>
+        </div>
+      </header>
+
+      <!-- Page views -->
+      <main class="page-shell" role="main">
+        <!-- Loading shell renders here once data arrives -->
+        <section class="page" data-page="overview" data-status="loading">
+          <div class="page-header">
+            <div>
+              <h1 class="page-title">Overview</h1>
+              <div class="page-subtitle">Health, run status, and quick actions</div>
+            </div>
+          </div>
+          <div class="grid grid-2">
+            <div class="card hero-card" id="hero-card" data-state="running">
+              <div class="hero-card-top">
+                <div>
+                  <div class="hero-label">Run status</div>
+                  <div class="hero-status">not available</div>
+                </div>
+                <span class="stage-pill mono" id="hero-stage">—</span>
+              </div>
+              <div class="progress-large" aria-hidden="true">
+                <div class="progress-large-track">
+                  <div class="progress-large-fill" id="hero-progress-fill" style="width:0%"></div>
+                </div>
+                <div class="progress-large-meta">
+                  <span class="mono"><span id="hero-progress-pct">—</span>% complete</span>
+                  <span class="muted">sim time <span class="mono" id="hero-sim-time">—</span> ns</span>
+                </div>
+              </div>
+              <div class="hero-grid">
+                <div class="hero-stat">
+                  <div class="hero-stat-label">Elapsed wall time</div>
+                  <div class="hero-stat-value mono" id="hero-elapsed">—</div>
+                </div>
+                <div class="hero-stat">
+                  <div class="hero-stat-label">ETA</div>
+                  <div class="hero-stat-value mono" id="hero-eta">—</div>
+                </div>
+                <div class="hero-stat">
+                  <div class="hero-stat-label">Step</div>
+                  <div class="hero-stat-value mono" id="hero-step">—</div>
+                </div>
+              </div>
+            </div>
+            <div class="card hero-card" id="hero-health" data-state="normal">
+              <div class="hero-card-top">
+                <div>
+                  <div class="hero-label">Simulation health</div>
+                  <div class="hero-status" id="health-headline">not available</div>
+                </div>
+                <span class="stage-pill" id="health-pill">normal</span>
+              </div>
+              <p class="muted" id="health-explanation">Live health classification will appear once telemetry has been written.</p>
+              <ul class="health-list" id="health-list" role="list"></ul>
+            </div>
+          </div>
+
+          <div class="card stage-timeline-card">
+            <div class="card-header">
+              <h2 class="card-title">Stage timeline</h2>
+            </div>
+            <ol class="stage-timeline" id="stage-timeline">
+              <li class="stage-step" data-stage="setup"><span class="stage-marker"></span><span class="stage-label">Setup</span></li>
+              <li class="stage-step" data-stage="minimization"><span class="stage-marker"></span><span class="stage-label">Minimization</span></li>
+              <li class="stage-step" data-stage="nvt"><span class="stage-marker"></span><span class="stage-label">NVT</span></li>
+              <li class="stage-step" data-stage="npt"><span class="stage-marker"></span><span class="stage-label">NPT</span></li>
+              <li class="stage-step" data-stage="production"><span class="stage-marker"></span><span class="stage-label">Production</span></li>
+              <li class="stage-step" data-stage="analysis"><span class="stage-marker"></span><span class="stage-label">Analysis</span></li>
+              <li class="stage-step" data-stage="report"><span class="stage-marker"></span><span class="stage-label">Report</span></li>
+            </ol>
+          </div>
+
+          <div class="grid grid-3 metric-cards" id="overview-metric-cards">
+            <div class="metric-card" data-metric="potential_energy">
+              <div class="metric-card-label">Potential energy</div>
+              <div class="metric-card-value mono" data-value>—</div>
+              <div class="metric-card-unit">kJ/mol</div>
+            </div>
+            <div class="metric-card" data-metric="temperature">
+              <div class="metric-card-label">Temperature</div>
+              <div class="metric-card-value mono" data-value>—</div>
+              <div class="metric-card-unit">K</div>
+            </div>
+            <div class="metric-card" data-metric="density">
+              <div class="metric-card-label">Density</div>
+              <div class="metric-card-value mono" data-value>—</div>
+              <div class="metric-card-unit">g/mL</div>
+            </div>
+            <div class="metric-card" data-metric="speed">
+              <div class="metric-card-label">Simulation speed</div>
+              <div class="metric-card-value mono" data-value>—</div>
+              <div class="metric-card-unit">ns/day</div>
+            </div>
+            <div class="metric-card" data-metric="frames">
+              <div class="metric-card-label">Frames written</div>
+              <div class="metric-card-value mono" data-value>—</div>
+              <div class="metric-card-unit">frames</div>
+            </div>
+            <div class="metric-card" data-metric="pressure">
+              <div class="metric-card-label">Pressure</div>
+              <div class="metric-card-value mono" data-value>—</div>
+              <div class="metric-card-unit">bar</div>
+            </div>
+          </div>
+        </section>
+
+        <section class="page" data-page="live" hidden>
+          <div class="page-header">
+            <div>
+              <h1 class="page-title">Live Simulation</h1>
+              <div class="page-subtitle">Detailed progress, live charts, and the latest events</div>
+            </div>
+          </div>
+          <div class="grid grid-2">
+            <div class="card">
+              <div class="card-header"><h2 class="card-title">Progress</h2></div>
+              <div class="progress-large">
+                <div class="progress-large-track">
+                  <div class="progress-large-fill" id="live-progress-fill" style="width:0%"></div>
+                </div>
+                <div class="progress-large-meta">
+                  <span class="mono"><span id="live-progress-pct">—</span>% complete</span>
+                  <span class="muted">sim time <span class="mono" id="live-sim-time">—</span> ns</span>
+                </div>
+              </div>
+              <table class="kv-table mono">
+                <tbody>
+                  <tr><th>Current stage</th><td id="live-stage-cell">not available</td></tr>
+                  <tr><th>Current step</th><td id="live-step-cell">not available</td></tr>
+                  <tr><th>Total planned steps</th><td id="live-total-cell">not available</td></tr>
+                  <tr><th>Frames written</th><td id="live-frames-cell">not available</td></tr>
+                  <tr><th>Simulation time</th><td id="live-simtime-cell">not available</td></tr>
+                  <tr><th>Elapsed wall time</th><td id="live-elapsed-cell">not available</td></tr>
+                  <tr><th>ETA</th><td id="live-eta-cell">not available</td></tr>
+                  <tr><th>Checkpoint</th><td id="live-checkpoint-cell">not available</td></tr>
+                  <tr><th>Last update</th><td id="live-lastupdate-cell">not available</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <div class="card">
+              <div class="card-header">
+                <h2 class="card-title">Mini molecular preview</h2>
+                <a href="#" class="ghost-link" data-view-link="viewer">Open full viewer</a>
+              </div>
+              <div class="preview-frame" id="mini-preview-frame">
+                <div class="preview-empty" id="mini-preview-empty">
+                  Waiting for a structure file…
+                </div>
+              </div>
+              <p class="muted small">Updates automatically as the simulation progresses.</p>
+            </div>
+          </div>
+
+          <div class="card">
+            <div class="card-header">
+              <h2 class="card-title">Live charts</h2>
+              <div class="card-header-actions">
+                <select class="metric-select" id="chart-metric-select" aria-label="Chart metric"></select>
+                <button class="ghost-btn" type="button" id="chart-reset">Reset zoom</button>
+              </div>
+            </div>
+            <div class="chart-stack" id="chart-stack">
+              <div class="chart-row">
+                <canvas class="chart-canvas" data-chart="potential_energy" data-color="cyan" width="900" height="220"></canvas>
+                <div class="chart-title">Potential energy (kJ/mol)</div>
+              </div>
+              <div class="chart-row">
+                <canvas class="chart-canvas" data-chart="temperature" data-color="orange" width="900" height="220"></canvas>
+                <div class="chart-title">Temperature (K)</div>
+              </div>
+              <div class="chart-row">
+                <canvas class="chart-canvas" data-chart="density" data-color="violet" width="900" height="220"></canvas>
+                <div class="chart-title">Density (g/mL)</div>
+              </div>
+              <div class="chart-row">
+                <canvas class="chart-canvas" data-chart="speed" data-color="silver" width="900" height="220"></canvas>
+                <div class="chart-title">Simulation speed (ns/day, derived)</div>
+              </div>
+            </div>
+            <div class="chart-empty muted" id="chart-empty">Live telemetry will appear after the first sample.</div>
+          </div>
+
+          <div class="grid grid-2">
+            <div class="card">
+              <div class="card-header">
+                <h2 class="card-title">Simulation health</h2>
+                <span class="stage-pill" id="live-health-pill">normal</span>
+              </div>
+              <p id="live-health-message">not available</p>
+              <p class="muted" id="live-health-explanation">Plain-English explanation of the latest sample.</p>
+            </div>
+            <div class="card">
+              <div class="card-header"><h2 class="card-title">Recent events</h2></div>
+              <ul class="events-list" id="events-list"></ul>
+            </div>
+          </div>
+        </section>
+
+        <section class="page" data-page="viewer" hidden>
+          <div class="page-header">
+            <div>
+              <h1 class="page-title">Molecular Viewer</h1>
+              <div class="page-subtitle">Live molecular canvas, ligand tools, trajectory playback</div>
+            </div>
+          </div>
+          <div class="viewer-layout">
+            <div class="viewer-canvas-wrap">
+              <div class="viewer-canvas-frame" id="viewer-canvas-frame">
+                <div id="viewer-canvas" class="viewer-canvas" aria-label="Molecular viewer canvas"></div>
+                <div class="viewer-empty" id="viewer-empty">
+                  <div class="empty-watermark"></div>
+                  <div class="empty-title">Waiting for structure</div>
+                  <div class="empty-detail muted">The 3D viewer will initialize when a topology or prepared PDB becomes available.</div>
+                </div>
+              </div>
+              <div class="viewer-overlay" id="viewer-overlay" data-live="false">
+                <span class="overlay-tag" id="overlay-tag">offline</span>
+                <span class="overlay-detail mono" id="overlay-stage">—</span>
+                <span class="overlay-detail mono" id="overlay-frame">frame —</span>
+                <span class="overlay-detail mono" id="overlay-age">age —</span>
+                <span class="overlay-detail mono" id="overlay-simtime">sim time —</span>
+              </div>
+
+              <!-- Toolbar / representation / camera / ligand controls -->
+              <div class="viewer-controls">
+                <div class="control-row">
+                  <div class="control-group">
+                    <button class="ctl-btn" type="button" data-action="live-toggle">Live Updates</button>
+                    <button class="ctl-btn" type="button" data-action="pause-toggle">Pause Updates</button>
+                    <button class="ctl-btn" type="button" data-action="play-trajectory">Play Trajectory</button>
+                    <button class="ctl-btn" type="button" data-action="prev-frame">‹ Frame</button>
+                    <button class="ctl-btn" type="button" data-action="next-frame">Frame ›</button>
+                    <button class="ctl-btn" type="button" data-action="reset-view">Reset View</button>
+                    <button class="ctl-btn" type="button" data-action="fullscreen">Fullscreen</button>
+                    <button class="ctl-btn" type="button" data-action="screenshot">Screenshot</button>
+                  </div>
+                </div>
+                <div class="control-row">
+                  <div class="control-group" role="group" aria-label="Representation">
+                    <span class="control-label">Representation</span>
+                    <button class="chip-btn active" type="button" data-rep="cartoon">Cartoon</button>
+                    <button class="chip-btn" type="button" data-rep="backbone">Backbone</button>
+                    <button class="chip-btn" type="button" data-rep="sticks">Sticks</button>
+                    <button class="chip-btn" type="button" data-rep="ballAndStick">Ball and Stick</button>
+                    <button class="chip-btn" type="button" data-rep="surface">Surface</button>
+                    <button class="chip-btn" type="button" data-rep="lines">Lines</button>
+                  </div>
+                  <div class="control-group" role="group" aria-label="Visibility">
+                    <span class="control-label">Visibility</span>
+                    <label class="chip-toggle"><input type="checkbox" data-vis="protein" checked>Protein</label>
+                    <label class="chip-toggle"><input type="checkbox" data-vis="ligand" checked>Ligand</label>
+                    <label class="chip-toggle"><input type="checkbox" data-vis="pocket" checked>Binding pocket</label>
+                    <label class="chip-toggle"><input type="checkbox" data-vis="water">Water</label>
+                    <label class="chip-toggle"><input type="checkbox" data-vis="ions">Ions</label>
+                    <label class="chip-toggle"><input type="checkbox" data-vis="hydrogens">Hydrogens</label>
+                    <label class="chip-toggle"><input type="checkbox" data-vis="box">Periodic box</label>
+                  </div>
+                </div>
+                <div class="control-row">
+                  <div class="control-group" role="group" aria-label="Color mode">
+                    <span class="control-label">Color mode</span>
+                    <button class="chip-btn" type="button" data-color="chain">Chain</button>
+                    <button class="chip-btn active" type="button" data-color="spectrum">Spectrum</button>
+                    <button class="chip-btn" type="button" data-color="residue">Residue</button>
+                    <button class="chip-btn" type="button" data-color="element">Element</button>
+                    <button class="chip-btn" type="button" data-color="secondary_structure">Secondary structure</button>
+                    <button class="chip-btn" type="button" data-color="monochrome">Monochrome</button>
+                  </div>
+                  <div class="control-group" role="group" aria-label="Camera">
+                    <span class="control-label">Camera</span>
+                    <button class="chip-btn" type="button" data-cam="spin">Spin</button>
+                    <button class="chip-btn" type="button" data-cam="stop">Stop</button>
+                    <button class="chip-btn" type="button" data-cam="center-protein">Center Protein</button>
+                    <button class="chip-btn" type="button" data-cam="center-ligand">Center Ligand</button>
+                    <button class="chip-btn" type="button" data-cam="center-pocket">Center Pocket</button>
+                    <button class="chip-btn" type="button" data-cam="zoom-in">Zoom +</button>
+                    <button class="chip-btn" type="button" data-cam="zoom-out">Zoom −</button>
+                  </div>
+                </div>
+                <div class="control-row" id="ligand-tools" hidden>
+                  <div class="control-group" role="group" aria-label="Ligand tools">
+                    <span class="control-label">Ligand tools</span>
+                    <span class="ligand-meta mono" id="ligand-meta">—</span>
+                    <button class="chip-btn" type="button" data-ligand="center">Center</button>
+                    <button class="chip-btn" type="button" data-ligand="isolate">Isolate</button>
+                    <label class="chip-toggle micro">Cutoff <input type="number" min="3" max="15" step="0.5" id="pocket-cutoff" value="5"> Å</label>
+                    <button class="chip-btn" type="button" data-ligand="show-pocket">Show pocket residues</button>
+                    <button class="chip-btn" type="button" data-ligand="show-pocket-surface">Show pocket surface</button>
+                    <button class="chip-btn" type="button" data-ligand="hide-distant">Hide distant residues</button>
+                    <button class="chip-btn" type="button" data-ligand="show-labels">Show atom labels</button>
+                    <button class="chip-btn" type="button" data-ligand="show-contacts">Geometric contacts</button>
+                    <button class="chip-btn" type="button" data-ligand="show-hbonds">H-bonds only</button>
+                  </div>
+                </div>
+                <div class="control-row" id="trajectory-row" hidden>
+                  <div class="control-group trajectory-controls">
+                    <span class="control-label">Trajectory playback</span>
+                    <button class="ctl-btn" type="button" data-traj="play">Play</button>
+                    <button class="ctl-btn" type="button" data-traj="pause">Pause</button>
+                    <button class="ctl-btn" type="button" data-traj="reverse">Reverse</button>
+                    <button class="ctl-btn" type="button" data-traj="prev">Prev</button>
+                    <button class="ctl-btn" type="button" data-traj="next">Next</button>
+                    <button class="ctl-btn" type="button" data-traj="first">⏮</button>
+                    <button class="ctl-btn" type="button" data-traj="last">⏭</button>
+                    <input type="range" class="traj-slider" id="traj-slider" min="0" max="0" value="0">
+                    <span class="traj-time mono"><span id="traj-current">0</span> / <span id="traj-total">0</span> · <span id="traj-simtime">—</span> ns</span>
+                    <label class="chip-toggle micro">Speed
+                      <select id="traj-speed">
+                        <option value="0.25">0.25×</option>
+                        <option value="0.5">0.5×</option>
+                        <option value="1" selected>1×</option>
+                        <option value="2">2×</option>
+                        <option value="4">4×</option>
+                      </select>
+                    </label>
+                    <label class="chip-toggle micro"><input type="checkbox" id="traj-loop">Loop</label>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <aside class="info-panel" aria-label="Molecular information panel">
+              <div class="info-tabs" role="tablist">
+                <button class="info-tab active" type="button" data-tab="structure">Structure</button>
+                <button class="info-tab" type="button" data-tab="simulation">Simulation</button>
+                <button class="info-tab" type="button" data-tab="selection">Selection</button>
+                <button class="info-tab" type="button" data-tab="ligand">Ligand</button>
+              </div>
+              <div class="info-content">
+                <div class="info-pane active" data-tab="structure">
+                  <table class="kv-table mono">
+                    <tbody id="structure-tab-tbody">
+                      <tr><th>Protein chains</th><td>—</td></tr>
+                      <tr><th>Protein residues</th><td>—</td></tr>
+                      <tr><th>Protein atoms</th><td>—</td></tr>
+                      <tr><th>Ligands</th><td>—</td></tr>
+                      <tr><th>Water</th><td>—</td></tr>
+                      <tr><th>Ions</th><td>—</td></tr>
+                    </tbody>
+                  </table>
+                </div>
+                <div class="info-pane" data-tab="simulation" hidden>
+                  <table class="kv-table mono">
+                    <tbody id="simulation-tab-tbody">
+                      <tr><th>Force field</th><td>—</td></tr>
+                      <tr><th>Water model</th><td>—</td></tr>
+                      <tr><th>pH</th><td>—</td></tr>
+                      <tr><th>Ion concentration</th><td>—</td></tr>
+                      <tr><th>Temperature</th><td>—</td></tr>
+                      <tr><th>Timestep</th><td>—</td></tr>
+                      <tr><th>Precision</th><td>—</td></tr>
+                      <tr><th>Platform</th><td>—</td></tr>
+                    </tbody>
+                  </table>
+                </div>
+                <div class="info-pane" data-tab="selection" hidden>
+                  <p class="muted small">Click an atom or residue in the viewer to populate this panel.</p>
+                  <table class="kv-table mono">
+                    <tbody id="selection-tab-tbody">
+                      <tr><th>Residue</th><td>—</td></tr>
+                      <tr><th>Chain</th><td>—</td></tr>
+                      <tr><th>Atom</th><td>—</td></tr>
+                      <tr><th>Element</th><td>—</td></tr>
+                      <tr><th>Coordinates</th><td>—</td></tr>
+                    </tbody>
+                  </table>
+                </div>
+                <div class="info-pane" data-tab="ligand" hidden>
+                  <table class="kv-table mono">
+                    <tbody id="ligand-tab-tbody">
+                      <tr><th>Ligand</th><td>—</td></tr>
+                      <tr><th>Chain</th><td>—</td></tr>
+                      <tr><th>Residue ID</th><td>—</td></tr>
+                      <tr><th>Atom count</th><td>—</td></tr>
+                      <tr><th>Nearby residues</th><td>—</td></tr>
+                      <tr><th>Pocket distance</th><td>—</td></tr>
+                      <tr><th>H-bonds</th><td>—</td></tr>
+                      <tr><th>Hydrophobic contacts</th><td>—</td></tr>
+                      <tr><th>Salt bridges</th><td>—</td></tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </aside>
+          </div>
+        </section>
+
+        <section class="page" data-page="analysis" hidden>
+          <div class="page-header">
+            <div>
+              <h1 class="page-title">Analysis</h1>
+              <div class="page-subtitle">Trajectory analyses and protein-ligand interactions</div>
+            </div>
+            <div class="muted small mono" id="analysis-meta">no analyses yet</div>
+          </div>
+          <div class="analysis-grid" id="analysis-grid"></div>
+          <div class="empty-state" id="analysis-empty">
+            <div class="empty-watermark"></div>
+            <div class="empty-title">Analysis outputs not available yet</div>
+            <div class="empty-detail muted">
+              Analyses and reports appear here after the analysis/report phases run.
+              Re-running analyses will appear without restarting the dashboard.
+            </div>
+          </div>
+        </section>
+
+        <section class="page" data-page="files" hidden>
+          <div class="page-header">
+            <div>
+              <h1 class="page-title">Files &amp; Reports</h1>
+              <div class="page-subtitle">Generated artifacts grouped by purpose</div>
+            </div>
+          </div>
+
+          <div class="card summary-card" id="summary-card" hidden>
+            <div class="card-header"><h2 class="card-title">Run completed</h2></div>
+            <div class="summary-grid mono" id="summary-grid"></div>
+          </div>
+
+          <div class="card">
+            <div class="card-header"><h2 class="card-title">Reports</h2></div>
+            <div class="files-list" data-fileset="reports" id="reports-files"></div>
+          </div>
+          <div class="card">
+            <div class="card-header"><h2 class="card-title">Simulation files</h2></div>
+            <div class="files-list" data-fileset="simulation" id="simulation-files"></div>
+          </div>
+          <div class="card">
+            <div class="card-header"><h2 class="card-title">Analysis files</h2></div>
+            <div class="files-list" data-fileset="analysis" id="analysis-files"></div>
+          </div>
+        </section>
+
+        <section class="page" data-page="settings" hidden>
+          <div class="page-header">
+            <div>
+              <h1 class="page-title">Settings</h1>
+              <div class="page-subtitle">Browser-side preferences. Existing simulations cannot be modified here.</div>
+            </div>
+          </div>
+          <div class="card">
+            <div class="card-header"><h2 class="card-title">Viewer</h2></div>
+            <div class="kv-form mono">
+              <label>Default protein representation
+                <select id="setting-protein-rep">
+                  <option value="cartoon" selected>Cartoon</option>
+                  <option value="backbone">Backbone</option>
+                  <option value="sticks">Sticks</option>
+                  <option value="ballAndStick">Ball and Stick</option>
+                  <option value="surface">Surface</option>
+                  <option value="lines">Lines</option>
+                </select>
+              </label>
+              <label>Default ligand representation
+                <select id="setting-ligand-rep">
+                  <option value="sticks" selected>Sticks</option>
+                  <option value="ballAndStick">Ball and Stick</option>
+                  <option value="cartoon">Cartoon</option>
+                  <option value="lines">Lines</option>
+                </select>
+              </label>
+              <label>Background
+                <select id="setting-background">
+                  <option value="matte-black" selected>Matte black</option>
+                  <option value="deepest-night">Deepest night</option>
+                  <option value="charcoal">Charcoal</option>
+                </select>
+              </label>
+              <label class="checkbox-row"><input type="checkbox" id="setting-show-water"> Show water</label>
+              <label class="checkbox-row"><input type="checkbox" id="setting-show-ions"> Show ions</label>
+              <label class="checkbox-row"><input type="checkbox" id="setting-spin"> Spin structures by default</label>
+              <label class="checkbox-row"><input type="checkbox" id="setting-fog"> Subtle depth fog</label>
+              <label class="checkbox-row"><input type="checkbox" id="setting-preserve-camera" checked> Preserve camera between frames</label>
+            </div>
+          </div>
+          <div class="card">
+            <div class="card-header"><h2 class="card-title">Dashboard</h2></div>
+            <div class="kv-form mono">
+              <label>Telemetry polling (s)
+                <input type="number" id="setting-refresh-seconds" min="1" max="60" step="1" value="3">
+              </label>
+              <label>Chart history (samples)
+                <input type="number" id="setting-chart-history" min="60" max="5000" step="60" value="600">
+              </label>
+              <label class="checkbox-row"><input type="checkbox" id="setting-compact"> Compact mode</label>
+              <label class="checkbox-row"><input type="checkbox" id="setting-reduced-motion"> Reduced motion</label>
+              <label class="checkbox-row"><input type="checkbox" id="setting-advanced-metrics"> Show advanced metrics</label>
+              <label>Time
+                <select id="setting-time-format">
+                  <option value="24h" selected>24-hour</option>
+                  <option value="12h">12-hour</option>
+                </select>
+              </label>
+            </div>
+          </div>
+          <div class="card">
+            <div class="card-header"><h2 class="card-title">Run display</h2></div>
+            <div class="kv-form mono">
+              <label>Custom run display name
+                <input type="text" id="setting-run-name" placeholder="(auto from manifest)">
+              </label>
+              <label>Explicit ligand residue name
+                <input type="text" id="setting-ligand-resname" placeholder="(auto-detected)">
+              </label>
+              <label>Binding-pocket cutoff (Å)
+                <input type="number" id="setting-pocket-cutoff" min="3" max="15" step="0.5" value="5">
+              </label>
+              <label>Scientific notation threshold
+                <input type="number" id="setting-scinote" min="0" max="20" step="1" value="5">
+              </label>
+            </div>
+            <p class="muted small">
+              These preferences affect only how the dashboard renders this run.
+              They do not modify the OpenMM simulation or any output files.
+            </p>
+          </div>
+        </section>
+      </main>
+    </div>
+  </div>
+
+  <!-- Live region for screen readers -->
+  <div class="sr-only" aria-live="polite" id="sr-live"></div>
+
+  <script src="/static/3Dmol-min.js"></script>
+  <script src="/static/dashboard.js"></script>
+  <script src="/static/charts.js"></script>
+  <script src="/static/molecule-viewer.js"></script>
+</body>
+</html>

--- a/src/fastmdxplora/live/templates/dashboard.html
+++ b/src/fastmdxplora/live/templates/dashboard.html
@@ -54,6 +54,10 @@
       </div>
       <nav class="sidebar-nav" role="navigation" aria-label="Dashboard sections">
         <div class="nav-heading">Workspace</div>
+        <a href="#builder" class="nav-link" data-view-link="builder">
+          <span class="nav-icon nav-icon-launch" aria-hidden="true"></span>
+          <span>New Simulation</span>
+        </a>
         <a href="#" class="nav-link" data-view-link="overview">
           <span class="nav-icon" aria-hidden="true"></span>
           <span>Overview</span>
@@ -147,6 +151,214 @@
 
       <!-- Page views -->
       <main class="page-shell" role="main">
+        <!-- Dashboard-first simulation builder -->
+        <section class="page" data-page="builder" hidden>
+          <div class="page-header builder-page-header">
+            <div>
+              <h1 class="page-title">New Simulation</h1>
+              <div class="page-subtitle">Configure and launch the standard FastMDXplora workflow from this dashboard.</div>
+            </div>
+            <div class="builder-run-state" id="builder-run-state" data-state="idle">
+              <span class="status-dot status-dot-waiting" id="builder-state-dot"></span>
+              <span id="builder-state-text">No active workflow</span>
+            </div>
+          </div>
+
+          <form id="simulation-builder-form" class="builder-layout" novalidate>
+            <div class="builder-main">
+              <div class="card builder-card">
+                <div class="card-header">
+                  <div>
+                    <h2 class="card-title">Molecular system</h2>
+                    <p class="builder-card-note">Enter a PDB ID, an amino-acid sequence, or a path visible to this computer.</p>
+                  </div>
+                  <span class="builder-step">01</span>
+                </div>
+                <div class="builder-grid builder-grid-2">
+                  <label class="builder-field builder-field-wide">
+                    <span class="builder-label">System</span>
+                    <input type="text" id="builder-system" autocomplete="off" placeholder="1L2Y or C:\path\protein.pdb" required>
+                    <span class="field-error" data-error-for="system"></span>
+                  </label>
+                  <label class="builder-field">
+                    <span class="builder-label">Run name</span>
+                    <input type="text" id="builder-run-name" autocomplete="off" placeholder="Generated automatically">
+                    <span class="field-error" data-error-for="run_name"></span>
+                  </label>
+                </div>
+              </div>
+
+              <div class="card builder-card">
+                <div class="card-header">
+                  <div>
+                    <h2 class="card-title">System setup</h2>
+                    <p class="builder-card-note">These values are passed to the existing setup phase.</p>
+                  </div>
+                  <span class="builder-step">02</span>
+                </div>
+                <div class="builder-grid builder-grid-3">
+                  <label class="builder-field">
+                    <span class="builder-label">Force field</span>
+                    <select id="builder-forcefield"></select>
+                  </label>
+                  <label class="builder-field">
+                    <span class="builder-label">Water model</span>
+                    <input type="text" id="builder-water-model" placeholder="auto">
+                  </label>
+                  <label class="builder-field">
+                    <span class="builder-label">pH</span>
+                    <div class="range-number-pair">
+                      <input type="range" id="builder-ph-range" min="0" max="14" step="0.1">
+                      <input type="number" id="builder-ph" min="0" max="14" step="0.1">
+                    </div>
+                    <span class="field-error" data-error-for="setup.ph"></span>
+                  </label>
+                  <label class="builder-field">
+                    <span class="builder-label">Ion concentration (M)</span>
+                    <div class="range-number-pair">
+                      <input type="range" id="builder-ion-range" min="0" max="1" step="0.01">
+                      <input type="number" id="builder-ion" min="0" max="5" step="0.01">
+                    </div>
+                    <span class="field-error" data-error-for="setup.ion_concentration_M"></span>
+                  </label>
+                  <label class="builder-field">
+                    <span class="builder-label">Solvent padding (nm)</span>
+                    <div class="range-number-pair">
+                      <input type="range" id="builder-padding-range" min="0.5" max="3" step="0.1">
+                      <input type="number" id="builder-padding" min="0.1" max="10" step="0.1">
+                    </div>
+                    <span class="field-error" data-error-for="setup.solvent_padding_nm"></span>
+                  </label>
+                  <div class="builder-field builder-toggle-group">
+                    <span class="builder-label">Structure retention</span>
+                    <label class="checkbox-row"><input type="checkbox" id="builder-keep-heterogens"> Keep heterogens</label>
+                    <label class="checkbox-row"><input type="checkbox" id="builder-keep-water"> Keep crystallographic water</label>
+                  </div>
+                </div>
+              </div>
+
+              <div class="card builder-card">
+                <div class="card-header">
+                  <div>
+                    <h2 class="card-title">Simulation stages</h2>
+                    <p class="builder-card-note">Use the sliders for quick changes or type exact step counts.</p>
+                  </div>
+                  <span class="builder-step">03</span>
+                </div>
+                <div class="builder-stage-list">
+                  <label class="builder-stage-row">
+                    <span class="builder-stage-name">NVT equilibration</span>
+                    <input type="range" id="builder-nvt-range" min="0" max="2000000" step="1000">
+                    <input type="number" id="builder-nvt" min="0" step="1000">
+                    <span class="builder-duration mono" id="builder-nvt-duration">— ns</span>
+                    <span class="field-error" data-error-for="simulation.nvt_steps"></span>
+                  </label>
+                  <label class="builder-stage-row">
+                    <span class="builder-stage-name">NPT equilibration</span>
+                    <input type="range" id="builder-npt-range" min="0" max="3000000" step="1000">
+                    <input type="number" id="builder-npt" min="0" step="1000">
+                    <span class="builder-duration mono" id="builder-npt-duration">— ns</span>
+                    <span class="field-error" data-error-for="simulation.npt_steps"></span>
+                  </label>
+                  <label class="builder-stage-row builder-stage-production">
+                    <span class="builder-stage-name">Production</span>
+                    <input type="range" id="builder-production-range" min="1000" max="5000000" step="1000">
+                    <input type="number" id="builder-production" min="1" step="1000">
+                    <span class="builder-duration mono" id="builder-production-duration">— ns</span>
+                    <span class="field-error" data-error-for="simulation.production_steps"></span>
+                  </label>
+                </div>
+              </div>
+
+              <div class="card builder-card">
+                <div class="card-header">
+                  <div>
+                    <h2 class="card-title">Dynamics and hardware</h2>
+                    <p class="builder-card-note">Scientific settings remain unchanged after the workflow starts.</p>
+                  </div>
+                  <span class="builder-step">04</span>
+                </div>
+                <div class="builder-grid builder-grid-3">
+                  <label class="builder-field">
+                    <span class="builder-label">Temperature (K)</span>
+                    <div class="range-number-pair">
+                      <input type="range" id="builder-temperature-range" min="50" max="500" step="1">
+                      <input type="number" id="builder-temperature" min="1" max="5000" step="1">
+                    </div>
+                  </label>
+                  <label class="builder-field">
+                    <span class="builder-label">Timestep (fs)</span>
+                    <div class="range-number-pair">
+                      <input type="range" id="builder-timestep-range" min="0.1" max="4" step="0.1">
+                      <input type="number" id="builder-timestep" min="0.01" max="20" step="0.1">
+                    </div>
+                  </label>
+                  <label class="builder-field">
+                    <span class="builder-label">Friction (1/ps)</span>
+                    <div class="range-number-pair">
+                      <input type="range" id="builder-friction-range" min="0" max="10" step="0.1">
+                      <input type="number" id="builder-friction" min="0" max="1000" step="0.1">
+                    </div>
+                  </label>
+                  <label class="builder-field"><span class="builder-label">Integrator</span><select id="builder-integrator"></select></label>
+                  <label class="builder-field"><span class="builder-label">Platform</span><select id="builder-platform"></select></label>
+                  <label class="builder-field"><span class="builder-label">Precision</span><select id="builder-precision"></select></label>
+                  <label class="builder-field"><span class="builder-label">Trajectory interval (steps)</span><input type="number" id="builder-trajectory-interval" min="1" step="1"></label>
+                  <label class="builder-field"><span class="builder-label">Dashboard frame interval (steps)</span><input type="number" id="builder-telemetry-interval" min="1" step="1"></label>
+                  <label class="builder-field"><span class="builder-label">Checkpoint interval (steps)</span><input type="number" id="builder-checkpoint-interval" min="0" step="1"></label>
+                  <label class="checkbox-row builder-checkbox"><input type="checkbox" id="builder-minimize" checked> Minimize before equilibration</label>
+                </div>
+              </div>
+
+              <div class="card builder-card">
+                <div class="card-header">
+                  <div>
+                    <h2 class="card-title">Analysis and reporting</h2>
+                    <p class="builder-card-note">The default full pipeline produces analyses, figures, slides, and a ZIP bundle.</p>
+                  </div>
+                  <span class="builder-step">05</span>
+                </div>
+                <div class="builder-workflow-options">
+                  <label class="checkbox-row"><input type="checkbox" id="builder-run-analysis" checked> Run trajectory analysis</label>
+                  <label class="checkbox-row"><input type="checkbox" id="builder-run-report" checked> Generate reports and dashboard artifacts</label>
+                  <label class="checkbox-row"><input type="checkbox" id="builder-report-document" checked> Markdown report</label>
+                  <label class="checkbox-row"><input type="checkbox" id="builder-report-slides" checked> PowerPoint slides</label>
+                  <label class="checkbox-row"><input type="checkbox" id="builder-report-bundle" checked> ZIP result bundle</label>
+                </div>
+                <div class="analysis-choice-grid" id="builder-analysis-choices" aria-label="Analyses"></div>
+              </div>
+            </div>
+
+            <aside class="builder-summary-column">
+              <div class="card builder-summary-card">
+                <div class="card-header"><h2 class="card-title">Review &amp; launch</h2></div>
+                <dl class="builder-summary-list mono">
+                  <div><dt>System</dt><dd id="builder-summary-system">—</dd></div>
+                  <div><dt>Output</dt><dd id="builder-summary-output">—</dd></div>
+                  <div><dt>NVT</dt><dd id="builder-summary-nvt">—</dd></div>
+                  <div><dt>NPT</dt><dd id="builder-summary-npt">—</dd></div>
+                  <div><dt>Production</dt><dd id="builder-summary-production">—</dd></div>
+                  <div><dt>Total simulated</dt><dd id="builder-summary-total">—</dd></div>
+                  <div><dt>Trajectory frames</dt><dd id="builder-summary-frames">—</dd></div>
+                  <div><dt>Platform</dt><dd id="builder-summary-platform">—</dd></div>
+                </dl>
+                <div class="builder-warning-list" id="builder-warning-list" hidden></div>
+                <div class="builder-command-preview">
+                  <div class="builder-label">Equivalent command</div>
+                  <code id="builder-command-preview">Validate to preview the command.</code>
+                </div>
+                <div class="builder-actions">
+                  <button type="button" class="ghost-btn" id="builder-reset">Reset defaults</button>
+                  <button type="button" class="ghost-btn" id="builder-validate">Validate</button>
+                  <button type="submit" class="primary-btn" id="builder-launch">Launch Simulation</button>
+                  <button type="button" class="danger-btn" id="builder-stop" hidden>Stop Workflow</button>
+                </div>
+                <div class="builder-message" id="builder-message" role="status" aria-live="polite"></div>
+              </div>
+            </aside>
+          </form>
+        </section>
+
         <!-- Loading shell renders here once data arrives -->
         <section class="page" data-page="overview" data-status="loading">
           <div class="page-header">
@@ -680,6 +892,7 @@
 
   <script src="/static/3Dmol-min.js"></script>
   <script src="/static/dashboard.js"></script>
+  <script src="/static/simulation-builder.js"></script>
   <script src="/static/charts.js"></script>
   <script src="/static/molecule-viewer.js"></script>
 </body>

--- a/src/fastmdxplora/live/templates/dashboard.html
+++ b/src/fastmdxplora/live/templates/dashboard.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="/static/dashboard.css">
   <meta name="fastmdx-expansion" content="Fully Automated SysTem for Molecular Dynamics eXploration">
 </head>
-<body class="state-loading">
+<body class="state-loading" data-refresh-seconds="__FASTMDX_REFRESH_SECONDS__">
   <!-- Loading screen -->
   <div id="loading-screen" class="loading-screen" aria-hidden="false">
     <div class="loading-shell">
@@ -160,7 +160,7 @@
               <div class="hero-card-top">
                 <div>
                   <div class="hero-label">Run status</div>
-                  <div class="hero-status">not available</div>
+                  <div class="hero-status" id="hero-status-text">not available</div>
                 </div>
                 <span class="stage-pill mono" id="hero-stage">—</span>
               </div>
@@ -289,6 +289,7 @@
                 <a href="#" class="ghost-link" data-view-link="viewer">Open full viewer</a>
               </div>
               <div class="preview-frame" id="mini-preview-frame">
+                <div id="mini-preview-canvas" class="mini-preview-canvas" aria-label="Molecular preview"></div>
                 <div class="preview-empty" id="mini-preview-empty">
                   Waiting for a structure file…
                 </div>
@@ -537,7 +538,16 @@
               <h1 class="page-title">Analysis</h1>
               <div class="page-subtitle">Trajectory analyses and protein-ligand interactions</div>
             </div>
-            <div class="muted small mono" id="analysis-meta">no analyses yet</div>
+            <div class="page-header-actions">
+              <div class="muted small mono" id="analysis-meta">no analyses yet</div>
+              <a
+                class="ghost-btn"
+                id="download-all-svg"
+                href="/analysis-figures-svg.zip"
+                download
+                hidden
+              >Download all SVG figures</a>
+            </div>
           </div>
           <div class="analysis-grid" id="analysis-grid"></div>
           <div class="empty-state" id="analysis-empty">
@@ -623,7 +633,7 @@
             <div class="card-header"><h2 class="card-title">Dashboard</h2></div>
             <div class="kv-form mono">
               <label>Telemetry polling (s)
-                <input type="number" id="setting-refresh-seconds" min="1" max="60" step="1" value="3">
+                <input type="number" id="setting-refresh-seconds" min="1" max="60" step="1" value="__FASTMDX_REFRESH_SECONDS__">
               </label>
               <label>Chart history (samples)
                 <input type="number" id="setting-chart-history" min="60" max="5000" step="60" value="600">

--- a/src/fastmdxplora/live/trajectory_playback.py
+++ b/src/fastmdxplora/live/trajectory_playback.py
@@ -1,15 +1,9 @@
-"""Trajectory playback helpers for the live dashboard.
+"""Browser-safe trajectory playback for the live dashboard.
 
-The dashboard's "Molecular Viewer" page can step through a downsampled
-playback of the production trajectory (200 frames max by default) so the
-user can scrub or play it back without the cost (or the file size) of
-loading the full scientific DCD. This module never mutates the DCD — it
-only reads frames and writes a multi-MODEL PDB companion.
-
-OpenMM is the only consumer-strict dependency for DCD reading, so it's
-imported lazily. If OpenMM isn't available, the playback route falls
-back to a clean "not available" message; the rest of the dashboard
-keeps working.
+While a run is active, playback is compiled from the rolling solvent-stripped
+PDB snapshots written by :mod:`fastmdxplora.live.live_frames`.  After the run
+completes, the scientific DCD is read with MDTraj and downsampled to a bounded,
+solvent-stripped multi-model PDB.  Neither source is modified.
 """
 
 from __future__ import annotations
@@ -17,49 +11,42 @@ from __future__ import annotations
 import json
 import os
 import time
-from io import StringIO
 from pathlib import Path
 from typing import Any
+
+from fastmdxplora.live.live_frames import read_live_frame_history
 
 PLAYBACK_FILE = "playback.pdb"
 PLAYBACK_INDEX_FILE = "playback_index.json"
 
-# Lines that record-level PDB writers emit which conflict when reusing
-# between MODEL blocks. CRYST1 may only appear once; HEADER / TITLE /
-# COMPND may only appear before the first MODEL.
 _HEADER_LIKE_RECORDS = frozenset({
-    "CRYST1", "HEADER", "OBSLTE", "TITLE ", "SPLT  ", "CAVEAT",
-    "COMPND", "SOURCE", "KEYWDS", "EXPDTA", "NUMMDL", "MDLTYP",
-    "AUTHOR", "REVDAT", "DBREF", "DBREF1", "DBREF2", "SEQADV",
-    "SEQRES", "MODRES", "HET ", "HETNAM", "HETSYN", "FORMUL",
+    "CRYST1", "HEADER", "OBSLTE", "TITLE", "SPLT", "CAVEAT", "COMPND",
+    "SOURCE", "KEYWDS", "EXPDTA", "NUMMDL", "MDLTYP", "AUTHOR", "REVDAT",
+    "DBREF", "DBREF1", "DBREF2", "SEQADV", "SEQRES", "MODRES", "HET",
+    "HETNAM", "HETSYN", "FORMUL",
 })
 
 
 def PlaybackUnavailable(reason: str) -> dict[str, Any]:
-    """Return a uniform "not available" envelope for the route handler."""
     return {
         "playback_available": False,
         "reason": reason,
+        "source_kind": None,
         "n_frames_total": 0,
         "n_frames_browser": 0,
         "frame_indices": [],
+        "frame_times_ns": [],
         "simulation_time_ns_first": None,
         "simulation_time_ns_last": None,
     }
 
 
-def _import_openmm() -> dict[str, Any] | None:
-    """Return a dict of OpenMM symbols or ``None`` if not importable."""
+def _import_mdtraj():
     try:
-        import openmm
-        from openmm.app import DCDFile, PDBFile
+        import mdtraj as md
     except ImportError:
         return None
-    return {
-        "openmm": openmm,
-        "PDBFile": PDBFile,
-        "DCDFile": DCDFile,
-    }
+    return md
 
 
 def playback_info(
@@ -69,186 +56,296 @@ def playback_info(
     simulation_time_ns_total: float | None = None,
     force: bool = False,
 ) -> dict[str, Any]:
-    """Build the playback companion files and return a status dictionary.
-
-    Parameters
-    ----------
-    output_dir : path-like
-        The dashboard's project root (typically the FastMDXplora run dir).
-    max_browser_frames : int
-        Cap on the number of frames the browser will load. The trajectory
-        is downsampled evenly so the browser never sees more than this
-        many frames regardless of how large the production run is.
-    simulation_time_ns_total : float | None
-        If known, used to compute simulation-time labels for each frame.
-    force : bool
-        Re-generate even if the companion files already exist. Useful for
-        the dashboard's refresh control.
-
-    Returns
-    -------
-    dict
-        Status envelope consumed by the ``/api/playback-info`` route.
-    """
+    """Return or build the best available browser playback companion."""
     out = Path(output_dir)
     sim_dir = out / "simulation"
-    topo_path = sim_dir / "topology.pdb"
-    dcd_path = sim_dir / "production.dcd"
     companion_pdb = sim_dir / PLAYBACK_FILE
     companion_idx = sim_dir / PLAYBACK_INDEX_FILE
+    cap = max(2, int(max_browser_frames or 200))
 
-    if not (topo_path.is_file() and dcd_path.is_file()):
-        return PlaybackUnavailable("missing-trajectory")
+    history = read_live_frame_history(sim_dir)
+    history_frames = [item for item in history.get("frames", []) if isinstance(item, dict)]
+    status = _load_json(sim_dir / "live_status.json")
+    workflow_completed = str(status.get("status") or "").lower() in {
+        "completed", "complete", "ok", "success", "succeeded"
+    }
 
-    if not force and companion_pdb.is_file() and companion_idx.is_file():
+    topology_path = sim_dir / "topology.pdb"
+    dcd_path = sim_dir / "production.dcd"
+
+    # During a live run use lightweight snapshots.  This allows play/pause and
+    # scrubbing during minimization/NVT/NPT before a production DCD even exists.
+    if len(history_frames) >= 2 and not workflow_completed:
+        signature = _history_signature(history_frames)
+        cached = _cached_playback(companion_pdb, companion_idx, "live-history", signature, force)
+        if cached is not None:
+            return cached
         try:
-            if companion_pdb.stat().st_mtime >= dcd_path.stat().st_mtime:
-                info = _load_index(companion_idx)
-                if info.get("playback_available"):
-                    return info
-        except OSError:
-            pass
+            return _generate_from_history(
+                sim_dir=sim_dir,
+                records=history_frames,
+                companion_pdb=companion_pdb,
+                companion_idx=companion_idx,
+                max_browser_frames=cap,
+                source_signature=signature,
+            )
+        except Exception as exc:  # noqa: BLE001 - dashboard is best effort
+            cached = _load_index(companion_idx)
+            if cached.get("playback_available"):
+                return cached
+            return PlaybackUnavailable(f"history-generate-error: {exc}")
 
-    omm = _import_openmm()
-    if omm is None:
-        return PlaybackUnavailable("openmm-not-installed")
+    # Completed runs prefer the scientific DCD.  The browser copy is atom-
+    # sliced and downsampled; the original DCD remains unchanged.
+    if topology_path.is_file() and dcd_path.is_file() and dcd_path.stat().st_size > 0:
+        signature = _file_signature(dcd_path)
+        cached = _cached_playback(companion_pdb, companion_idx, "production-dcd", signature, force)
+        if cached is not None:
+            return cached
+        md = _import_mdtraj()
+        if md is not None:
+            try:
+                return _generate_from_dcd(
+                    md=md,
+                    topology_path=topology_path,
+                    dcd_path=dcd_path,
+                    companion_pdb=companion_pdb,
+                    companion_idx=companion_idx,
+                    max_browser_frames=cap,
+                    simulation_time_ns_total=simulation_time_ns_total,
+                    source_signature=signature,
+                )
+            except Exception:
+                # A DCD can be temporarily unreadable while OpenMM is writing
+                # its final frame. Fall through to the already-safe history.
+                pass
 
-    try:
-        return _generate_companion(
-            omm=omm,
-            topology_path=topo_path,
-            dcd_path=dcd_path,
-            companion_pdb=companion_pdb,
-            companion_idx=companion_idx,
-            max_browser_frames=max(1, int(max_browser_frames)),
-            simulation_time_ns_total=simulation_time_ns_total,
-        )
-    except Exception as exc:  # noqa: BLE001 — never crash the dashboard
-        return PlaybackUnavailable(f"generate-error: {exc}")
+    if len(history_frames) >= 2:
+        signature = _history_signature(history_frames)
+        cached = _cached_playback(companion_pdb, companion_idx, "live-history", signature, force)
+        if cached is not None:
+            return cached
+        try:
+            return _generate_from_history(
+                sim_dir=sim_dir,
+                records=history_frames,
+                companion_pdb=companion_pdb,
+                companion_idx=companion_idx,
+                max_browser_frames=cap,
+                source_signature=signature,
+            )
+        except Exception as exc:  # noqa: BLE001
+            return PlaybackUnavailable(f"history-generate-error: {exc}")
+
+    if dcd_path.is_file() and _import_mdtraj() is None:
+        return PlaybackUnavailable("mdtraj-not-installed")
+    return PlaybackUnavailable("not-enough-frames")
 
 
-def _generate_companion(
+def _generate_from_history(
     *,
-    omm: dict[str, Any],
+    sim_dir: Path,
+    records: list[dict[str, Any]],
+    companion_pdb: Path,
+    companion_idx: Path,
+    max_browser_frames: int,
+    source_signature: str,
+) -> dict[str, Any]:
+    selected = _even_sample(records, max_browser_frames)
+    blocks: list[str] = []
+    used: list[dict[str, Any]] = []
+    for record in selected:
+        path = sim_dir / str(record.get("path") or "")
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        atoms = _pdb_atom_lines(text)
+        if not atoms:
+            continue
+        model_number = len(used) + 1
+        blocks.append(f"MODEL     {model_number:>4d}")
+        blocks.extend(atoms)
+        blocks.append("ENDMDL")
+        used.append(record)
+    if len(used) < 2:
+        return PlaybackUnavailable("not-enough-readable-history-frames")
+    blocks.append("END")
+    _atomic_text(companion_pdb, "\n".join(blocks) + "\n")
+
+    times = [record.get("simulation_time_ns") for record in used]
+    indices = [record.get("frame_index") for record in used]
+    payload = _playback_payload(
+        source_kind="live-history",
+        source_signature=source_signature,
+        n_total=len(records),
+        n_browser=len(used),
+        frame_indices=indices,
+        frame_times_ns=times,
+    )
+    _atomic_json(companion_idx, payload)
+    return payload
+
+
+def _generate_from_dcd(
+    *,
+    md: Any,
     topology_path: Path,
     dcd_path: Path,
     companion_pdb: Path,
     companion_idx: Path,
     max_browser_frames: int,
     simulation_time_ns_total: float | None,
+    source_signature: str,
 ) -> dict[str, Any]:
-    PDBFile = omm["PDBFile"]
-    DCDFile = omm["DCDFile"]
-
-    pdb = PDBFile(str(topology_path))
-    topology = pdb.topology
-
-    dcd = DCDFile(str(dcd_path))
-    n_total = int(len(dcd))
-    if n_total <= 0:
-        return PlaybackUnavailable("empty-trajectory")
-
-    if n_total <= max_browser_frames:
-        frame_indices = list(range(n_total))
-    else:
-        # Even downsample so coverage is uniform across the trajectory.
-        stride = max(1, n_total // max_browser_frames)
-        frame_indices = list(range(0, n_total, stride))[:max_browser_frames]
-        if frame_indices[-1] != n_total - 1:
-            frame_indices.append(n_total - 1)
-
-    n_browser = len(frame_indices)
-    frame_set = set(frame_indices)
-
-    out_lines: list[str] = []
-    written = 0
-    frame_times_ns: list[float | None] = []
-    # DCD iteration is partial-write risky: the OpenMM C++ layer may raise
-    # on a torn final frame. Break on the first error so the dashboard
-    # still serves whatever it already had.
+    topology_traj = md.load_pdb(str(topology_path))
     try:
-        for idx, frame in enumerate(dcd):
-            if idx not in frame_set:
-                continue
-            buf = StringIO()
-            try:
-                PDBFile.writeFile(topology, frame, buf, keepIds=True)
-            except TypeError:
-                # Older OpenMM versions don't accept keepIds.
-                PDBFile.writeFile(topology, frame, buf)  # type: ignore[call-arg]
-            text = buf.getvalue()
-            # 3Dmol expects MODEL/ENDMDL wrapping. Strip the per-frame
-            # header-record lines that conflict with the multi-MODEL
-            # contract (CRYST1 may only appear once).
-            if written == 0:
-                out_lines.append(f"MODEL     {idx + 1:>4d}")
-            else:
-                out_lines.append(f"MODEL     {idx + 1:>4d}")
-            for ln in text.splitlines():
-                stripped = ln[:6].rstrip().upper()
-                if not stripped:
-                    continue
-                if (
-                    stripped in _HEADER_LIKE_RECORDS
-                    or stripped.startswith("END")
-                    or stripped == "MODEL"
-                    or stripped == "ENDMDL"
-                ):
-                    continue
-                out_lines.append(ln)
-            out_lines.append("ENDMDL")
-            written += 1
-            if simulation_time_ns_total is not None and n_total > 1:
-                frame_times_ns.append(
-                    simulation_time_ns_total * (idx / (n_total - 1))
-                )
-            else:
-                frame_times_ns.append(None)
-            if written >= n_browser:
-                break
+        display_atoms = topology_traj.topology.select("not water")
     except Exception:
-        # Mid-trajectory read error (e.g. simulation still writing).
-        # Whatever we already wrote is still servable.
-        pass
+        display_atoms = None
+    if display_atoms is not None and len(display_atoms) == 0:
+        display_atoms = None
 
-    if written == 0:
-        return PlaybackUnavailable("no-frames-read")
-    out_lines.append("END")
-
+    trajectory = md.load_dcd(
+        str(dcd_path),
+        top=topology_traj.topology,
+        atom_indices=display_atoms,
+    )
+    n_total = int(trajectory.n_frames)
+    if n_total < 2:
+        return PlaybackUnavailable("not-enough-trajectory-frames")
+    frame_indices = _even_indices(n_total, max_browser_frames)
+    browser_traj = trajectory[frame_indices]
     tmp = companion_pdb.with_suffix(".pdb.tmp")
-    tmp.write_text("\n".join(out_lines), encoding="utf-8")
+    browser_traj.save_pdb(str(tmp))
     os.replace(tmp, companion_pdb)
 
-    payload = {
-        "playback_available": True,
-        "n_frames_total": n_total,
-        "n_frames_browser": written,
-        "frame_indices": [int(i) for i in frame_indices[:written]],
-        "frame_times_ns": frame_times_ns,
-        "simulation_time_ns_first": (
-            frame_times_ns[0] if frame_times_ns and frame_times_ns[0] is not None
-            else None
-        ),
-        "simulation_time_ns_last": (
-            frame_times_ns[-1] if frame_times_ns and frame_times_ns[-1] is not None
-            else None
-        ),
-        "companion_pdb": companion_pdb.name,
-        "compiled_at": time.time(),
-    }
-    tmp_idx = companion_idx.with_suffix(".json.tmp")
-    tmp_idx.write_text(json.dumps(payload), encoding="utf-8")
-    os.replace(tmp_idx, companion_idx)
+    times: list[float | None]
+    try:
+        raw_time = [float(value) / 1000.0 for value in browser_traj.time]
+        if len(raw_time) > 1 and max(raw_time) > min(raw_time):
+            times = raw_time
+        else:
+            raise ValueError
+    except Exception:
+        if simulation_time_ns_total is not None and n_total > 1:
+            times = [
+                float(simulation_time_ns_total) * (index / (n_total - 1))
+                for index in frame_indices
+            ]
+        else:
+            times = [None] * len(frame_indices)
+
+    payload = _playback_payload(
+        source_kind="production-dcd",
+        source_signature=source_signature,
+        n_total=n_total,
+        n_browser=len(frame_indices),
+        frame_indices=frame_indices,
+        frame_times_ns=times,
+    )
+    _atomic_json(companion_idx, payload)
     return payload
 
 
-def _load_index(path: Path) -> dict[str, Any]:
-    if not path.is_file():
-        return PlaybackUnavailable("missing-companion")
+def _playback_payload(
+    *,
+    source_kind: str,
+    source_signature: str,
+    n_total: int,
+    n_browser: int,
+    frame_indices: list[Any],
+    frame_times_ns: list[Any],
+) -> dict[str, Any]:
+    clean_times = [float(value) if value not in (None, "") else None for value in frame_times_ns]
+    return {
+        "playback_available": True,
+        "reason": None,
+        "source_kind": source_kind,
+        "source_signature": source_signature,
+        "n_frames_total": int(n_total),
+        "n_frames_browser": int(n_browser),
+        "frame_indices": [int(value) if value not in (None, "") else None for value in frame_indices],
+        "frame_times_ns": clean_times,
+        "simulation_time_ns_first": clean_times[0] if clean_times else None,
+        "simulation_time_ns_last": clean_times[-1] if clean_times else None,
+        "companion_pdb": PLAYBACK_FILE,
+        "compiled_at": time.time(),
+    }
+
+
+def _cached_playback(
+    pdb_path: Path,
+    index_path: Path,
+    source_kind: str,
+    source_signature: str,
+    force: bool,
+) -> dict[str, Any] | None:
+    if force or not pdb_path.is_file() or not index_path.is_file():
+        return None
+    payload = _load_index(index_path)
+    if (
+        payload.get("playback_available")
+        and payload.get("source_kind") == source_kind
+        and payload.get("source_signature") == source_signature
+    ):
+        return payload
+    return None
+
+
+def _even_indices(count: int, cap: int) -> list[int]:
+    if count <= cap:
+        return list(range(count))
+    if cap <= 2:
+        return [0, count - 1]
+    return sorted({round(index * (count - 1) / (cap - 1)) for index in range(cap)})
+
+
+def _even_sample(records: list[dict[str, Any]], cap: int) -> list[dict[str, Any]]:
+    return [records[index] for index in _even_indices(len(records), cap)]
+
+
+def _pdb_atom_lines(text: str) -> list[str]:
+    output: list[str] = []
+    for line in text.splitlines():
+        record = line[:6].strip().upper()
+        if record in {"ATOM", "HETATM", "TER"}:
+            output.append(line)
+    return output
+
+
+def _history_signature(records: list[dict[str, Any]]) -> str:
+    last = records[-1] if records else {}
+    return f"{len(records)}:{last.get('sequence')}:{last.get('mtime_ns')}"
+
+
+def _file_signature(path: Path) -> str:
+    stat = path.stat()
+    return f"{stat.st_size}:{stat.st_mtime_ns}"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
     except (OSError, json.JSONDecodeError):
-        return PlaybackUnavailable("invalid-companion")
+        return {}
+
+
+def _load_index(path: Path) -> dict[str, Any]:
+    payload = _load_json(path)
+    return payload if payload else PlaybackUnavailable("invalid-companion")
+
+
+def _atomic_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(text, encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def _atomic_json(path: Path, payload: dict[str, Any]) -> None:
+    _atomic_text(path, json.dumps(payload, indent=2))
 
 
 def neighborhood_residues(
@@ -258,15 +355,7 @@ def neighborhood_residues(
     cutoff_angstrom: float = 5.0,
     coords_path: Path | None = None,
 ) -> list[tuple[str, int]]:
-    """Residue keys within ``cutoff_angstrom`` of any ligand atom.
-
-    Returns a list of ``(chain, resSeq)`` tuples. Distances are measured
-    **per atom** (any ligand atom in contact counts) — not centroid
-    sphere — so elongated or peptide-like ligands aren't underestimated.
-
-    Coordinates are read from ``coords_path`` if provided (e.g. the
-    live-frame PDB) and otherwise from the topology file's atoms.
-    """
+    """Return residues with any atom within ``cutoff_angstrom`` of ligand."""
     if not topology_path.is_file():
         return []
     coords_source = coords_path if coords_path and coords_path.is_file() else topology_path
@@ -286,19 +375,12 @@ def neighborhood_residues(
                 chain_id = line[21:22].strip() or "A"
                 try:
                     res_seq = int(line[22:26])
-                except ValueError:
-                    res_seq = 0
-                try:
                     x = float(line[30:38])
                     y = float(line[38:46])
                     z = float(line[46:54])
                 except (ValueError, IndexError):
                     continue
-                # Per-atom contact check — fast enough for normal pockets
-                # (<200 protein residues × <200 ligand atoms in pure Python).
-                if _any_atom_within_cutoff(
-                    x, y, z, ligand_coords, cutoff_sq
-                ):
+                if _any_atom_within_cutoff(x, y, z, ligand_coords, cutoff_sq):
                     residues.add((chain_id, res_seq))
     except OSError:
         return []
@@ -313,17 +395,10 @@ def _ligand_coord_list(path: Path, ligand_resname: str) -> list[tuple[float, flo
             for line in fh:
                 if not (line.startswith("ATOM") or line.startswith("HETATM")):
                     continue
-                resname = line[17:20].strip().upper()
-                if resname != target:
+                if line[17:20].strip().upper() != target:
                     continue
                 try:
-                    coords.append(
-                        (
-                            float(line[30:38]),
-                            float(line[38:46]),
-                            float(line[46:54]),
-                        )
-                    )
+                    coords.append((float(line[30:38]), float(line[38:46]), float(line[46:54])))
                 except (ValueError, IndexError):
                     continue
     except OSError:
@@ -338,10 +413,7 @@ def _any_atom_within_cutoff(
     ligand_coords: list[tuple[float, float, float]],
     cutoff_sq: float,
 ) -> bool:
-    for lx, ly, lz in ligand_coords:
-        dx = x - lx
-        dy = y - ly
-        dz = z - lz
-        if dx * dx + dy * dy + dz * dz <= cutoff_sq:
-            return True
-    return False
+    return any(
+        (x - lx) ** 2 + (y - ly) ** 2 + (z - lz) ** 2 <= cutoff_sq
+        for lx, ly, lz in ligand_coords
+    )

--- a/src/fastmdxplora/live/trajectory_playback.py
+++ b/src/fastmdxplora/live/trajectory_playback.py
@@ -1,0 +1,347 @@
+"""Trajectory playback helpers for the live dashboard.
+
+The dashboard's "Molecular Viewer" page can step through a downsampled
+playback of the production trajectory (200 frames max by default) so the
+user can scrub or play it back without the cost (or the file size) of
+loading the full scientific DCD. This module never mutates the DCD — it
+only reads frames and writes a multi-MODEL PDB companion.
+
+OpenMM is the only consumer-strict dependency for DCD reading, so it's
+imported lazily. If OpenMM isn't available, the playback route falls
+back to a clean "not available" message; the rest of the dashboard
+keeps working.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from io import StringIO
+from pathlib import Path
+from typing import Any
+
+PLAYBACK_FILE = "playback.pdb"
+PLAYBACK_INDEX_FILE = "playback_index.json"
+
+# Lines that record-level PDB writers emit which conflict when reusing
+# between MODEL blocks. CRYST1 may only appear once; HEADER / TITLE /
+# COMPND may only appear before the first MODEL.
+_HEADER_LIKE_RECORDS = frozenset({
+    "CRYST1", "HEADER", "OBSLTE", "TITLE ", "SPLT  ", "CAVEAT",
+    "COMPND", "SOURCE", "KEYWDS", "EXPDTA", "NUMMDL", "MDLTYP",
+    "AUTHOR", "REVDAT", "DBREF", "DBREF1", "DBREF2", "SEQADV",
+    "SEQRES", "MODRES", "HET ", "HETNAM", "HETSYN", "FORMUL",
+})
+
+
+def PlaybackUnavailable(reason: str) -> dict[str, Any]:
+    """Return a uniform "not available" envelope for the route handler."""
+    return {
+        "playback_available": False,
+        "reason": reason,
+        "n_frames_total": 0,
+        "n_frames_browser": 0,
+        "frame_indices": [],
+        "simulation_time_ns_first": None,
+        "simulation_time_ns_last": None,
+    }
+
+
+def _import_openmm() -> dict[str, Any] | None:
+    """Return a dict of OpenMM symbols or ``None`` if not importable."""
+    try:
+        import openmm
+        from openmm.app import DCDFile, PDBFile
+    except ImportError:
+        return None
+    return {
+        "openmm": openmm,
+        "PDBFile": PDBFile,
+        "DCDFile": DCDFile,
+    }
+
+
+def playback_info(
+    output_dir: str | Path,
+    *,
+    max_browser_frames: int = 200,
+    simulation_time_ns_total: float | None = None,
+    force: bool = False,
+) -> dict[str, Any]:
+    """Build the playback companion files and return a status dictionary.
+
+    Parameters
+    ----------
+    output_dir : path-like
+        The dashboard's project root (typically the FastMDXplora run dir).
+    max_browser_frames : int
+        Cap on the number of frames the browser will load. The trajectory
+        is downsampled evenly so the browser never sees more than this
+        many frames regardless of how large the production run is.
+    simulation_time_ns_total : float | None
+        If known, used to compute simulation-time labels for each frame.
+    force : bool
+        Re-generate even if the companion files already exist. Useful for
+        the dashboard's refresh control.
+
+    Returns
+    -------
+    dict
+        Status envelope consumed by the ``/api/playback-info`` route.
+    """
+    out = Path(output_dir)
+    sim_dir = out / "simulation"
+    topo_path = sim_dir / "topology.pdb"
+    dcd_path = sim_dir / "production.dcd"
+    companion_pdb = sim_dir / PLAYBACK_FILE
+    companion_idx = sim_dir / PLAYBACK_INDEX_FILE
+
+    if not (topo_path.is_file() and dcd_path.is_file()):
+        return PlaybackUnavailable("missing-trajectory")
+
+    if not force and companion_pdb.is_file() and companion_idx.is_file():
+        try:
+            if companion_pdb.stat().st_mtime >= dcd_path.stat().st_mtime:
+                info = _load_index(companion_idx)
+                if info.get("playback_available"):
+                    return info
+        except OSError:
+            pass
+
+    omm = _import_openmm()
+    if omm is None:
+        return PlaybackUnavailable("openmm-not-installed")
+
+    try:
+        return _generate_companion(
+            omm=omm,
+            topology_path=topo_path,
+            dcd_path=dcd_path,
+            companion_pdb=companion_pdb,
+            companion_idx=companion_idx,
+            max_browser_frames=max(1, int(max_browser_frames)),
+            simulation_time_ns_total=simulation_time_ns_total,
+        )
+    except Exception as exc:  # noqa: BLE001 — never crash the dashboard
+        return PlaybackUnavailable(f"generate-error: {exc}")
+
+
+def _generate_companion(
+    *,
+    omm: dict[str, Any],
+    topology_path: Path,
+    dcd_path: Path,
+    companion_pdb: Path,
+    companion_idx: Path,
+    max_browser_frames: int,
+    simulation_time_ns_total: float | None,
+) -> dict[str, Any]:
+    PDBFile = omm["PDBFile"]
+    DCDFile = omm["DCDFile"]
+
+    pdb = PDBFile(str(topology_path))
+    topology = pdb.topology
+
+    dcd = DCDFile(str(dcd_path))
+    n_total = int(len(dcd))
+    if n_total <= 0:
+        return PlaybackUnavailable("empty-trajectory")
+
+    if n_total <= max_browser_frames:
+        frame_indices = list(range(n_total))
+    else:
+        # Even downsample so coverage is uniform across the trajectory.
+        stride = max(1, n_total // max_browser_frames)
+        frame_indices = list(range(0, n_total, stride))[:max_browser_frames]
+        if frame_indices[-1] != n_total - 1:
+            frame_indices.append(n_total - 1)
+
+    n_browser = len(frame_indices)
+    frame_set = set(frame_indices)
+
+    out_lines: list[str] = []
+    written = 0
+    frame_times_ns: list[float | None] = []
+    # DCD iteration is partial-write risky: the OpenMM C++ layer may raise
+    # on a torn final frame. Break on the first error so the dashboard
+    # still serves whatever it already had.
+    try:
+        for idx, frame in enumerate(dcd):
+            if idx not in frame_set:
+                continue
+            buf = StringIO()
+            try:
+                PDBFile.writeFile(topology, frame, buf, keepIds=True)
+            except TypeError:
+                # Older OpenMM versions don't accept keepIds.
+                PDBFile.writeFile(topology, frame, buf)  # type: ignore[call-arg]
+            text = buf.getvalue()
+            # 3Dmol expects MODEL/ENDMDL wrapping. Strip the per-frame
+            # header-record lines that conflict with the multi-MODEL
+            # contract (CRYST1 may only appear once).
+            if written == 0:
+                out_lines.append(f"MODEL     {idx + 1:>4d}")
+            else:
+                out_lines.append(f"MODEL     {idx + 1:>4d}")
+            for ln in text.splitlines():
+                stripped = ln[:6].rstrip().upper()
+                if not stripped:
+                    continue
+                if (
+                    stripped in _HEADER_LIKE_RECORDS
+                    or stripped.startswith("END")
+                    or stripped == "MODEL"
+                    or stripped == "ENDMDL"
+                ):
+                    continue
+                out_lines.append(ln)
+            out_lines.append("ENDMDL")
+            written += 1
+            if simulation_time_ns_total is not None and n_total > 1:
+                frame_times_ns.append(
+                    simulation_time_ns_total * (idx / (n_total - 1))
+                )
+            else:
+                frame_times_ns.append(None)
+            if written >= n_browser:
+                break
+    except Exception:
+        # Mid-trajectory read error (e.g. simulation still writing).
+        # Whatever we already wrote is still servable.
+        pass
+
+    if written == 0:
+        return PlaybackUnavailable("no-frames-read")
+    out_lines.append("END")
+
+    tmp = companion_pdb.with_suffix(".pdb.tmp")
+    tmp.write_text("\n".join(out_lines), encoding="utf-8")
+    os.replace(tmp, companion_pdb)
+
+    payload = {
+        "playback_available": True,
+        "n_frames_total": n_total,
+        "n_frames_browser": written,
+        "frame_indices": [int(i) for i in frame_indices[:written]],
+        "frame_times_ns": frame_times_ns,
+        "simulation_time_ns_first": (
+            frame_times_ns[0] if frame_times_ns and frame_times_ns[0] is not None
+            else None
+        ),
+        "simulation_time_ns_last": (
+            frame_times_ns[-1] if frame_times_ns and frame_times_ns[-1] is not None
+            else None
+        ),
+        "companion_pdb": companion_pdb.name,
+        "compiled_at": time.time(),
+    }
+    tmp_idx = companion_idx.with_suffix(".json.tmp")
+    tmp_idx.write_text(json.dumps(payload), encoding="utf-8")
+    os.replace(tmp_idx, companion_idx)
+    return payload
+
+
+def _load_index(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return PlaybackUnavailable("missing-companion")
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return PlaybackUnavailable("invalid-companion")
+
+
+def neighborhood_residues(
+    *,
+    topology_path: Path,
+    ligand_resname: str,
+    cutoff_angstrom: float = 5.0,
+    coords_path: Path | None = None,
+) -> list[tuple[str, int]]:
+    """Residue keys within ``cutoff_angstrom`` of any ligand atom.
+
+    Returns a list of ``(chain, resSeq)`` tuples. Distances are measured
+    **per atom** (any ligand atom in contact counts) — not centroid
+    sphere — so elongated or peptide-like ligands aren't underestimated.
+
+    Coordinates are read from ``coords_path`` if provided (e.g. the
+    live-frame PDB) and otherwise from the topology file's atoms.
+    """
+    if not topology_path.is_file():
+        return []
+    coords_source = coords_path if coords_path and coords_path.is_file() else topology_path
+    ligand_coords = _ligand_coord_list(coords_source, ligand_resname)
+    if not ligand_coords:
+        return []
+    cutoff_sq = cutoff_angstrom * cutoff_angstrom
+    residues: set[tuple[str, int]] = set()
+    try:
+        with coords_source.open("r", encoding="utf-8", errors="ignore") as fh:
+            for line in fh:
+                if not (line.startswith("ATOM") or line.startswith("HETATM")):
+                    continue
+                resname = line[17:20].strip().upper()
+                if resname == ligand_resname.upper():
+                    continue
+                chain_id = line[21:22].strip() or "A"
+                try:
+                    res_seq = int(line[22:26])
+                except ValueError:
+                    res_seq = 0
+                try:
+                    x = float(line[30:38])
+                    y = float(line[38:46])
+                    z = float(line[46:54])
+                except (ValueError, IndexError):
+                    continue
+                # Per-atom contact check — fast enough for normal pockets
+                # (<200 protein residues × <200 ligand atoms in pure Python).
+                if _any_atom_within_cutoff(
+                    x, y, z, ligand_coords, cutoff_sq
+                ):
+                    residues.add((chain_id, res_seq))
+    except OSError:
+        return []
+    return sorted(residues)
+
+
+def _ligand_coord_list(path: Path, ligand_resname: str) -> list[tuple[float, float, float]]:
+    target = ligand_resname.upper()
+    coords: list[tuple[float, float, float]] = []
+    try:
+        with path.open("r", encoding="utf-8", errors="ignore") as fh:
+            for line in fh:
+                if not (line.startswith("ATOM") or line.startswith("HETATM")):
+                    continue
+                resname = line[17:20].strip().upper()
+                if resname != target:
+                    continue
+                try:
+                    coords.append(
+                        (
+                            float(line[30:38]),
+                            float(line[38:46]),
+                            float(line[46:54]),
+                        )
+                    )
+                except (ValueError, IndexError):
+                    continue
+    except OSError:
+        return []
+    return coords
+
+
+def _any_atom_within_cutoff(
+    x: float,
+    y: float,
+    z: float,
+    ligand_coords: list[tuple[float, float, float]],
+    cutoff_sq: float,
+) -> bool:
+    for lx, ly, lz in ligand_coords:
+        dx = x - lx
+        dy = y - ly
+        dz = z - lz
+        if dx * dx + dy * dy + dz * dz <= cutoff_sq:
+            return True
+    return False

--- a/src/fastmdxplora/orchestrator.py
+++ b/src/fastmdxplora/orchestrator.py
@@ -313,6 +313,9 @@ class FastMDXplora:
             )]
 
         merged_options = self._merge_options(options)
+        dashboard_writer = self._dashboard_writer(merged_options)
+        if dashboard_writer is not None:
+            self._initialize_dashboard_timeline(dashboard_writer, plan)
 
         # Remember the resolved phase selection + merged options so the
         # resolved_config.yml dump reflects what *actually* ran (including
@@ -326,13 +329,28 @@ class FastMDXplora:
         # Plan goes to file/audit; the presenter shows headers visually.
         logger.debug("Plan: %s", " -> ".join(plan))
         for phase in plan:
+            self._mark_dashboard_phase_start(
+                dashboard_writer, phase, merged_options.get(phase, {})
+            )
             self._presenter.phase_start(phase)
             result = self._run_phase(phase, merged_options.get(phase, {}))
             self.results.append(result)
             self._presenter.phase_end(phase, status=result.status)
+            self._mark_dashboard_phase_end(dashboard_writer, phase, result)
             if result.status == "error":
                 logger.error("Phase '%s' failed: %s", phase, result.message)
                 break
+
+        if dashboard_writer is not None:
+            failed = next((item for item in self.results if item.status == "error"), None)
+            dashboard_writer.write_status(
+                status="failed" if failed else "completed",
+                latest_error=failed.message if failed else None,
+            )
+            dashboard_writer.event(
+                "FastMDXplora workflow failed" if failed else "FastMDXplora workflow completed",
+                level="error" if failed else "info",
+            )
 
         self._write_manifest()
         self._write_resolved_config()
@@ -455,6 +473,89 @@ class FastMDXplora:
     # ------------------------------------------------------------------
     # Internals
     # ------------------------------------------------------------------
+    def _dashboard_writer(
+        self, merged_options: dict[str, dict[str, Any]] | None = None
+    ):
+        """Return the project-level telemetry writer when a dashboard is active."""
+        simulation_options = (merged_options or self.options).get("simulation", {})
+        active = bool(
+            simulation_options.get("live_telemetry")
+            or os.getenv("FASTMDX_DASHBOARD_ACTIVE")
+        )
+        if not active:
+            return None
+        try:
+            from fastmdxplora.live.telemetry import TelemetryWriter
+
+            return TelemetryWriter(self.output_dir / "simulation", enabled=True)
+        except Exception as exc:  # noqa: BLE001 -- dashboard must not block science
+            logger.debug("Could not initialize dashboard phase telemetry: %s", exc)
+            return None
+
+    @staticmethod
+    def _initialize_dashboard_timeline(writer: Any, plan: list[str]) -> None:
+        states = {
+            "setup": "waiting" if "setup" in plan else "skipped",
+            "minimization": "waiting" if "simulation" in plan else "skipped",
+            "nvt": "waiting" if "simulation" in plan else "skipped",
+            "npt": "waiting" if "simulation" in plan else "skipped",
+            "production": "waiting" if "simulation" in plan else "skipped",
+            "analysis": "waiting" if "analysis" in plan else "skipped",
+            "report": "waiting" if "report" in plan else "skipped",
+        }
+        writer.write_status(
+            stage=plan[0] if plan else "completed",
+            status="running" if plan else "completed",
+            stage_states=states,
+        )
+        writer.event("Workflow timeline initialized")
+
+    @staticmethod
+    def _mark_dashboard_phase_start(
+        writer: Any, phase: str, options: dict[str, Any]
+    ) -> None:
+        if writer is None:
+            return
+        if phase == "simulation":
+            first_stage = "minimization" if options.get("minimize", True) else "nvt"
+            writer.mark_stage(first_stage, "current", status="running")
+        else:
+            writer.mark_stage(phase, "current", status="running")
+        writer.event(f"{phase.title()} phase started")
+
+    @staticmethod
+    def _mark_dashboard_phase_end(
+        writer: Any, phase: str, result: PhaseResult
+    ) -> None:
+        if writer is None:
+            return
+        state = "completed" if result.status == "ok" else (
+            "skipped" if result.status == "skipped" else "failed"
+        )
+        if phase == "simulation":
+            # The runner records each internal simulation stage.  Only fill
+            # unresolved entries here so a zero-step NPT stage can remain
+            # explicitly skipped and an error remains visible.
+            from fastmdxplora.live.telemetry import read_status
+
+            status = read_status(writer.root.parent)
+            stages = status.get("stage_states") if isinstance(status, dict) else {}
+            stages = stages if isinstance(stages, dict) else {}
+            for name in ("minimization", "nvt", "npt", "production"):
+                if str(stages.get(name, "waiting")).lower() in {"waiting", "current"}:
+                    writer.mark_stage(name, state, status="running" if state != "failed" else "failed")
+        else:
+            writer.mark_stage(
+                phase,
+                state,
+                status="running" if state != "failed" else "failed",
+                latest_error=result.message if state == "failed" else None,
+            )
+        writer.event(
+            f"{phase.title()} phase {state}",
+            level="error" if state == "failed" else "info",
+        )
+
     def _build_plan(
         self,
         *,

--- a/src/fastmdxplora/orchestrator.py
+++ b/src/fastmdxplora/orchestrator.py
@@ -474,35 +474,72 @@ class FastMDXplora:
     # Internals
     # ------------------------------------------------------------------
     def _dashboard_writer(
-        self, merged_options: dict[str, dict[str, Any]] | None = None
+        self,
+        merged_options: dict[str, dict[str, Any]] | None = None,
     ):
         """Return the project-level telemetry writer when a dashboard is active."""
-        simulation_options = (merged_options or self.options).get("simulation", {})
+
+        simulation_options = (
+            merged_options or self.options
+        ).get("simulation", {})
+
+        dashboard_active = (
+            os.getenv("FASTMDX_DASHBOARD_ACTIVE") == "1"
+        )
+        dashboard_output = os.getenv("FASTMDX_DASHBOARD_OUTPUT")
+
+        dashboard_matches_run = False
+
+        if dashboard_active and dashboard_output:
+            try:
+                dashboard_matches_run = (
+                    Path(dashboard_output).expanduser().resolve()
+                    == self.output_dir.expanduser().resolve()
+                )
+            except (OSError, RuntimeError):
+                dashboard_matches_run = False
+
         active = bool(
             simulation_options.get("live_telemetry")
-            or os.getenv("FASTMDX_DASHBOARD_ACTIVE")
+            or dashboard_matches_run
         )
+
         if not active:
             return None
+
         try:
             from fastmdxplora.live.telemetry import TelemetryWriter
 
-            return TelemetryWriter(self.output_dir / "simulation", enabled=True)
-        except Exception as exc:  # noqa: BLE001 -- dashboard must not block science
-            logger.debug("Could not initialize dashboard phase telemetry: %s", exc)
+            return TelemetryWriter(
+                self.output_dir / "simulation",
+                enabled=True,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "Could not initialize dashboard phase telemetry: %s",
+                exc,
+            )
             return None
 
     @staticmethod
-    def _initialize_dashboard_timeline(writer: Any, plan: list[str]) -> None:
+    def _initialize_dashboard_timeline(
+        writer: Any,
+        plan: list[str],
+    ) -> None:
         states = {
             "setup": "waiting" if "setup" in plan else "skipped",
-            "minimization": "waiting" if "simulation" in plan else "skipped",
+            "minimization": (
+                "waiting" if "simulation" in plan else "skipped"
+            ),
             "nvt": "waiting" if "simulation" in plan else "skipped",
             "npt": "waiting" if "simulation" in plan else "skipped",
-            "production": "waiting" if "simulation" in plan else "skipped",
+            "production": (
+                "waiting" if "simulation" in plan else "skipped"
+            ),
             "analysis": "waiting" if "analysis" in plan else "skipped",
             "report": "waiting" if "report" in plan else "skipped",
         }
+
         writer.write_status(
             stage=plan[0] if plan else "completed",
             status="running" if plan else "completed",
@@ -512,50 +549,101 @@ class FastMDXplora:
 
     @staticmethod
     def _mark_dashboard_phase_start(
-        writer: Any, phase: str, options: dict[str, Any]
+        writer: Any,
+        phase: str,
+        options: dict[str, Any],
     ) -> None:
         if writer is None:
             return
+
         if phase == "simulation":
-            first_stage = "minimization" if options.get("minimize", True) else "nvt"
-            writer.mark_stage(first_stage, "current", status="running")
+            first_stage = (
+                "minimization"
+                if options.get("minimize", True)
+                else "nvt"
+            )
+            writer.mark_stage(
+                first_stage,
+                "current",
+                status="running",
+            )
         else:
-            writer.mark_stage(phase, "current", status="running")
+            writer.mark_stage(
+                phase,
+                "current",
+                status="running",
+            )
+
         writer.event(f"{phase.title()} phase started")
 
     @staticmethod
     def _mark_dashboard_phase_end(
-        writer: Any, phase: str, result: PhaseResult
+        writer: Any,
+        phase: str,
+        result: PhaseResult,
     ) -> None:
         if writer is None:
             return
-        state = "completed" if result.status == "ok" else (
-            "skipped" if result.status == "skipped" else "failed"
-        )
+
+        if result.status == "ok":
+            state = "completed"
+        elif result.status == "skipped":
+            state = "skipped"
+        else:
+            state = "failed"
+
         if phase == "simulation":
-            # The runner records each internal simulation stage.  Only fill
-            # unresolved entries here so a zero-step NPT stage can remain
-            # explicitly skipped and an error remains visible.
             from fastmdxplora.live.telemetry import read_status
 
             status = read_status(writer.root.parent)
-            stages = status.get("stage_states") if isinstance(status, dict) else {}
+            stages = (
+                status.get("stage_states")
+                if isinstance(status, dict)
+                else {}
+            )
             stages = stages if isinstance(stages, dict) else {}
-            for name in ("minimization", "nvt", "npt", "production"):
-                if str(stages.get(name, "waiting")).lower() in {"waiting", "current"}:
-                    writer.mark_stage(name, state, status="running" if state != "failed" else "failed")
+
+            for name in (
+                "minimization",
+                "nvt",
+                "npt",
+                "production",
+            ):
+                current_state = str(
+                    stages.get(name, "waiting")
+                ).lower()
+
+                if current_state in {"waiting", "current"}:
+                    writer.mark_stage(
+                        name,
+                        state,
+                        status=(
+                            "failed"
+                            if state == "failed"
+                            else "running"
+                        ),
+                    )
         else:
             writer.mark_stage(
                 phase,
                 state,
-                status="running" if state != "failed" else "failed",
-                latest_error=result.message if state == "failed" else None,
+                status=(
+                    "failed"
+                    if state == "failed"
+                    else "running"
+                ),
+                latest_error=(
+                    result.message
+                    if state == "failed"
+                    else None
+                ),
             )
+
         writer.event(
             f"{phase.title()} phase {state}",
             level="error" if state == "failed" else "info",
         )
-
+        
     def _build_plan(
         self,
         *,

--- a/src/fastmdxplora/report/dashboard.py
+++ b/src/fastmdxplora/report/dashboard.py
@@ -687,9 +687,9 @@ def _write_dashboard_chart(
             alpha=0.95,
         )
         cbar = fig.colorbar(points, ax=ax, pad=0.02, fraction=0.05)
-        cbar.ax.tick_params(colors="#a7b5c6", labelsize=7)
-        cbar.outline.set_edgecolor("#34506a")
-        cbar.set_label("Frame", color="#cbd7e6", fontsize=8)
+        cbar.ax.tick_params(colors="black", labelsize=7)
+        cbar.outline.set_edgecolor("#666666")
+        cbar.set_label("Frame", color="black", fontsize=8)
         summary = f"{len(rows)} frames"
     elif kind == "cluster":
         rows = _numeric_rows(data_path)
@@ -739,9 +739,9 @@ def _write_dashboard_chart(
         ax.set_xlim(-180, 180)
         ax.set_ylim(-180, 180)
         cbar = fig.colorbar(points, ax=ax, pad=0.02, fraction=0.05)
-        cbar.ax.tick_params(colors="#a7b5c6", labelsize=7)
-        cbar.outline.set_edgecolor("#34506a")
-        cbar.set_label("Frame", color="#cbd7e6", fontsize=8)
+        cbar.ax.tick_params(colors="black", labelsize=7)
+        cbar.outline.set_edgecolor("#666666")
+        cbar.set_label("Frame", color="black", fontsize=8)
         summary = f"{len(rows)} angles"
     elif kind == "ss":
         matrix, residues, frames = _secondary_structure_matrix(data_path)
@@ -827,21 +827,38 @@ def _plot_dashboard_dendrogram(
 
 
 def _style_dashboard_axes(fig, ax) -> None:
-    fig.patch.set_facecolor("#0f1a2a")
-    ax.set_facecolor("#0f1a2a")
+    """Apply publication-safe styling to report chart assets."""
+    fig.patch.set_facecolor("white")
+    ax.set_facecolor("white")
     for spine in ax.spines.values():
-        spine.set_color("#34506a")
-    ax.tick_params(colors="#a7b5c6", labelsize=8)
-    ax.xaxis.label.set_color("#cbd7e6")
-    ax.yaxis.label.set_color("#cbd7e6")
+        spine.set_color("#333333")
+    ax.tick_params(colors="black", labelsize=8)
+    ax.xaxis.label.set_color("black")
+    ax.yaxis.label.set_color("black")
     ax.xaxis.label.set_size(8)
     ax.yaxis.label.set_size(8)
-    ax.grid(True, color="#34506a", alpha=0.25, linewidth=0.7)
+    ax.grid(True, color="#d9d9d9", alpha=0.8, linewidth=0.6, linestyle="--")
 
 
 def _finish_dashboard_chart(fig, ax, output_path: Path) -> None:
     fig.tight_layout(pad=0.75)
-    fig.savefig(output_path, facecolor=fig.get_facecolor(), bbox_inches="tight")
+    fig.savefig(
+        output_path,
+        dpi=300,
+        facecolor="white",
+        edgecolor="white",
+        transparent=False,
+        bbox_inches="tight",
+    )
+    if output_path.suffix.lower() != ".svg":
+        fig.savefig(
+            output_path.with_suffix(".svg"),
+            format="svg",
+            facecolor="white",
+            edgecolor="white",
+            transparent=False,
+            bbox_inches="tight",
+        )
     import matplotlib.pyplot as plt
 
     plt.close(fig)

--- a/src/fastmdxplora/report/region_highlights.py
+++ b/src/fastmdxplora/report/region_highlights.py
@@ -349,7 +349,23 @@ def _plot_region_summary(
 
     fig.tight_layout(pad=0.6)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    fig.savefig(output_path, dpi=250, bbox_inches="tight")
+    fig.savefig(
+        output_path,
+        dpi=300,
+        bbox_inches="tight",
+        facecolor="white",
+        edgecolor="white",
+        transparent=False,
+    )
+    if output_path.suffix.lower() != ".svg":
+        fig.savefig(
+            output_path.with_suffix(".svg"),
+            format="svg",
+            bbox_inches="tight",
+            facecolor="white",
+            edgecolor="white",
+            transparent=False,
+        )
     plt.close(fig)
 
 

--- a/src/fastmdxplora/report/summary_figure.py
+++ b/src/fastmdxplora/report/summary_figure.py
@@ -126,7 +126,24 @@ def build_analysis_summary_figure(
 
     fig.tight_layout(pad=0.6)
     figure_path = output_dir / "analysis_summary.png"
-    fig.savefig(figure_path, dpi=250, bbox_inches="tight")
+    fig.savefig(
+        figure_path,
+        dpi=300,
+        bbox_inches="tight",
+        facecolor="white",
+        edgecolor="white",
+        transparent=False,
+    )
+    svg_path = figure_path.with_suffix(".svg")
+    fig.savefig(
+        svg_path,
+        format="svg",
+        bbox_inches="tight",
+        facecolor="white",
+        edgecolor="white",
+        transparent=False,
+    )
     plt.close(fig)
+    artifacts.insert(0, "analysis_summary.svg")
     artifacts.insert(0, "analysis_summary.png")
     return artifacts

--- a/src/fastmdxplora/simulation/runner.py
+++ b/src/fastmdxplora/simulation/runner.py
@@ -1107,6 +1107,36 @@ def _append_live_metric(
         current_frame_count=frame_count,
         simulation_time_completed_ns=sim_time_ns,
     )
+    _maybe_write_live_frame(omm, simulation, telemetry, step)
+
+
+def _maybe_write_live_frame(
+    omm: dict,
+    simulation: Any,
+    telemetry: Any,
+    step: int,
+) -> None:
+    """Snapshot the current positions to ``simulation/live_frame.pdb``.
+
+    Best-effort. Called from the telemetry loop so the dashboard's
+    molecular viewer can refresh without disturbing the simulation.
+    All exceptions are swallowed: live frames are a UI affordance and
+    must never terminate the run.
+    """
+    try:
+        from fastmdxplora.live.live_frames import write_openmm_live_frame
+        positions_state = simulation.context.getState(
+            getPositions=True, enforcePeriodicBox=True
+        )
+        write_openmm_live_frame(
+            telemetry.root,
+            pdb_writer=omm["PDBFile"].writeFile,
+            topology=simulation.topology,
+            positions=positions_state.getPositions(),
+            frame_index=step,
+        )
+    except Exception as exc:  # noqa: BLE001 - dashboard failures must not crash sim
+        logger.debug("live frame snapshot skipped: %s", exc)
 
 
 def _quantity_to_float(quantity: Any, unit_value: Any) -> float | None:

--- a/src/fastmdxplora/simulation/runner.py
+++ b/src/fastmdxplora/simulation/runner.py
@@ -23,6 +23,7 @@ import csv
 import math
 import shutil
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
@@ -813,7 +814,7 @@ def run_simulation(
         # ---- Stage 1: Minimize ----------------------------------------
         if minimize:
             if telemetry is not None:
-                telemetry.write_status(stage="minimization", status="running", current_step=0)
+                telemetry.mark_stage("minimization", "current", status="running", current_step=0)
                 telemetry.event("Minimization started")
             _run_minimize(
                 omm,
@@ -850,7 +851,11 @@ def run_simulation(
                     total_steps=total_planned_steps,
                     timestep_fs=timestep_fs,
                 )
+                telemetry.mark_stage("minimization", "completed", status="running", current_step=0)
                 telemetry.event("Minimization completed")
+        elif telemetry is not None:
+            telemetry.mark_stage("minimization", "skipped", status="running", current_step=0)
+            telemetry.event("Minimization skipped")
 
         # ---- Stage 2: NVT equilibration -------------------------------
         # Use the integrator's existing thermostat (Langevin). No barostat.
@@ -861,8 +866,12 @@ def run_simulation(
         )
         current_step = 0
         if telemetry is not None:
-            telemetry.write_status(stage="NVT", status="running", current_step=current_step)
-            telemetry.event("NVT started")
+            if plan["nvt_steps"] > 0:
+                telemetry.mark_stage("nvt", "current", status="running", current_step=current_step)
+                telemetry.event("NVT started")
+            else:
+                telemetry.mark_stage("nvt", "skipped", status="running", current_step=current_step)
+                telemetry.event("NVT skipped (0 steps)")
         if telemetry is not None:
             current_step = _run_md_stage_with_live_metrics(
                 omm,
@@ -895,7 +904,9 @@ def run_simulation(
                 total_steps=total_planned_steps,
                 timestep_fs=timestep_fs,
             )
-            telemetry.event("NVT completed")
+            if plan["nvt_steps"] > 0:
+                telemetry.mark_stage("nvt", "completed", status="running", current_step=current_step)
+                telemetry.event("NVT completed")
 
         # ---- Stage 3: NPT equilibration -------------------------------
         # Add the barostat and reinitialize the context so the system picks up
@@ -909,7 +920,7 @@ def run_simulation(
             )
             simulation.context.reinitialize(preserveState=True)
             if telemetry is not None:
-                telemetry.write_status(stage="NPT", status="running", current_step=current_step)
+                telemetry.mark_stage("npt", "current", status="running", current_step=current_step)
                 telemetry.event("NPT started")
             if telemetry is not None:
                 current_step = _run_md_stage_with_live_metrics(
@@ -943,7 +954,11 @@ def run_simulation(
                     total_steps=total_planned_steps,
                     timestep_fs=timestep_fs,
                 )
+                telemetry.mark_stage("npt", "completed", status="running", current_step=current_step)
                 telemetry.event("NPT completed")
+        elif telemetry is not None:
+            telemetry.mark_stage("npt", "skipped", status="running", current_step=current_step)
+            telemetry.event("NPT skipped (0 steps)")
 
         # ---- Stage 4: Production --------------------------------------
         # Production runs in NPT (the standard default ensemble).
@@ -965,8 +980,12 @@ def run_simulation(
             interval=checkpoint_interval_steps,
         )
         if telemetry is not None:
-            telemetry.write_status(stage="production", status="running", current_step=current_step)
-            telemetry.event("Production started")
+            if plan["production_steps"] > 0:
+                telemetry.mark_stage("production", "current", status="running", current_step=current_step)
+                telemetry.event("Production started")
+            else:
+                telemetry.mark_stage("production", "skipped", status="running", current_step=current_step)
+                telemetry.event("Production skipped (0 steps)")
         if telemetry is not None:
             current_step = _run_md_stage_with_live_metrics(
                 omm,
@@ -1013,20 +1032,48 @@ def run_simulation(
                 timestep_fs=timestep_fs,
                 frame_count=n_frames,
             )
-            telemetry.event("Production completed")
+            if plan["production_steps"] > 0:
+                telemetry.mark_stage(
+                    "production",
+                    "completed",
+                    status="running",
+                    current_step=current_step,
+                    current_frame_count=n_frames,
+                    simulation_time_completed_ns=(
+                        float(current_step) * float(timestep_fs) / 1_000_000.0
+                    ),
+                )
+                telemetry.event("Production completed")
             telemetry.write_status(
-                stage="completed",
-                status="completed",
+                status="running",
                 current_step=current_step,
                 current_frame_count=n_frames,
-                simulation_time_completed_ns=plan["production_steps"] * timestep_fs / 1_000_000.0,
+                simulation_time_completed_ns=(
+                    float(current_step) * float(timestep_fs) / 1_000_000.0
+                ),
             )
 
         _detach_all_reporters(simulation)
     except Exception as exc:
         if telemetry is not None:
             telemetry.event(f"error: {type(exc).__name__}: {exc}", level="error")
-            telemetry.write_status(status="failed", latest_error=f"{type(exc).__name__}: {exc}")
+            try:
+                from fastmdxplora.live.telemetry import read_status
+
+                current = str(read_status(output_dir.parent).get("stage") or "production").lower()
+                if current in {"minimization", "nvt", "npt", "production"}:
+                    telemetry.mark_stage(
+                        current,
+                        "failed",
+                        status="failed",
+                        latest_error=f"{type(exc).__name__}: {exc}",
+                    )
+                else:
+                    telemetry.write_status(
+                        status="failed", latest_error=f"{type(exc).__name__}: {exc}"
+                    )
+            except Exception:
+                telemetry.write_status(status="failed", latest_error=f"{type(exc).__name__}: {exc}")
         raise
     finally:
         log_fh.close()
@@ -1091,6 +1138,10 @@ def _append_live_metric(
         total = potential + kinetic
     sim_time_ns = float(step) * float(timestep_fs) / 1_000_000.0
     progress = (float(step) / float(total_steps) * 100.0) if total_steps else None
+    temperature = _temperature_from_kinetic_energy(simulation, kinetic)
+    volume_nm3 = _periodic_volume_nm3(state, unit)
+    density_g_ml = _system_density_g_ml(simulation, unit, volume_nm3)
+    speed_ns_day = _telemetry_speed_ns_day(telemetry, sim_time_ns)
     telemetry.append_metric(
         stage=stage,
         step=step,
@@ -1098,16 +1149,109 @@ def _append_live_metric(
         potential_energy=potential,
         kinetic_energy=kinetic,
         total_energy=total,
+        temperature=temperature,
+        volume=volume_nm3,
+        density=density_g_ml,
+        speed=speed_ns_day,
+        current_frame_count=frame_count,
         progress_percent=progress,
     )
-    telemetry.write_status(
-        stage=stage,
+    stage_text = str(stage).lower()
+    if "minim" in stage_text:
+        stage_key = "minimization"
+    elif "nvt" in stage_text:
+        stage_key = "nvt"
+    elif "npt" in stage_text:
+        stage_key = "npt"
+    elif "production" in stage_text:
+        stage_key = "production"
+    else:
+        stage_key = stage_text
+    telemetry.mark_stage(
+        stage_key,
+        "current",
         status="running",
         current_step=step,
         current_frame_count=frame_count,
         simulation_time_completed_ns=sim_time_ns,
     )
-    _maybe_write_live_frame(omm, simulation, telemetry, step)
+    _maybe_write_live_frame(
+        omm,
+        simulation,
+        telemetry,
+        step,
+        stage=stage_key,
+        simulation_time_ns=sim_time_ns,
+    )
+
+
+def _temperature_from_kinetic_energy(
+    simulation: Any,
+    kinetic_kj_per_mol: float | None,
+) -> float | None:
+    """Estimate instantaneous temperature using OpenMM's standard DOF rule."""
+
+    if kinetic_kj_per_mol is None:
+        return None
+    try:
+        system = simulation.system
+        dof = 3 * int(system.getNumParticles()) - int(system.getNumConstraints())
+        for index in range(int(system.getNumForces())):
+            force = system.getForce(index)
+            if force.__class__.__name__ == "CMMotionRemover":
+                dof -= 3
+                break
+        if dof <= 0:
+            return None
+        # R in kJ mol^-1 K^-1.  OpenMM's StateDataReporter uses the same
+        # equipartition relation for its Temperature column.
+        gas_constant = 0.00831446261815324
+        return (2.0 * float(kinetic_kj_per_mol)) / (float(dof) * gas_constant)
+    except Exception:  # noqa: BLE001 - telemetry is best-effort
+        return None
+
+
+def _periodic_volume_nm3(state: Any, unit: Any) -> float | None:
+    try:
+        volume = state.getPeriodicBoxVolume()
+    except Exception:  # noqa: BLE001
+        return None
+    try:
+        return _quantity_to_float(volume, unit.nanometer**3)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _system_density_g_ml(
+    simulation: Any,
+    unit: Any,
+    volume_nm3: float | None,
+) -> float | None:
+    if volume_nm3 is None or volume_nm3 <= 0:
+        return None
+    try:
+        system = simulation.system
+        mass_dalton = 0.0
+        for index in range(int(system.getNumParticles())):
+            mass_dalton += float(
+                _value_in_unit(system.getParticleMass(index), unit.dalton)
+            )
+        # 1 Da / nm^3 = 1.66053906660e-3 g/mL.
+        return mass_dalton * 1.66053906660e-3 / float(volume_nm3)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _telemetry_speed_ns_day(telemetry: Any, sim_time_ns: float) -> float | None:
+    try:
+        elapsed = (
+            datetime.now(timezone.utc) - telemetry.start_time
+        ).total_seconds()
+    except Exception:  # noqa: BLE001
+        return None
+    if elapsed <= 0:
+        return None
+    return float(sim_time_ns) * 86400.0 / float(elapsed)
 
 
 def _maybe_write_live_frame(
@@ -1115,6 +1259,9 @@ def _maybe_write_live_frame(
     simulation: Any,
     telemetry: Any,
     step: int,
+    *,
+    stage: str,
+    simulation_time_ns: float,
 ) -> None:
     """Snapshot the current positions to ``simulation/live_frame.pdb``.
 
@@ -1130,10 +1277,13 @@ def _maybe_write_live_frame(
         )
         write_openmm_live_frame(
             telemetry.root,
-            pdb_writer=omm["PDBFile"].writeFile,
+            pdbfile_writer=omm["PDBFile"].writeFile,
             topology=simulation.topology,
             positions=positions_state.getPositions(),
             frame_index=step,
+            stage=stage,
+            simulation_time_ns=simulation_time_ns,
+            archive=True,
         )
     except Exception as exc:  # noqa: BLE001 - dashboard failures must not crash sim
         logger.debug("live frame snapshot skipped: %s", exc)

--- a/src/fastmdxplora/utils/presenter.py
+++ b/src/fastmdxplora/utils/presenter.py
@@ -149,10 +149,186 @@ class SessionPresenter:
         self._session_start: float | None = None
         self._phase_start: float | None = None
         self._current_phase: str | None = None
+        self._welcome_shown: bool = False
 
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
+    def welcome(
+        self,
+        *,
+        dashboard_url: str = "http://127.0.0.1:8765",
+        dashboard_enabled: bool = False,
+    ) -> None:
+        """Print the centered FastMDXplora startup identity once.
+
+        The startup screen is deliberately minimal: one responsive wordmark,
+        the product name and tagline, and the dashboard address.  It performs
+        no simulation work and does not print the full command help.
+
+        ``dashboard_enabled`` is retained for API compatibility with older
+        callers, but the startup design intentionally avoids active/inactive
+        status wording.
+        """
+        if self.quiet or self._welcome_shown:
+            return
+
+        self._welcome_shown = True
+        _ = dashboard_enabled
+
+        # Five-row block glyphs are rendered as one plain-text block before
+        # ANSI styling is applied. This keeps width calculations accurate and
+        # prevents individual lines from drifting away from the shared center.
+        glyphs = {
+            "A": ("01110", "10001", "11111", "10001", "10001"),
+            "D": ("11110", "10001", "10001", "10001", "11110"),
+            "F": ("11111", "10000", "11110", "10000", "10000"),
+            "L": ("10000", "10000", "10000", "10000", "11111"),
+            "M": ("10001", "11011", "10101", "10001", "10001"),
+            "O": ("01110", "10001", "10001", "10001", "01110"),
+            "P": ("11110", "10001", "11110", "10000", "10000"),
+            "R": ("11110", "10001", "11110", "10100", "10010"),
+            "S": ("01111", "10000", "01110", "00001", "11110"),
+            "T": ("11111", "00100", "00100", "00100", "00100"),
+            "X": ("10001", "01010", "00100", "01010", "10001"),
+        }
+        word = "FASTMDXPLORA"
+
+        def render_wordmark(cell_width: int, gap: int) -> list[str]:
+            on = "█" * cell_width
+            off = " " * cell_width
+            separator = " " * gap
+            rows: list[str] = []
+            for row_index in range(5):
+                letters = [
+                    "".join(
+                        on if bit == "1" else off
+                        for bit in glyphs[letter][row_index]
+                    )
+                    for letter in word
+                ]
+                rows.append(separator.join(letters).rstrip())
+            return rows
+
+        usable_width = max(36, self.width - 4)
+        target_width = max(1, int(usable_width * 0.88))
+
+        if usable_width >= 131:
+            # Two-column pixels produce the largest wordmark. Select the gap
+            # dynamically so the logo occupies most of wide terminals.
+            gap = max(1, min(4, (target_width - 120) // 11))
+            logo = render_wordmark(cell_width=2, gap=gap)
+        elif usable_width >= 71:
+            # One-column pixels remain crisp on normal terminals while a
+            # variable gap prevents the wordmark from looking undersized.
+            gap = max(1, min(4, (target_width - 60) // 11))
+            logo = render_wordmark(cell_width=1, gap=gap)
+        else:
+            logo = ["FASTMDXPLORA"]
+
+        def center_plain(text: str, width: int | None = None) -> str:
+            available = self.width if width is None else width
+            padding = max(0, (available - _visual_width(text)) // 2)
+            return (" " * padding) + text
+
+        def purple_bold(text: str) -> str:
+            if not self._color:
+                return text
+            return f"{_C['purple']}{_C['bold']}{text}{_C['reset']}"
+
+        # Normalize every row to one block width and apply one shared left
+        # padding value. The block therefore has a single visual center axis.
+        logo_width = max(_visual_width(line) for line in logo)
+        normalized_logo = [line.ljust(logo_width) for line in logo]
+        logo_left = max(0, (self.width - logo_width) // 2)
+
+        self._write("")
+        for logo_line in normalized_logo:
+            plain_line = (" " * logo_left) + logo_line
+            self._write(self._c(plain_line, "purple"))
+
+        product_name = "FastMDXplora"
+        tagline = "Fully Automated SysTem for Molecular Dynamics eXploration"
+
+        def wrap_words(text: str, limit: int) -> list[str]:
+            words = text.split()
+            lines: list[str] = []
+            current: list[str] = []
+            current_width = 0
+            for word in words:
+                added = len(word) if not current else len(word) + 1
+                if current and current_width + added > limit:
+                    lines.append(" ".join(current))
+                    current = [word]
+                    current_width = len(word)
+                else:
+                    current.append(word)
+                    current_width += added
+            if current:
+                lines.append(" ".join(current))
+            return lines or [""]
+
+        self._write("")
+        self._write(purple_bold(center_plain(product_name)))
+        for tagline_line in wrap_words(tagline, max(20, self.width - 4)):
+            self._write(self._c(center_plain(tagline_line), "purple"))
+        self._write("")
+
+        # The box is centered as one unit; each content line is then centered
+        # inside the box. All branding uses the same purple palette.
+        box_width = min(
+            max(64, _visual_width(tagline) + 8),
+            max(36, self.width - 4),
+        )
+        inner_width = max(1, box_width - 2)
+
+        def fit(text: str) -> str:
+            if _visual_width(text) <= inner_width:
+                return text
+            if inner_width <= 3:
+                return text[:inner_width]
+            return text[: inner_width - 3] + "..."
+
+        def box_line(text: str) -> str:
+            fitted = fit(text)
+            visible = _visual_width(fitted)
+            left = max(0, (inner_width - visible) // 2)
+            right = max(0, inner_width - visible - left)
+            return "│" + (" " * left) + fitted + (" " * right) + "│"
+
+        box_left = max(0, (self.width - box_width) // 2)
+        box_prefix = " " * box_left
+        top = "╭" + ("─" * inner_width) + "╮"
+        bottom = "╰" + ("─" * inner_width) + "╯"
+
+        # Keep the wordmark purple, but make the dashboard call-to-action
+        # visually distinct with a cyan border, white heading/instruction,
+        # and a bright cyan URL.
+        self._write(self._c(box_prefix + top, "cyan"))
+        self._write(
+            self._c(
+                box_prefix + box_line("DASHBOARD"),
+                "white",
+            )
+        )
+        self._write(
+            self._c(
+                box_prefix + box_line(dashboard_url),
+                "cyan",
+            )
+        )
+        self._write(
+            self._c(
+                box_prefix
+                + box_line(
+                    "Open the dashboard to configure and launch a simulation."
+                ),
+                "white",
+            )
+        )
+        self._write(self._c(box_prefix + bottom, "cyan"))
+        self._write("")
+
     def banner(self, **fields: str) -> None:
         import os as _os
         import sys as _sys
@@ -352,15 +528,21 @@ class SessionPresenter:
             or _os.environ.get("FASTMDX_DASHBOARD_URL", "")
         )
 
-        dashboard_enabled = "--dashboard" in argv
+        dashboard_enabled = (
+            "--dashboard" in argv
+            or "--live-dashboard" in argv
+            or _os.environ.get("FASTMDX_DASHBOARD_ACTIVE") == "1"
+        )
 
-        if not dashboard_link and dashboard_enabled:
+        if not dashboard_link:
             dashboard_host = arg_value(
                 "--dashboard-host",
+                "--host",
                 default="127.0.0.1",
             )
             dashboard_port = arg_value(
                 "--dashboard-port",
+                "--port",
                 default="8765",
             )
 
@@ -382,52 +564,86 @@ class SessionPresenter:
         BR = chr(0x256F)
         CHECK = chr(0x2713)
 
-        box_width = min(max(40, self.width - 2), 112)
+        # Every run-information box uses one shared width and one shared
+        # indentation. The boxes are centered beneath the startup wordmark,
+        # while their internal content remains left-aligned for readability.
+        box_width = min(112, max(72, self.width - 24))
+        box_width = min(box_width, max(38, self.width - 2))
         content_w = box_width - 4
+        box_indent = max(0, (self.width - box_width) // 2)
+        box_prefix = " " * box_indent
 
-        ascii_logo = [
-            r" ______        _   __  __ _______   __      _                 ",
-            r"|  ____|      | | |  \/  |  __ \ \ / /     | |                ",
-            r"| |__ __ _ ___| |_| \  / | |  | \ V / _ __ | | ___  _ __ __ _ ",
-            r"|  __/ _` / __| __| |\/| | |  | |> < | '_ \| |/ _ \| '__/ _` |",
-            r"| | | (_| \__ \ |_| |  | | |__| / . \| |_) | | (_) | | | (_| |",
-            r"|_|  \__,_|___/\__|_|  |_|_____/_/ \_\ .__/|_|\___/|_|  \__,_|",
-            r"                                     | |                      ",
-            r"                                     |_|                      ",
-        ]
-
-        def fit(text: str) -> str:
+        def fit(text: str, limit: int | None = None) -> str:
             text = str(text)
-            if len(text) <= content_w:
+            available = content_w if limit is None else max(0, limit)
+            if _visual_width(text) <= available:
                 return text
-            return text[: max(0, content_w - 3)] + "..."
+            if available <= 3:
+                return text[:available]
+            return text[: max(0, available - 3)] + "..."
 
         def top(color: str) -> None:
-            self._write(self._c(TL + H * (box_width - 2) + TR, color))
+            self._write(
+                box_prefix + self._c(TL + H * (box_width - 2) + TR, color)
+            )
 
         def bottom(color: str) -> None:
-            self._write(self._c(BL + H * (box_width - 2) + BR, color))
+            self._write(
+                box_prefix + self._c(BL + H * (box_width - 2) + BR, color)
+            )
 
-        def line(text: str = "", border: str = "cyan", text_color: str | None = None) -> None:
+        def line(
+            text: str = "",
+            border: str = "cyan",
+            text_color: str | None = None,
+        ) -> None:
             raw = fit(text)
-            pad = " " * max(0, content_w - len(raw))
+            pad = " " * max(0, content_w - _visual_width(raw))
             body = self._c(raw, text_color) if text_color else raw
-            self._write(self._c(V, border) + " " + body + pad + " " + self._c(V, border))
+            self._write(
+                box_prefix
+                + self._c(V, border)
+                + " "
+                + body
+                + pad
+                + " "
+                + self._c(V, border)
+            )
 
         def title(text: str, border: str) -> None:
             line(text, border, "white")
             line(H * len(text), border, border)
 
-        def kv(label: str, value: str, border: str, value_color: str = "white") -> None:
-            line(f"{label:<16} {value}", border, value_color)
+        def kv(
+            label: str,
+            value: str,
+            border: str,
+            *,
+            label_color: str | None = None,
+            value_color: str = "white",
+        ) -> None:
+            label_width = min(16, max(8, content_w // 3))
+            label_raw = fit(label, label_width).ljust(label_width)
+            value_limit = max(0, content_w - label_width - 1)
+            value_raw = fit(value, value_limit)
+            visible = _visual_width(label_raw) + 1 + _visual_width(value_raw)
+            pad = " " * max(0, content_w - visible)
+            self._write(
+                box_prefix
+                + self._c(V, border)
+                + " "
+                + self._c(label_raw, label_color or border)
+                + " "
+                + self._c(value_raw, value_color)
+                + pad
+                + " "
+                + self._c(V, border)
+            )
 
-        self._write("")
-
-        for logo_line in ascii_logo:
-            self._write(self._c(logo_line, "purple"))
-
-        self._write(self._c("Fully Automated SysTem for Molecular Dynamics eXploration", "cyan"))
-        self._write("")
+        self.welcome(
+            dashboard_url=dashboard_link,
+            dashboard_enabled=dashboard_enabled,
+        )
 
         top("green")
         title("CURRENT RUN", "green")
@@ -460,18 +676,40 @@ class SessionPresenter:
         bottom("orange")
         self._write("")
 
-        top("purple")
-        title("ANALYSIS & REPORT", "purple")
-        kv("Dashboard", dashboard_link if dashboard_link else " ", "purple")
-        kv("Report", report_title, "purple")
-        bottom("purple")
+        # Analysis and report information uses a blue frame, cyan labels,
+        # and white values. The box itself shares the same centered layout as
+        # every other run-information section; its contents remain left-aligned.
+        top("blue")
+        title("ANALYSIS & REPORT", "blue")
+        kv(
+            "Dashboard",
+            dashboard_link if dashboard_link else "Not available",
+            "blue",
+            label_color="cyan",
+        )
+        kv(
+            "Report",
+            report_title,
+            "blue",
+            label_color="cyan",
+        )
+        bottom("blue")
         self._write("")
 
-        top("blue")
-        title("REPORTING & OUTPUTS", "blue")
-        line(f"{CHECK} Markdown report      {CHECK} HTML summary        {CHECK} PDF figures", "blue", "white")
-        line(f"{CHECK} PowerPoint slides    {CHECK} PNG/SVG plots       {CHECK} ZIP result bundle", "blue", "white")
-        bottom("blue")
+        # Use green here to balance the cyan, orange, and blue sections above.
+        top("green")
+        title("REPORTING & OUTPUTS", "green")
+        line(
+            f"{CHECK} Markdown report      {CHECK} HTML summary        {CHECK} PDF figures",
+            "green",
+            "white",
+        )
+        line(
+            f"{CHECK} PowerPoint slides    {CHECK} PNG/SVG plots       {CHECK} ZIP result bundle",
+            "green",
+            "white",
+        )
+        bottom("green")
         self._write("")
 
         badges = [
@@ -486,11 +724,11 @@ class SessionPresenter:
             return "  ".join(self._c(CHECK, "green") + f" {item}" for item in items)
 
         all_badges = badge_line(badges)
-        if _visual_width(all_badges) <= self.width + 20:
-            self._write(all_badges)
+        if _visual_width(all_badges) <= box_width:
+            self._write(box_prefix + all_badges)
         else:
-            self._write(badge_line(badges[:3]))
-            self._write(badge_line(badges[3:]))
+            self._write(box_prefix + badge_line(badges[:3]))
+            self._write(box_prefix + badge_line(badges[3:]))
         self._write("")
 
     def phase_start(self, name: str) -> None:

--- a/src/fastmdxplora/utils/presenter.py
+++ b/src/fastmdxplora/utils/presenter.py
@@ -344,7 +344,34 @@ class SessionPresenter:
         trajectory_display = resolve_trajectory_display()
 
         report_title = arg_value("--report-title", default="FastMDXplora Run")
-        dashboard_link = _os.environ.get("FASTMDX_DASHBOARD_URL", "")
+        # Resolve the dashboard URL from an explicitly supplied field,
+        # an environment variable, or the dashboard CLI flags.
+        dashboard_link = str(
+            fields.get("Dashboard")
+            or fields.get("dashboard_url")
+            or _os.environ.get("FASTMDX_DASHBOARD_URL", "")
+        )
+
+        dashboard_enabled = "--dashboard" in argv
+
+        if not dashboard_link and dashboard_enabled:
+            dashboard_host = arg_value(
+                "--dashboard-host",
+                default="127.0.0.1",
+            )
+            dashboard_port = arg_value(
+                "--dashboard-port",
+                default="8765",
+            )
+
+            # 0.0.0.0 and :: are server bind addresses, not useful browser URLs.
+            display_host = (
+                "127.0.0.1"
+                if dashboard_host in {"0.0.0.0", "::", "[::]"}
+                else dashboard_host
+            )
+
+            dashboard_link = f"http://{display_host}:{dashboard_port}"
         started = _time.strftime("%Y-%m-%d %H:%M:%S")
 
         H = chr(0x2500)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,11 +50,9 @@ def test_cli_help_subprocess() -> None:
     assert "report" in result.stdout
 
 
-def test_cli_no_args_starts_dashboard_home() -> None:
-    with patch("fastmdxplora.cli.main._cmd_dashboard_home", return_value=0) as home:
-        rc = main([])
+def test_cli_no_args_shows_help() -> None:
+    rc = main([])
     assert rc == 0
-    home.assert_called_once_with()
 
 
 def test_cli_cite() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,9 +50,12 @@ def test_cli_help_subprocess() -> None:
     assert "report" in result.stdout
 
 
-def test_cli_no_args_shows_help() -> None:
-    rc = main([])
+def test_cli_no_args_starts_dashboard_home() -> None:
+    cli_main_module = sys.modules["fastmdxplora.cli.main"]
+    with patch.object(cli_main_module, "_cmd_dashboard_home", return_value=0) as home:
+        rc = main([])
     assert rc == 0
+    home.assert_called_once_with()
 
 
 def test_cli_cite() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,9 +50,11 @@ def test_cli_help_subprocess() -> None:
     assert "report" in result.stdout
 
 
-def test_cli_no_args_shows_help() -> None:
-    rc = main([])
+def test_cli_no_args_starts_dashboard_home() -> None:
+    with patch("fastmdxplora.cli.main._cmd_dashboard_home", return_value=0) as home:
+        rc = main([])
     assert rc == 0
+    home.assert_called_once_with()
 
 
 def test_cli_cite() -> None:

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -6,8 +6,9 @@ from types import SimpleNamespace
 
 import numpy as np
 import pytest
+from PIL import Image
 
-from fastmdxplora.report.dashboard import build_dashboard
+from fastmdxplora.report.dashboard import build_dashboard, _write_dashboard_chart
 from fastmdxplora.report.region_highlights import (
     RegionHighlight,
     build_pymol_script,
@@ -186,3 +187,24 @@ def _write_plot(root: Path, image_rel: str, data_rel: str | None, data: str | No
         path = root / data_rel
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(data, encoding="utf-8")
+
+
+def test_report_chart_assets_use_publication_white_background_and_labels(tmp_path: Path) -> None:
+    data = tmp_path / "rmsd.dat"
+    data.write_text("0 0.10\n1 0.20\n2 0.15\n", encoding="utf-8")
+    output = tmp_path / "rmsd_dashboard.png"
+
+    _write_dashboard_chart(
+        data_path=data,
+        output_path=output,
+        kind="line",
+        color="#4E79A7",
+        xlabel="Time (ns)",
+        ylabel="RMSD (nm)",
+    )
+
+    assert output.is_file()
+    with Image.open(output).convert("RGB") as image:
+        # Corners are outside the axes and should remain opaque white.
+        assert image.getpixel((0, 0)) == (255, 255, 255)
+        assert image.getpixel((image.width - 1, image.height - 1)) == (255, 255, 255)

--- a/tests/test_dashboard_coverage.py
+++ b/tests/test_dashboard_coverage.py
@@ -131,6 +131,7 @@ def test_playback_error_branches_and_neighborhood(tmp_path: Path) -> None:
 
 
 def test_launcher_validation_command_and_runtime_branches(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(launch, "launcher_environment_error", lambda _config: None)
     bad = _launch_payload()
     bad.update(system="x" * 4097)
     bad["setup"].update(ph="bad", forcefield="bad", ion_concentration_M="bad", solvent_padding_nm=99)

--- a/tests/test_dashboard_coverage.py
+++ b/tests/test_dashboard_coverage.py
@@ -1,0 +1,364 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from fastmdxplora.live import launcher as launch
+from fastmdxplora.live import live_frames as frames
+from fastmdxplora.live import trajectory_playback as playback
+from fastmdxplora.live.ligand_detection import detect_ligands, filter_pdb_to_ligand
+from fastmdxplora.live.structure_info import _count_structure_cached, count_structure, ligand_atom_counts
+
+
+def _atom(record="ATOM", res="ALA", chain="A", seq=1, x=0.0, y=0.0, z=0.0) -> str:
+    return f"{record:<6}{1:5d}  CA  {res:>3} {chain}{seq:4d}    {x:8.3f}{y:8.3f}{z:8.3f}  1.00 10.00           C"
+
+
+def _launch_payload() -> dict:
+    return {
+        "system": "1L2Y", "run_name": "run",
+        "setup": {"ph": 7, "forcefield": "charmm36", "water_model": "auto",
+                  "ion_concentration_M": .15, "solvent_padding_nm": 1},
+        "simulation": {"minimize": True, "nvt_steps": 1, "npt_steps": 1,
+                       "production_steps": 10, "timestep_fs": 2, "temperature_K": 300,
+                       "friction_per_ps": 1, "integrator": "langevin_middle", "platform": "CPU",
+                       "precision": "mixed", "trajectory_interval_steps": 2,
+                       "checkpoint_interval_steps": 0, "telemetry_interval": 2},
+        "workflow": {"run_analysis": True, "run_report": True, "analyses": ["rmsd"],
+                     "report_document": True, "report_slides": True, "report_bundle": True},
+    }
+
+
+class _Topology:
+    def __init__(self, selected=(0, 1), fail=False):
+        self.selected, self.fail = selected, fail
+
+    def select(self, _query):
+        if self.fail:
+            raise RuntimeError("selection failed")
+        return list(self.selected)
+
+
+class _BrowserTrajectory:
+    def __init__(self, times=(0.0, 0.0)):
+        self.time = list(times)
+
+    def save_pdb(self, path):
+        Path(path).write_text(_atom() + "\nEND\n", encoding="utf-8")
+
+
+class _Trajectory:
+    def __init__(self, n_frames=5, times=(0.0, 0.0)):
+        self.n_frames, self.times = n_frames, times
+
+    def __getitem__(self, _indices):
+        return _BrowserTrajectory(self.times)
+
+
+class _MD:
+    def __init__(self, *, n_frames=5, selected=(0, 1), select_fail=False, dcd_fail=False):
+        self.topology = _Topology(selected, select_fail)
+        self.trajectory = _Trajectory(n_frames)
+        self.dcd_fail = dcd_fail
+
+    def load_pdb(self, _path):
+        return SimpleNamespace(topology=self.topology)
+
+    def load_dcd(self, *_args, **_kwargs):
+        if self.dcd_fail:
+            raise RuntimeError("busy dcd")
+        return self.trajectory
+
+
+def test_playback_dcd_cache_fallback_and_helpers(tmp_path: Path, monkeypatch) -> None:
+    out, sim = tmp_path / "run", tmp_path / "run" / "simulation"
+    sim.mkdir(parents=True)
+    (sim / "topology.pdb").write_text(_atom() + "\nEND\n", encoding="utf-8")
+    (sim / "production.dcd").write_bytes(b"dcd")
+    (sim / "live_status.json").write_text('{"status":"completed"}', encoding="utf-8")
+    monkeypatch.setattr(playback, "_import_mdtraj", lambda: _MD())
+
+    result = playback.playback_info(out, max_browser_frames=3, simulation_time_ns_total=1.0)
+    assert result["source_kind"] == "production-dcd" and result["frame_times_ns"][-1] == 1.0
+    assert playback.playback_info(out) == json.loads((sim / "playback_index.json").read_text())
+    assert playback._even_indices(10, 2) == [0, 9]
+    assert playback._even_indices(3, 5) == [0, 1, 2]
+    assert playback._load_index(tmp_path / "missing.json")["reason"] == "invalid-companion"
+
+    # A temporarily unreadable DCD falls back to completed live-history snapshots.
+    for i in range(2):
+        p = sim / f"h{i}.pdb"
+        p.write_text(_atom(seq=i + 1) + "\nEND\n", encoding="utf-8")
+    (sim / "live_frame_history.json").write_text(json.dumps({"frames": [
+        {"path": "h0.pdb", "sequence": 0, "frame_index": 0, "simulation_time_ns": 0.0},
+        {"path": "h1.pdb", "sequence": 1, "frame_index": 1, "simulation_time_ns": 0.1},
+    ]}), encoding="utf-8")
+    monkeypatch.setattr(playback, "_import_mdtraj", lambda: _MD(dcd_fail=True))
+    result = playback.playback_info(out, force=True)
+    assert result["source_kind"] == "live-history"
+
+
+def test_playback_error_branches_and_neighborhood(tmp_path: Path) -> None:
+    topology = tmp_path / "top.pdb"
+    topology.write_text("\n".join([
+        _atom("HETATM", "LIG", seq=9),
+        _atom("ATOM", "ALA", seq=1, x=1),
+        "ATOM bad-coordinate-line",
+        "END",
+    ]), encoding="utf-8")
+    assert playback.neighborhood_residues(topology_path=topology, ligand_resname="LIG") == [("A", 1)]
+    assert playback.neighborhood_residues(topology_path=tmp_path / "none", ligand_resname="LIG") == []
+    assert playback.neighborhood_residues(topology_path=topology, ligand_resname="XXX") == []
+
+    idx = tmp_path / "index.json"
+    pdb = tmp_path / "playback.pdb"
+    one = playback._generate_from_dcd(
+        md=_MD(n_frames=1, selected=(), select_fail=True), topology_path=topology,
+        dcd_path=tmp_path / "x.dcd", companion_pdb=pdb, companion_idx=idx,
+        max_browser_frames=2, simulation_time_ns_total=None, source_signature="x",
+    )
+    assert one["reason"] == "not-enough-trajectory-frames"
+
+    unreadable = playback._generate_from_history(
+        sim_dir=tmp_path, records=[{"path": "missing"}, {"path": "also-missing"}],
+        companion_pdb=pdb, companion_idx=idx, max_browser_frames=2, source_signature="x",
+    )
+    assert unreadable["reason"] == "not-enough-readable-history-frames"
+
+
+def test_launcher_validation_command_and_runtime_branches(tmp_path: Path, monkeypatch) -> None:
+    bad = _launch_payload()
+    bad.update(system="x" * 4097)
+    bad["setup"].update(ph="bad", forcefield="bad", ion_concentration_M="bad", solvent_padding_nm=99)
+    bad["simulation"].update(integrator="bad", platform="bad", precision="bad", nvt_steps="bad")
+    bad["workflow"].update(run_analysis=False, run_report=True, analyses="bad")
+    result = launch.validate_launcher_payload(bad)
+    assert not result["valid"] and result["warnings"]
+    assert {"system", "setup.ph", "setup.forcefield", "simulation.integrator"} <= result["errors"].keys()
+
+    cfg = launch.validate_launcher_payload(_launch_payload())["config"]
+    cfg["setup"].update(water_model="tip3p", keep_heterogens=True, keep_water=True)
+    cfg["simulation"]["minimize"] = False
+    cfg["workflow"].update(run_analysis=False, report_document=False, report_slides=False, report_bundle=False)
+    command = launch.build_launcher_command(cfg, tmp_path / "out")
+    for flag in ("--setup-water-model", "--setup-keep-heterogens", "--setup-keep-water",
+                 "--simulate-no-minimize", "--include", "--report-no-document",
+                 "--report-no-slides", "--report-no-bundle"):
+        assert flag in command
+
+    runtime = launch.DashboardRuntime(tmp_path / "workspace", tmp_path / "runs")
+    assert runtime.launch({"system": ""})["valid"] is False
+    runtime.process = SimpleNamespace(poll=lambda: 0)
+    assert runtime.snapshot()["status"] == "completed"
+    runtime.process = SimpleNamespace(poll=lambda: 2)
+    runtime.process_returncode = None
+    assert runtime.snapshot()["status"] == "failed"
+
+    terminated = []
+    runtime.process = SimpleNamespace(poll=lambda: None, terminate=lambda: terminated.append(True))
+    assert runtime.stop()["stopped"] and terminated
+    assert runtime.launch(_launch_payload())["errors"]["run"]
+
+    occupied = launch.DashboardRuntime(tmp_path / "w2", tmp_path / "runs2")
+    target = occupied.launch_root / "run"
+    target.mkdir()
+    (target / "file").write_text("x", encoding="utf-8")
+    assert "not empty" in occupied.launch(_launch_payload())["errors"]["run_name"]
+
+    failing = launch.DashboardRuntime(tmp_path / "w3", tmp_path / "runs3")
+    monkeypatch.setattr(launch.subprocess, "Popen", lambda *_a, **_k: (_ for _ in ()).throw(OSError("no")))
+    with pytest.raises(OSError):
+        failing.launch(_launch_payload())
+
+
+def test_live_frame_failure_fallbacks_and_bounded_archive(tmp_path: Path, monkeypatch) -> None:
+    text = "CRYST1".ljust(80) + "\n" + _atom() + "\nTER\nEND\n"
+    assert "CRYST1" in frames.dashboard_display_pdb(text) and "TER" in frames.dashboard_display_pdb(text)
+
+    with patch.object(Path, "stat", side_effect=OSError), patch.object(frames, "_atomic_json", side_effect=OSError):
+        result = frames.write_live_frame(tmp_path / "fallback", pdb_text=text, frame_index=1)
+    assert result["ok"] and result["live_frame_size"] == len(text.encode())
+
+    def old_writer(_topology, _positions, buf):
+        buf.write(text)
+    assert frames.write_openmm_live_frame(tmp_path / "openmm", pdbfile_writer=old_writer,
+                                          topology=None, positions=None)["ok"]
+    assert not frames.write_openmm_live_frame(tmp_path, pdbfile_writer=lambda *_a, **_k: None,
+                                              topology=None, positions=None)["ok"]
+    assert not frames.write_openmm_live_frame(tmp_path, pdbfile_writer=lambda *_a, **_k: 1 / 0,
+                                              topology=None, positions=None)["ok"]
+
+    archive = tmp_path / "archive"
+    for i in range(3):
+        assert frames.write_live_frame(archive, pdb_text=text, frame_index=i, archive=True,
+                                       max_history_frames=2)["ok"]
+    history = frames.read_live_frame_history(archive)
+    assert history["count"] == 2 and history["frames"][0]["frame_index"] == 1
+
+    (archive / frames.LIVE_FRAME_INDEX_FILE).write_text("bad", encoding="utf-8")
+    assert frames.read_live_frame_index(archive) == {"live_frame_available": False}
+    monkeypatch.setattr(Path, "mkdir", lambda *_a, **_k: (_ for _ in ()).throw(OSError("blocked")))
+    assert frames._archive_frame(tmp_path / "blocked", pdb_text=text, frame_index=0, stage="NVT",
+                                 simulation_time_ns=0, max_history_frames=2)["count"] == 0
+
+
+def test_ligand_and_structure_edge_paths(tmp_path: Path) -> None:
+    detected = detect_ligands([("A", "", "1"), ("A", "ALA", "2"), ("A", "LIG", "10A")])
+    assert detected["resnames"] == ["LIG"]
+    pdb = "HEADER keep\n" + _atom("HETATM", "LIG") + "\n" + _atom("ATOM", "ALA")
+    assert filter_pdb_to_ligand(pdb, "") == pdb
+    filtered = filter_pdb_to_ligand(pdb, "lig")
+    assert "LIG" in filtered and "ALA" not in filtered and "HEADER" in filtered
+
+    structure = tmp_path / "structure.pdb"
+    structure.write_text("\n".join([_atom("HETATM", "NA"), "ATOM bad-coordinate-line", "END"]), encoding="utf-8")
+    info = count_structure(structure)
+    assert info["ions"] == 1
+
+    empty = tmp_path / "empty.pdb"
+    empty.write_text("HEADER\nEND\n", encoding="utf-8")
+    assert count_structure(empty)["centroid_angstrom"] == [None, None, None]
+    assert _count_structure_cached(str(tmp_path), 0, 0)["reason"].startswith("read-error")
+
+    fake_path = SimpleNamespace(is_file=lambda: True, stat=lambda: (_ for _ in ()).throw(OSError("stat")), as_posix=lambda: "fake")
+    with patch("fastmdxplora.live.structure_info.Path", return_value=fake_path):
+        assert count_structure(structure)["reason"].startswith("stat-error")
+    with patch.object(Path, "open", side_effect=OSError("read")):
+        assert ligand_atom_counts(structure) == {}
+
+
+def test_orchestrator_dashboard_telemetry_paths(tmp_path: Path, monkeypatch) -> None:
+    from fastmdxplora.orchestrator import FastMDXplora, PhaseResult
+
+    app = object.__new__(FastMDXplora)
+    app.output_dir = tmp_path / "run"
+    app.output_dir.mkdir()
+    app.options = {"simulation": {}}
+
+    class Writer:
+        def __init__(self):
+            self.root = app.output_dir / "simulation"
+            self.statuses, self.stages, self.events = [], [], []
+
+        def write_status(self, **kwargs): self.statuses.append(kwargs)
+        def mark_stage(self, *args, **kwargs): self.stages.append((args, kwargs))
+        def event(self, *args, **kwargs): self.events.append((args, kwargs))
+
+    writer = Writer()
+    monkeypatch.setenv("FASTMDX_DASHBOARD_ACTIVE", "1")
+    monkeypatch.setenv("FASTMDX_DASHBOARD_OUTPUT", str(app.output_dir))
+    monkeypatch.setattr("fastmdxplora.live.telemetry.TelemetryWriter", lambda *_a, **_k: writer)
+    assert app._dashboard_writer() is writer
+    monkeypatch.setattr("fastmdxplora.live.telemetry.TelemetryWriter", lambda *_a, **_k: 1 / 0)
+    assert app._dashboard_writer() is None
+
+    FastMDXplora._initialize_dashboard_timeline(writer, ["setup", "simulation", "report"])
+    assert writer.statuses[-1]["stage_states"]["analysis"] == "skipped"
+    FastMDXplora._initialize_dashboard_timeline(writer, [])
+    assert writer.statuses[-1]["status"] == "completed"
+
+    FastMDXplora._mark_dashboard_phase_start(None, "setup", {})
+    FastMDXplora._mark_dashboard_phase_start(writer, "simulation", {"minimize": False})
+    FastMDXplora._mark_dashboard_phase_start(writer, "analysis", {})
+
+    ok = PhaseResult("simulation", "ok", app.output_dir)
+    skipped = PhaseResult("report", "skipped", app.output_dir)
+    failed = PhaseResult("analysis", "error", app.output_dir, message="boom")
+    monkeypatch.setattr("fastmdxplora.live.telemetry.read_status", lambda _root: {
+        "stage_states": {"minimization": "waiting", "nvt": "current",
+                         "npt": "completed", "production": "waiting"}
+    })
+    FastMDXplora._mark_dashboard_phase_end(None, "setup", ok)
+    FastMDXplora._mark_dashboard_phase_end(writer, "simulation", ok)
+    FastMDXplora._mark_dashboard_phase_end(writer, "report", skipped)
+    FastMDXplora._mark_dashboard_phase_end(writer, "analysis", failed)
+    assert any(args[1] == "failed" for args, _kwargs in writer.stages)
+    assert writer.events[-1][1]["level"] == "error"
+
+
+def test_server_helpers_cover_changed_display_branches(tmp_path: Path, monkeypatch) -> None:
+    from fastmdxplora.live import server
+
+    assert server.DashboardConfig(binding_pocket_cutoff_A=4.5).binding_pocket_cutoff_m == 4.5
+    assert server._artifact_records(tmp_path / "missing") == []
+    assert server._summary_records(tmp_path, {"phases": [{"status": "ok"}]}, {}, {})[0]["value"] == "completed"
+    assert server._summary_records(tmp_path, {"phases": [{"status": "failed"}]}, {}, {})[0]["value"] == "failed"
+    assert server._summary_records(tmp_path, {"phases": [{"status": "running"}]}, {}, {})[0]["value"] == "in progress"
+
+    monkeypatch.setattr(server, "read_metrics", lambda *_a, **_k: [{"temperature": 301}, {"temperature": None}])
+    assert server._last_metric_value(tmp_path, "temperature") is None
+    monkeypatch.setattr(server, "read_metrics", lambda *_a, **_k: [{"temperature": 301}])
+    assert server._last_metric_value(tmp_path, "temperature") == "301"
+
+    assert server._run_title(tmp_path, {"title": "Named"}) == "Named"
+    assert server._run_title(tmp_path, {"system": "/x/1abc.pdb"}).startswith("1abc")
+    assert server._setup_details({"parameters": {}, "resolved_forcefield": {"ligand": {"name": "LIG"}}})["ligand"] == "LIG"
+    assert server._analysis_records({"status": "skipped", "note": "none"}, [], [])[0]["status"] == "skipped"
+    assert server._phase_records({"phases": [{"name": "setup", "status": "ok"}]})[0]["status"] == "ok"
+    assert server._plot_title("analysis/rmsd/rmsd_plot.png") == "RMSD"
+    assert server._plot_title("report/dashboard_assets/rmsd.png") == "RMSD"
+    assert server._plot_category("analysis/cluster/plot.png") == "Clustering"
+    assert server._plot_category("analysis/sasa/plot.png") == "Additional Analysis"
+    assert server._plot_category("misc/plot.png") == "Other"
+
+    monkeypatch.setattr(server.subprocess, "Popen", lambda *_a, **_k: object())
+    assert server._open_local_path(tmp_path)[0] is True
+    monkeypatch.setattr(server.subprocess, "Popen", lambda *_a, **_k: (_ for _ in ()).throw(OSError("no opener")))
+    assert server._open_local_path(tmp_path) == (False, "no opener")
+
+
+def test_server_error_and_launcher_routes(tmp_path: Path, monkeypatch) -> None:
+    import urllib.error
+    import urllib.request
+    from fastmdxplora.live import server as live_server
+
+    root = tmp_path / "run"
+    root.mkdir()
+    monkeypatch.setattr(live_server, "_open_local_path", lambda _path: (True, "opened"))
+    httpd, url = live_server.start_test_server(root, home_mode=True)
+
+    def get(path: str, expected: int = 200):
+        try:
+            with urllib.request.urlopen(url + path) as response:
+                assert response.status == expected
+                return response.read()
+        except urllib.error.HTTPError as exc:
+            assert exc.code == expected
+            return exc.read()
+
+    def post(path: str, value, expected: int):
+        request = urllib.request.Request(
+            url + path, data=json.dumps(value).encode(),
+            headers={"Content-Type": "application/json"}, method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request) as response:
+                assert response.status == expected
+                return response.read()
+        except urllib.error.HTTPError as exc:
+            assert exc.code == expected
+            return exc.read()
+
+    try:
+        get("/api/playback-info?max=bad")
+        get("/api/open-output")
+        get("/structure/playback.pdb", 404)
+        get("/analysis-figures-svg.zip", 404)
+        get("/structure/topology.pdb", 404)
+        get("/artifacts/missing.txt", 404)
+        get("/static/missing.txt", 404)
+        get("/not-found", 404)
+        post("/api/launcher/launch", {"system": ""}, 422)
+        post("/api/launcher/stop", {}, 200)
+        post("/not-found", {}, 404)
+        post("/api/launcher/validate", [], 500)
+
+        monkeypatch.setattr(live_server, "_results_payload", lambda _root: (_ for _ in ()).throw(RuntimeError("route")))
+        get("/api/results", 500)
+    finally:
+        httpd.shutdown()
+        httpd.server_close()

--- a/tests/test_dashboard_coverage.py
+++ b/tests/test_dashboard_coverage.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import os
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -9,9 +11,11 @@ import pytest
 
 from fastmdxplora.live import launcher as launch
 from fastmdxplora.live import live_frames as frames
+from fastmdxplora.live import telemetry
 from fastmdxplora.live import trajectory_playback as playback
 from fastmdxplora.live.ligand_detection import detect_ligands, filter_pdb_to_ligand
 from fastmdxplora.live.structure_info import _count_structure_cached, count_structure, ligand_atom_counts
+from fastmdxplora.simulation import runner
 
 
 def _atom(record="ATOM", res="ALA", chain="A", seq=1, x=0.0, y=0.0, z=0.0) -> str:
@@ -378,3 +382,367 @@ def test_server_error_and_launcher_routes(tmp_path: Path, monkeypatch) -> None:
     finally:
         httpd.shutdown()
         httpd.server_close()
+
+
+def test_runner_live_metric_fields_stage_mapping_and_sample_failure(
+    tmp_path: Path,
+) -> None:
+    """Exercise the dashboard-only OpenMM metric calculations without OpenMM."""
+
+    class Quantity:
+        def __init__(self, value):
+            self.value = value
+
+        def value_in_unit(self, _unit):
+            return self.value
+
+    class Unit:
+        kilojoules_per_mole = 1.0
+        nanometer = 1.0
+        dalton = 1.0
+
+    class State:
+        def getPotentialEnergy(self):
+            return Quantity(-90.0)
+
+        def getKineticEnergy(self):
+            return Quantity(30.0)
+
+        def getPeriodicBoxVolume(self):
+            return Quantity(2.0)
+
+    class System:
+        masses = (12.0, 18.0)
+
+        def getNumParticles(self):
+            return len(self.masses)
+
+        def getNumConstraints(self):
+            return 0
+
+        def getNumForces(self):
+            return 1
+
+        def getForce(self, _index):
+            return type("CMMotionRemover", (), {})()
+
+        def getParticleMass(self, index):
+            return self.masses[index]
+
+    state = State()
+    simulation = SimpleNamespace(
+        context=SimpleNamespace(getState=lambda **_kwargs: state),
+        system=System(),
+        topology="topology",
+    )
+
+    class Recorder:
+        def __init__(self):
+            self.root = tmp_path / "simulation"
+            self.start_time = datetime.now(timezone.utc) - timedelta(seconds=60)
+            self.metrics = []
+            self.stages = []
+            self.events = []
+
+        def append_metric(self, **values):
+            self.metrics.append(values)
+
+        def mark_stage(self, *values, **updates):
+            self.stages.append((values, updates))
+
+        def event(self, message, **updates):
+            self.events.append((message, updates))
+
+    recorder = Recorder()
+    stage_cases = (
+        ("Minimizing energy", "minimization"),
+        ("NVT equilibration", "nvt"),
+        ("NPT equilibration", "npt"),
+        ("Production", "production"),
+        ("custom", "custom"),
+    )
+    with patch.object(runner, "_maybe_write_live_frame") as live_frame:
+        for stage, expected_key in stage_cases:
+            runner._append_live_metric(
+                {"unit": Unit()},
+                simulation,
+                recorder,
+                stage=stage,
+                step=50,
+                total_steps=100,
+                timestep_fs=2.0,
+                frame_count=5,
+            )
+            assert recorder.stages[-1][0] == (expected_key, "current")
+
+    metric = recorder.metrics[-1]
+    assert metric["potential_energy"] == -90.0
+    assert metric["kinetic_energy"] == 30.0
+    assert metric["total_energy"] == -60.0
+    assert metric["temperature"] == pytest.approx(
+        60.0 / (3.0 * 0.00831446261815324)
+    )
+    assert metric["volume"] == 2.0
+    assert metric["density"] == pytest.approx(30.0 * 1.66053906660e-3 / 2.0)
+    assert metric["speed"] > 0
+    assert metric["progress_percent"] == 50.0
+    assert live_frame.call_count == len(stage_cases)
+
+    failed_recorder = Recorder()
+    failed_simulation = SimpleNamespace(
+        context=SimpleNamespace(
+            getState=lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("busy"))
+        )
+    )
+    runner._append_live_metric(
+        {"unit": Unit()},
+        failed_simulation,
+        failed_recorder,
+        stage="production",
+        step=1,
+        total_steps=10,
+        timestep_fs=2.0,
+    )
+    assert "could not sample live metrics" in failed_recorder.events[-1][0]
+    assert failed_recorder.events[-1][1]["level"] == "warning"
+
+
+def test_runner_metric_helper_edge_cases(tmp_path: Path) -> None:
+    class Unit:
+        nanometer = 1.0
+        dalton = 1.0
+
+    class ZeroDofSystem:
+        def getNumParticles(self):
+            return 1
+
+        def getNumConstraints(self):
+            return 3
+
+        def getNumForces(self):
+            return 0
+
+    assert runner._temperature_from_kinetic_energy(SimpleNamespace(), None) is None
+    assert (
+        runner._temperature_from_kinetic_energy(
+            SimpleNamespace(system=ZeroDofSystem()), 10.0
+        )
+        is None
+    )
+    assert runner._temperature_from_kinetic_energy(SimpleNamespace(), 10.0) is None
+
+    broken_state = SimpleNamespace(
+        getPeriodicBoxVolume=lambda: (_ for _ in ()).throw(RuntimeError("no box"))
+    )
+    assert runner._periodic_volume_nm3(broken_state, Unit()) is None
+    assert runner._system_density_g_ml(SimpleNamespace(), Unit(), None) is None
+    assert runner._system_density_g_ml(SimpleNamespace(), Unit(), 0.0) is None
+    assert runner._system_density_g_ml(SimpleNamespace(), Unit(), 1.0) is None
+
+    assert (
+        runner._telemetry_speed_ns_day(
+            SimpleNamespace(start_time="not a datetime"), 1.0
+        )
+        is None
+    )
+    assert (
+        runner._telemetry_speed_ns_day(
+            SimpleNamespace(start_time=datetime.now(timezone.utc) + timedelta(days=1)),
+            1.0,
+        )
+        is None
+    )
+    assert (
+        runner._telemetry_speed_ns_day(
+            SimpleNamespace(start_time=datetime.now(timezone.utc) - timedelta(days=1)),
+            1.0,
+        )
+        == pytest.approx(1.0, rel=0.01)
+    )
+
+    class BadQuantity:
+        def value_in_unit(self, _unit):
+            raise RuntimeError("bad quantity")
+
+    assert runner._quantity_to_float(BadQuantity(), 1.0) is None
+    assert runner._quantity_to_float("not numeric", 1.0) is None
+    assert runner._quantity_to_float([[3.5, 4.5]], 1.0) == 3.5
+
+    # Live-frame snapshots are best-effort and must not terminate a run.
+    simulation = SimpleNamespace(
+        context=SimpleNamespace(
+            getState=lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("busy"))
+        )
+    )
+    runner._maybe_write_live_frame(
+        {"PDBFile": SimpleNamespace(writeFile=lambda *_a, **_k: None)},
+        simulation,
+        SimpleNamespace(root=tmp_path),
+        1,
+        stage="nvt",
+        simulation_time_ns=0.1,
+    )
+
+
+def test_telemetry_merges_live_and_energy_rows_and_normalizes_status(
+    tmp_path: Path,
+) -> None:
+    run_root = tmp_path / "run"
+    simulation_dir = run_root / "simulation"
+    simulation_dir.mkdir(parents=True)
+    status_path = simulation_dir / telemetry.STATUS_FILE
+    status_path.write_text(
+        json.dumps(
+            {
+                "run_started_at": "2026-07-24T12:00:00",
+                "stage_states": ["invalid"],
+                "current_frame_count": 7,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    writer = telemetry.TelemetryWriter(simulation_dir)
+    writer.write_status(stage="production")
+    status = telemetry.read_status(run_root)
+    assert status["run_started_at"].endswith("+00:00")
+    assert status["stage_states"] == {
+        name: "waiting" for name in telemetry.STAGE_ORDER
+    }
+    assert status["current_frame_count"] == 7
+
+    before = dict(status["stage_states"])
+    writer.mark_stage("not-a-stage", "failed")
+    assert telemetry.read_status(run_root)["stage_states"] == before
+    writer.mark_stage("analysis", "CURRENT", status="running")
+    assert telemetry.read_status(run_root)["stage_states"]["analysis"] == "current"
+
+    (simulation_dir / telemetry.METRICS_FILE).write_text(
+        "timestamp,stage,step,temperature,current_frame_count\n"
+        ",production,10,,\n",
+        encoding="utf-8",
+    )
+    (simulation_dir / "energy.csv").write_text(
+        '#"Step","Time (ps)","Temperature (K)","Speed (ns/day)","Ignored"\n'
+        "10,2500,302.0,4.2,value\n"
+        "20,bad,303.0,5.0,value\n",
+        encoding="utf-8",
+    )
+    metrics = telemetry.read_metrics(run_root)
+    assert len(metrics) == 1
+    assert metrics[0]["temperature"] == "302.0"
+    assert metrics[0]["simulation_time_ns"] == "2.5"
+    assert metrics[0]["speed"] == "4.2"
+    assert metrics[0]["current_frame_count"] == "7"
+
+    assert telemetry._normalise_energy_header("unknown") is None
+    assert telemetry._parse_iso_datetime(None) is None
+    assert telemetry._parse_iso_datetime("bad-date") is None
+    assert telemetry._parse_iso_datetime("2026-07-24T12:00:00").tzinfo is not None
+
+    status_path.write_text("[]", encoding="utf-8")
+    assert telemetry._read_status_path(status_path) == {}
+    status_path.write_text("{bad", encoding="utf-8")
+    assert telemetry._read_status_path(status_path) == {}
+
+
+def test_cli_dashboard_remaining_lifecycle_and_startup_branches(
+    tmp_path: Path,
+) -> None:
+    import importlib
+
+    cli = importlib.import_module("fastmdxplora.cli.main")
+
+    url, enabled = cli._startup_dashboard_details(
+        ["dashboard", "serve", "--host=0.0.0.0", "--port", "9001"]
+    )
+    assert (url, enabled) == ("http://127.0.0.1:9001", True)
+
+    url, enabled = cli._startup_dashboard_details(
+        ["explore", "--dashboard-host", "localhost", "--dashboard-port=9002"]
+    )
+    assert (url, enabled) == ("http://localhost:9002", False)
+
+    with patch.dict(
+        os.environ,
+        {
+            "FASTMDX_DASHBOARD_ACTIVE": "1",
+            "FASTMDX_DASHBOARD_URL": "http://example.test:1234",
+        },
+    ):
+        assert cli._startup_dashboard_details([]) == (
+            "http://example.test:1234",
+            True,
+        )
+
+    assert cli._dashboard_requested(SimpleNamespace(dashboard=True))
+    assert not cli._dashboard_requested(SimpleNamespace())
+    config = {}
+    cli._enable_dashboard_telemetry(config)
+    assert config["simulation"] == {"live_telemetry": True}
+
+    explicit = cli._resolve_dashboard_output_dir(
+        SimpleNamespace(output_dir=tmp_path / "explicit")
+    )
+    configured = cli._resolve_dashboard_output_dir(
+        SimpleNamespace(output_dir=None), {"output": tmp_path / "configured"}
+    )
+    generated = cli._resolve_dashboard_output_dir(SimpleNamespace(output_dir=None))
+    assert explicit == (tmp_path / "explicit").resolve()
+    assert configured == (tmp_path / "configured").resolve()
+    assert generated.name.startswith("fastmdxplora_output_")
+
+    assert cli._cmd_dashboard(SimpleNamespace(dashboard_command=None)) == 2
+    dashboard_args = SimpleNamespace(
+        dashboard_command="serve",
+        output=tmp_path,
+        host="127.0.0.1",
+        port=8765,
+        ligand_resname=None,
+        binding_pocket_cutoff_A=None,
+        max_playback_frames=None,
+        open_browser=False,
+    )
+    with patch("fastmdxplora.live.server.serve_dashboard") as serve:
+        assert cli._cmd_dashboard(dashboard_args) == 0
+    assert serve.call_args.kwargs["output"] == tmp_path
+    assert serve.call_args.kwargs["config"].binding_pocket_cutoff_A == 5.0
+
+    dashboard_args.open_browser = True
+    with (
+        patch("fastmdxplora.live.server.serve_dashboard"),
+        patch("webbrowser.open", side_effect=RuntimeError("headless")),
+    ):
+        assert cli._cmd_dashboard(dashboard_args) == 0
+
+    with patch("fastmdxplora.live.server.serve_dashboard") as serve_home:
+        assert cli._cmd_dashboard_home() == 0
+    assert serve_home.call_args.kwargs == {
+        "output": Path.cwd(),
+        "host": "127.0.0.1",
+        "port": 8765,
+    }
+
+    stopped = []
+    cli._finish_dashboard_for_command(None, SimpleNamespace())
+    session = SimpleNamespace(stop=lambda: stopped.append("stopped"))
+    cli._finish_dashboard_for_command(
+        session, SimpleNamespace(dashboard_stop_on_complete=True)
+    )
+    assert stopped == ["stopped"]
+
+    waited = []
+
+    def interrupt_wait():
+        waited.append(True)
+        raise KeyboardInterrupt
+
+    session = SimpleNamespace(
+        url="http://127.0.0.1:8765",
+        wait_forever=interrupt_wait,
+        stop=lambda: stopped.append("after-wait"),
+    )
+    cli._finish_dashboard_for_command(
+        session, SimpleNamespace(dashboard_stop_on_complete=False)
+    )
+    assert waited and stopped[-1] == "after-wait"

--- a/tests/test_dashboard_coverage.py
+++ b/tests/test_dashboard_coverage.py
@@ -305,9 +305,24 @@ def test_server_helpers_cover_changed_display_branches(tmp_path: Path, monkeypat
     assert server._plot_category("analysis/sasa/plot.png") == "Additional Analysis"
     assert server._plot_category("misc/plot.png") == "Other"
 
+    def fail_open(*_args, **_kwargs):
+        raise OSError("no opener")
+
+    # Windows uses os.startfile; POSIX platforms use subprocess.Popen.
+    # Exercise each branch directly so the test is deterministic on every CI OS.
+    monkeypatch.setattr(server.os, "name", "nt")
+    monkeypatch.setattr(server.os, "startfile", lambda *_a, **_k: None, raising=False)
+    assert server._open_local_path(tmp_path) == (True, "opened")
+    monkeypatch.setattr(server.os, "startfile", fail_open)
+    assert server._open_local_path(tmp_path) == (False, "no opener")
+
+    monkeypatch.setattr(server.os, "name", "posix")
+    monkeypatch.setattr(server.sys, "platform", "darwin")
     monkeypatch.setattr(server.subprocess, "Popen", lambda *_a, **_k: object())
-    assert server._open_local_path(tmp_path)[0] is True
-    monkeypatch.setattr(server.subprocess, "Popen", lambda *_a, **_k: (_ for _ in ()).throw(OSError("no opener")))
+    assert server._open_local_path(tmp_path) == (True, "opened")
+
+    monkeypatch.setattr(server.sys, "platform", "linux")
+    monkeypatch.setattr(server.subprocess, "Popen", fail_open)
     assert server._open_local_path(tmp_path) == (False, "no opener")
 
 

--- a/tests/test_dashboard_coverage.py
+++ b/tests/test_dashboard_coverage.py
@@ -648,10 +648,17 @@ def test_telemetry_merges_live_and_energy_rows_and_normalizes_status(
 
 def test_cli_dashboard_remaining_lifecycle_and_startup_branches(
     tmp_path: Path,
+    monkeypatch,
 ) -> None:
     import importlib
 
     cli = importlib.import_module("fastmdxplora.cli.main")
+
+    # Other CLI tests intentionally activate dashboard telemetry in this
+    # process.  This assertion covers startup with no activation marker, so
+    # make that precondition explicit instead of depending on test order.
+    monkeypatch.delenv("FASTMDX_DASHBOARD_ACTIVE", raising=False)
+    monkeypatch.delenv("FASTMDX_DASHBOARD_URL", raising=False)
 
     url, enabled = cli._startup_dashboard_details(
         ["dashboard", "serve", "--host=0.0.0.0", "--port", "9001"]

--- a/tests/test_dashboard_launcher.py
+++ b/tests/test_dashboard_launcher.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 from fastmdxplora.live.launcher import (
     DashboardRuntime,
     build_launcher_command,
+    launcher_environment_error,
     launcher_defaults,
     validate_launcher_payload,
 )
@@ -86,19 +87,126 @@ def test_launcher_command_uses_module_entrypoint(tmp_path: Path) -> None:
     assert "--analyze-analyses" in command
 
 
+def test_launcher_environment_preflight_is_workflow_aware() -> None:
+    imported: list[str] = []
+
+    def fake_import(name: str):
+        imported.append(name)
+        if name == "pdbfixer":
+            raise ImportError("missing")
+        return SimpleNamespace()
+
+    with patch("fastmdxplora.live.launcher.importlib.import_module", side_effect=fake_import):
+        detail = launcher_environment_error(_payload())
+
+    assert detail is not None
+    assert "PDBFixer" in detail
+    assert "MDTraj" not in detail
+    assert imported == ["openmm", "openmm.app", "pdbfixer", "mdtraj"]
+
+    payload = _payload()
+    payload["workflow"]["run_analysis"] = False
+    imported.clear()
+    with patch("fastmdxplora.live.launcher.importlib.import_module", side_effect=fake_import):
+        launcher_environment_error(payload)
+    assert "mdtraj" not in imported
+
+
 def test_runtime_launches_without_shell(tmp_path: Path) -> None:
     runtime = DashboardRuntime(
         workspace_root=tmp_path / "workspace",
         launch_root=tmp_path / "runs",
     )
     fake_process = SimpleNamespace(pid=42, poll=lambda: None, terminate=lambda: None)
-    with patch("fastmdxplora.live.launcher.subprocess.Popen", return_value=fake_process) as popen:
+    with (
+        patch("fastmdxplora.live.launcher.launcher_environment_error", return_value=None),
+        patch("fastmdxplora.live.launcher.subprocess.Popen", return_value=fake_process) as popen,
+    ):
         result = runtime.launch(_payload(), dashboard_url="http://127.0.0.1:8765")
     assert result["launched"] is True
     kwargs = popen.call_args.kwargs
     assert kwargs["shell"] is False
     assert kwargs["env"]["FASTMDX_DASHBOARD_ACTIVE"] == "1"
     assert runtime.data_root().name == "trpcage_test"
+
+
+def test_runtime_refuses_launch_when_simulation_dependencies_are_missing(
+    tmp_path: Path,
+) -> None:
+    runtime = DashboardRuntime(
+        workspace_root=tmp_path / "workspace",
+        launch_root=tmp_path / "runs",
+    )
+    detail = "Simulation dependencies are unavailable: OpenMM, PDBFixer."
+    with (
+        patch("fastmdxplora.live.launcher.launcher_environment_error", return_value=detail),
+        patch("fastmdxplora.live.launcher.subprocess.Popen") as popen,
+    ):
+        result = runtime.launch(_payload())
+    assert result["valid"] is False
+    assert result["error"] == detail
+    assert result["errors"]["run"] == detail
+    popen.assert_not_called()
+    assert not (runtime.launch_root / "trpcage_test").exists()
+
+
+def test_runtime_rejects_zero_exit_without_simulation_outputs(tmp_path: Path) -> None:
+    runtime = DashboardRuntime(
+        workspace_root=tmp_path / "workspace",
+        launch_root=tmp_path / "runs",
+    )
+    run_root = runtime.launch_root / "incomplete"
+    (run_root / "setup").mkdir(parents=True)
+    (run_root / "simulation").mkdir()
+    (run_root / "setup" / "setup_parameters.json").write_text(
+        json.dumps({"notes": ["PDBFixer unavailable"]}),
+        encoding="utf-8",
+    )
+    runtime.active_root = run_root
+    runtime.log_path = run_root / "dashboard_launcher.log"
+    runtime.command = ["python", "-m", "fastmdxplora.cli.main", "explore"]
+    runtime.process = SimpleNamespace(poll=lambda: 0)
+
+    state = runtime.snapshot()
+
+    assert state["status"] == "failed"
+    assert state["returncode"] == 0
+    assert "Setup did not produce" in state["error"]
+    live_status = json.loads(
+        (run_root / "simulation" / "live_status.json").read_text(encoding="utf-8")
+    )
+    assert live_status["status"] == "failed"
+    assert live_status["stage_states"]["setup"] == "failed"
+    assert live_status["stage_states"]["production"] == "skipped"
+    assert live_status["stage_states"]["analysis"] == "skipped"
+    assert live_status["stage_states"]["report"] == "skipped"
+
+
+def test_runtime_accepts_zero_exit_with_completed_simulation(tmp_path: Path) -> None:
+    runtime = DashboardRuntime(
+        workspace_root=tmp_path / "workspace",
+        launch_root=tmp_path / "runs",
+    )
+    run_root = runtime.launch_root / "complete"
+    setup_dir = run_root / "setup"
+    simulation_dir = run_root / "simulation"
+    setup_dir.mkdir(parents=True)
+    simulation_dir.mkdir()
+    for name in ("system.xml", "state.xml", "topology.pdb"):
+        (setup_dir / name).write_text("ready", encoding="utf-8")
+    (simulation_dir / "state_final.xml").write_text("<State />", encoding="utf-8")
+    (simulation_dir / "simulation_parameters.json").write_text(
+        json.dumps({"platform_used": "CPU", "duration_ns_actual": 0.02}),
+        encoding="utf-8",
+    )
+    runtime.active_root = run_root
+    runtime.command = ["python", "-m", "fastmdxplora.cli.main", "explore"]
+    runtime.process = SimpleNamespace(poll=lambda: 0)
+
+    state = runtime.snapshot()
+
+    assert state["status"] == "completed"
+    assert state["error"] is None
 
 
 def test_home_server_exposes_launcher_apis(tmp_path: Path) -> None:

--- a/tests/test_dashboard_launcher.py
+++ b/tests/test_dashboard_launcher.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from fastmdxplora.live.launcher import (
+    DashboardRuntime,
+    build_launcher_command,
+    launcher_defaults,
+    validate_launcher_payload,
+)
+from fastmdxplora.live.server import start_test_server
+
+
+def _payload() -> dict:
+    return {
+        "system": "1L2Y",
+        "run_name": "trpcage_test",
+        "setup": {
+            "ph": 7.4,
+            "forcefield": "charmm36",
+            "water_model": "auto",
+            "ion_concentration_M": 0.15,
+            "solvent_padding_nm": 1.0,
+        },
+        "simulation": {
+            "minimize": True,
+            "nvt_steps": 1000,
+            "npt_steps": 1000,
+            "production_steps": 10000,
+            "timestep_fs": 2.0,
+            "temperature_K": 300,
+            "friction_per_ps": 1.0,
+            "integrator": "langevin_middle",
+            "platform": "CPU",
+            "precision": "mixed",
+            "trajectory_interval_steps": 100,
+            "checkpoint_interval_steps": 1000,
+            "telemetry_interval": 100,
+        },
+        "workflow": {
+            "run_analysis": True,
+            "run_report": True,
+            "analyses": ["rmsd", "rg"],
+            "report_document": True,
+            "report_slides": True,
+            "report_bundle": True,
+        },
+    }
+
+
+def test_launcher_defaults_are_backend_derived() -> None:
+    defaults = launcher_defaults()
+    assert defaults["setup"]["forcefield"] == "charmm36"
+    assert defaults["simulation"]["nvt_steps"] == 250_000
+    assert "CPU" in defaults["choices"]["platforms"]
+
+
+def test_launcher_validation_computes_durations() -> None:
+    result = validate_launcher_payload(_payload())
+    assert result["valid"] is True
+    assert result["summary"]["production_ns"] == 0.02
+    assert result["summary"]["trajectory_frames"] == 100
+
+
+def test_launcher_validation_rejects_bad_values() -> None:
+    payload = _payload()
+    payload["system"] = ""
+    payload["simulation"]["production_steps"] = 0
+    result = validate_launcher_payload(payload)
+    assert result["valid"] is False
+    assert "system" in result["errors"]
+    assert "simulation.production_steps" in result["errors"]
+
+
+def test_launcher_command_uses_module_entrypoint(tmp_path: Path) -> None:
+    result = validate_launcher_payload(_payload())
+    command = build_launcher_command(result["config"], tmp_path / "out")
+    assert command[1:4] == ["-m", "fastmdxplora.cli.main", "explore"]
+    assert "--simulate-live-telemetry" in command
+    assert "--dashboard" not in command
+    assert "--analyze-analyses" in command
+
+
+def test_runtime_launches_without_shell(tmp_path: Path) -> None:
+    runtime = DashboardRuntime(
+        workspace_root=tmp_path / "workspace",
+        launch_root=tmp_path / "runs",
+    )
+    fake_process = SimpleNamespace(pid=42, poll=lambda: None, terminate=lambda: None)
+    with patch("fastmdxplora.live.launcher.subprocess.Popen", return_value=fake_process) as popen:
+        result = runtime.launch(_payload(), dashboard_url="http://127.0.0.1:8765")
+    assert result["launched"] is True
+    kwargs = popen.call_args.kwargs
+    assert kwargs["shell"] is False
+    assert kwargs["env"]["FASTMDX_DASHBOARD_ACTIVE"] == "1"
+    assert runtime.data_root().name == "trpcage_test"
+
+
+def test_home_server_exposes_launcher_apis(tmp_path: Path) -> None:
+    server, url = start_test_server(tmp_path / "workspace", home_mode=True)
+    try:
+        with urllib.request.urlopen(url + "/") as response:
+            html = response.read().decode("utf-8")
+        assert "New Simulation" in html
+        assert "/static/simulation-builder.js" in html
+        with urllib.request.urlopen(url + "/api/app-state") as response:
+            state = json.load(response)
+        assert state["active_run"] is None
+        with urllib.request.urlopen(url + "/api/launcher/defaults") as response:
+            defaults = json.load(response)
+        assert defaults["simulation"]["temperature_K"] == 300.0
+
+        request = urllib.request.Request(
+            url + "/api/launcher/validate",
+            data=json.dumps(_payload()).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(request) as response:
+            validated = json.load(response)
+        assert validated["valid"] is True
+        assert "command" in validated
+    finally:
+        server.shutdown()
+        server.server_close()

--- a/tests/test_install_bootstrap.py
+++ b/tests/test_install_bootstrap.py
@@ -24,15 +24,18 @@ Also covers:
 
 from __future__ import annotations
 
+import io
 import os
 import ssl
 import subprocess
 import sys
+import urllib.error
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+import fastmdxplora.install as install_module
 from fastmdxplora.install import (
     MINIFORGE_INSTALLERS,
     MINIFORGE_SHA256,
@@ -250,3 +253,241 @@ class TestSha256OfFile:
             _sha256_of_file(f)
             == "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
         )
+
+
+# ---------------------------------------------------------------------------
+# Cross-platform discovery, download, and orchestration branches
+# ---------------------------------------------------------------------------
+def test_platform_discovery_and_command_helpers(tmp_path: Path):
+    yaml_text = install_module._build_bootstrap_yaml()
+    assert "python>=3.9,<3.13" in yaml_text
+    assert "openmm>=8.0" in yaml_text
+    assert install_module._normalize_arch("AMD64") == "x86_64"
+    assert install_module._normalize_arch("arm64") == "aarch64"
+    assert install_module._normalize_arch("riscv64") == "riscv64"
+
+    with (
+        patch.object(install_module.platform, "system", return_value="Linux"),
+        patch.object(install_module.platform, "machine", return_value="AMD64"),
+    ):
+        assert install_module._miniforge_installer_name().endswith("Linux-x86_64.sh")
+
+    with (
+        patch.object(install_module.platform, "system", return_value="Windows"),
+        patch.object(install_module.platform, "machine", return_value="arm64"),
+        pytest.raises(BootstrapError, match="Windows-aarch64"),
+    ):
+        install_module._miniforge_installer_path()
+
+    with (
+        patch.object(install_module.platform, "system", return_value="Haiku"),
+        patch.object(install_module.platform, "machine", return_value="riscv64"),
+        pytest.raises(BootstrapError, match="No Miniforge installer"),
+    ):
+        install_module._miniforge_installer_path()
+
+    posix_conda = tmp_path / "posix" / "bin" / "conda"
+    posix_conda.parent.mkdir(parents=True)
+    posix_conda.write_text("", encoding="utf-8")
+    with patch.object(install_module.platform, "system", return_value="Linux"):
+        assert (
+            install_module._conda_executable_from_prefix(tmp_path / "posix", "conda")
+            == posix_conda
+        )
+
+    windows_mamba = tmp_path / "windows" / "Scripts" / "mamba.exe"
+    windows_mamba.parent.mkdir(parents=True)
+    windows_mamba.write_text("", encoding="utf-8")
+    with patch.object(install_module.platform, "system", return_value="Windows"):
+        assert (
+            install_module._conda_executable_from_prefix(
+                tmp_path / "windows", "mamba"
+            )
+            == windows_mamba
+        )
+
+    with patch.object(
+        install_module, "command_exists", side_effect=lambda name: name == "conda"
+    ):
+        assert install_module._locate_conda_cli() == ["conda"]
+    fallback_conda = tmp_path / "fallback" / "bin" / "conda"
+    with (
+        patch.object(install_module, "command_exists", return_value=False),
+        patch.object(
+            install_module,
+            "_conda_executable_from_prefix",
+            side_effect=[None, fallback_conda],
+        ),
+    ):
+        assert install_module._locate_conda_cli() == [str(fallback_conda)]
+    with (
+        patch.object(install_module, "command_exists", return_value=False),
+        patch.object(install_module, "_conda_executable_from_prefix", return_value=None),
+    ):
+        assert install_module._locate_conda_cli() is None
+
+    with patch.object(install_module.subprocess, "run", side_effect=FileNotFoundError):
+        result = install_module._run_command(["missing-command"])
+    assert result.returncode == 127
+    assert "Command not found" in result.stderr
+
+
+def test_download_stream_http_classification_and_checksum_paths(tmp_path: Path):
+    request = install_module.urllib.request.Request("https://example.test/file")
+    destination = tmp_path / "stream.bin"
+    with patch.object(
+        install_module.urllib.request,
+        "urlopen",
+        return_value=io.BytesIO(b"downloaded"),
+    ) as urlopen:
+        install_module._stream_url_to_path(request, destination)
+    assert destination.read_bytes() == b"downloaded"
+    assert urlopen.call_args.kwargs["timeout"] == install_module._DOWNLOAD_TIMEOUT_SECONDS
+
+    not_found = urllib.error.HTTPError(
+        "https://example.test/missing", 404, "Not Found", {}, None
+    )
+    server_error = urllib.error.HTTPError(
+        "https://example.test/error", 503, "Unavailable", {}, None
+    )
+    assert "installer not found" in str(
+        install_module._classify_http_error(not_found, not_found.url)
+    )
+    assert "HTTP 503" in str(
+        install_module._classify_http_error(server_error, server_error.url)
+    )
+
+    installer_name = "Miniforge3-Linux-x86_64.sh"
+    destination = tmp_path / "destination" / installer_name
+    destination.parent.mkdir()
+    private_dir = tmp_path / "private-success"
+    private_dir.mkdir()
+    downloaded = private_dir / installer_name
+    downloaded.write_bytes(b"verified")
+    expected = MINIFORGE_SHA256[installer_name]
+    with (
+        patch.object(
+            install_module, "_download_to_temp_file", return_value=downloaded
+        ),
+        patch.object(install_module, "_sha256_of_file", return_value=expected),
+        patch.object(install_module.platform, "system", return_value="Linux"),
+        patch.object(install_module, "_print"),
+    ):
+        install_module._download_miniforge_installer(destination)
+    assert destination.read_bytes() == b"verified"
+    assert not private_dir.exists()
+
+    bad_destination = tmp_path / "bad-destination" / installer_name
+    bad_destination.parent.mkdir()
+    bad_private = tmp_path / "private-failure"
+    bad_private.mkdir()
+    bad_download = bad_private / installer_name
+    bad_download.write_bytes(b"tampered")
+    with (
+        patch.object(
+            install_module, "_download_to_temp_file", return_value=bad_download
+        ),
+        patch.object(install_module, "_sha256_of_file", return_value="0" * 64),
+        patch.object(install_module, "_print"),
+        pytest.raises(BootstrapError, match="SHA-256 mismatch"),
+    ):
+        install_module._download_miniforge_installer(bad_destination)
+    assert not bad_destination.exists()
+    assert not bad_private.exists()
+
+
+def test_conda_manifest_and_bootstrap_orchestration(tmp_path: Path):
+    completed = subprocess.CompletedProcess(
+        ["conda"], 0, '{"envs": ["/opt/envs/alpha", "/opt/envs/beta", ""]}', ""
+    )
+    with patch.object(install_module, "_run_command", return_value=completed):
+        assert install_module._parse_conda_envs("conda") == ["alpha", "beta"]
+        assert install_module._conda_env_exists("conda", "beta")
+
+    with patch.object(
+        install_module,
+        "_run_command",
+        return_value=subprocess.CompletedProcess(["conda"], 1, "", "failed"),
+    ):
+        assert install_module._parse_conda_envs("conda") == []
+    with patch.object(
+        install_module,
+        "_run_command",
+        return_value=subprocess.CompletedProcess(["conda"], 0, "not-json", ""),
+    ):
+        assert install_module._parse_conda_envs("conda") == []
+
+    detail = install_module._format_conda_error(
+        "UnsatisfiableError PackagesNotFoundError Cannot connect",
+        "fastmdx",
+        create=True,
+    )
+    assert "Package resolution failed" in detail
+    assert "required package could not be found" in detail
+    assert "Network or SSL error" in detail
+
+    with pytest.raises(BootstrapError, match="Invalid Python version"):
+        install_module.bootstrap_environment(python_version="2.7")
+    with pytest.raises(BootstrapError, match="outside the supported range"):
+        install_module.bootstrap_environment(python_version="3.13")
+
+    calls: list[tuple] = []
+
+    def make_yaml():
+        directory = tmp_path / f"env-{len(calls)}"
+        directory.mkdir()
+        path = directory / "environment.yml"
+        path.write_text(install_module._build_bootstrap_yaml(), encoding="utf-8")
+        return path
+
+    with (
+        patch.object(install_module, "_ensure_conda_available", return_value=["conda"]),
+        patch.object(install_module, "_conda_env_exists", return_value=True),
+        patch.object(install_module, "_write_environment_yaml", side_effect=make_yaml),
+        patch.object(
+            install_module,
+            "_remove_conda_env",
+            side_effect=lambda *args: calls.append(("remove", *args)),
+        ),
+        patch.object(
+            install_module,
+            "_create_conda_env",
+            side_effect=lambda *args: calls.append(("create", *args)),
+        ),
+        patch.object(
+            install_module,
+            "_update_conda_env",
+            side_effect=lambda *args: calls.append(("update", *args)),
+        ),
+        patch.object(
+            install_module,
+            "_install_package_in_env",
+            side_effect=lambda *args, **kwargs: calls.append(
+                ("install", *args, kwargs)
+            ),
+        ),
+        patch.object(
+            install_module,
+            "_verify_env",
+            side_effect=lambda *args: calls.append(("verify", *args)),
+        ),
+        patch.object(install_module, "_print"),
+    ):
+        install_module.bootstrap_environment(
+            env_name="fastmdx",
+            python_version="3.11",
+            force=True,
+            package_name=".",
+            editable=True,
+        )
+        install_module.bootstrap_environment(
+            env_name="fastmdx",
+            python_version="3.10",
+            force=False,
+        )
+
+    assert [call[0] for call in calls].count("remove") == 1
+    assert [call[0] for call in calls].count("create") == 1
+    assert [call[0] for call in calls].count("update") == 1
+    assert [call[0] for call in calls].count("install") == 2
+    assert [call[0] for call in calls].count("verify") == 2

--- a/tests/test_install_bootstrap.py
+++ b/tests/test_install_bootstrap.py
@@ -344,17 +344,19 @@ def test_download_stream_http_classification_and_checksum_paths(tmp_path: Path):
     assert destination.read_bytes() == b"downloaded"
     assert urlopen.call_args.kwargs["timeout"] == install_module._DOWNLOAD_TIMEOUT_SECONDS
 
+    not_found_url = "https://example.test/missing"
+    server_error_url = "https://example.test/error"
     not_found = urllib.error.HTTPError(
-        "https://example.test/missing", 404, "Not Found", {}, None
+        not_found_url, 404, "Not Found", {}, None
     )
     server_error = urllib.error.HTTPError(
-        "https://example.test/error", 503, "Unavailable", {}, None
+        server_error_url, 503, "Unavailable", {}, None
     )
     assert "installer not found" in str(
-        install_module._classify_http_error(not_found, not_found.url)
+        install_module._classify_http_error(not_found, not_found_url)
     )
     assert "HTTP 503" in str(
-        install_module._classify_http_error(server_error, server_error.url)
+        install_module._classify_http_error(server_error, server_error_url)
     )
 
     installer_name = "Miniforge3-Linux-x86_64.sh"

--- a/tests/test_live_dashboard.py
+++ b/tests/test_live_dashboard.py
@@ -15,13 +15,19 @@ import socket
 from pathlib import Path
 from urllib.error import HTTPError
 from urllib.request import urlopen
+from types import SimpleNamespace
 
 import pytest
 
-from fastmdxplora.cli.main import _build_parser
+from fastmdxplora.cli.main import _build_parser, _enable_dashboard_telemetry
 from fastmdxplora.live import protein_preview
 from fastmdxplora.live.ligand_detection import detect_ligands, normalise_ligand_resname
-from fastmdxplora.live.live_frames import write_live_frame, write_openmm_live_frame
+from fastmdxplora.live.live_frames import (
+    dashboard_display_pdb,
+    read_live_frame_history,
+    write_live_frame,
+    write_openmm_live_frame,
+)
 from fastmdxplora.live.protein_preview import protein_preview_payload
 from fastmdxplora.live.server import (
     DashboardConfig,
@@ -30,6 +36,7 @@ from fastmdxplora.live.server import (
     start_test_server,
 )
 from fastmdxplora.live.structure_info import count_structure, ligand_atom_counts
+from fastmdxplora.simulation.runner import _maybe_write_live_frame
 from fastmdxplora.live.telemetry import (
     TelemetryWriter,
     analyze_health,
@@ -365,13 +372,13 @@ def test_playback_returns_unavailable_when_missing(tmp_path: Path) -> None:
 def test_playback_generation_failure_is_safe(tmp_path: Path, monkeypatch) -> None:
     # Force a failure inside the writer.
     import fastmdxplora.live.trajectory_playback as mod
-    monkeypatch.setattr(mod, "_import_openmm", lambda: None)
+    monkeypatch.setattr(mod, "_import_mdtraj", lambda: None)
     (tmp_path / "simulation").mkdir(parents=True)
     (tmp_path / "simulation" / "topology.pdb").write_text(_tiny_pdb(), encoding="utf-8")
     (tmp_path / "simulation" / "production.dcd").write_bytes(b"\x00\x00")
     info = playback_info(tmp_path)
     assert info["playback_available"] is False
-    assert info["reason"] == "openmm-not-installed"
+    assert info["reason"] == "mdtraj-not-installed"
 
 
 def test_neighborhood_residues_per_atom_check(tmp_path: Path) -> None:
@@ -388,6 +395,64 @@ def test_neighborhood_residues_per_atom_check(tmp_path: Path) -> None:
     assert ("A", 1) in residues
     assert ("A", 2) not in residues
 
+
+
+def test_telemetry_stage_states_survive_multiple_writers(tmp_path: Path) -> None:
+    sim = tmp_path / "run" / "simulation"
+    orchestrator_writer = TelemetryWriter(sim)
+    runner_writer = TelemetryWriter(sim)
+    orchestrator_writer.write_status(
+        stage="setup",
+        status="running",
+        stage_states={
+            "setup": "current", "minimization": "waiting", "nvt": "waiting",
+            "npt": "waiting", "production": "waiting", "analysis": "waiting",
+            "report": "waiting",
+        },
+    )
+    runner_writer.mark_stage("minimization", "current", status="running")
+    runner_writer.mark_stage("minimization", "completed", status="running")
+    orchestrator_writer.mark_stage("analysis", "current", status="running")
+    status = read_status(tmp_path / "run")
+    assert status["stage_states"]["setup"] == "current"
+    assert status["stage_states"]["minimization"] == "completed"
+    assert status["stage_states"]["analysis"] == "current"
+
+
+def test_live_frame_history_builds_playback(tmp_path: Path) -> None:
+    sim = tmp_path / "simulation"
+    write_live_frame(
+        sim, pdb_text=_tiny_pdb(), frame_index=10, stage="nvt",
+        simulation_time_ns=0.001, archive=True,
+    )
+    moved = _tiny_pdb().replace("   0.000   0.000   0.000", "   0.200   0.000   0.000")
+    write_live_frame(
+        sim, pdb_text=moved, frame_index=20, stage="nvt",
+        simulation_time_ns=0.002, archive=True,
+    )
+    history = read_live_frame_history(sim)
+    assert history["count"] == 2
+    info = playback_info(tmp_path, max_browser_frames=20)
+    assert info["playback_available"] is True
+    assert info["source_kind"] == "live-history"
+    assert info["n_frames_browser"] == 2
+    text = (sim / "playback.pdb").read_text(encoding="utf-8")
+    assert text.count("MODEL") == 2
+
+
+def test_dashboard_display_pdb_strips_solvent_and_keeps_ligand() -> None:
+    pdb = "\n".join([
+        "ATOM      1  CA  ALA A   1       0.000   0.000   0.000  1.00 10.00           C",
+        "HETATM    2  O   HOH B   2       2.000   2.000   2.000  1.00 10.00           O",
+        "HETATM    3  NA   NA C   3       3.000   3.000   3.000  1.00 10.00          NA",
+        "HETATM    4  C1  LIG D   4       4.000   4.000   4.000  1.00 10.00           C",
+        "END",
+    ])
+    display = dashboard_display_pdb(pdb)
+    assert "ALA" in display
+    assert "LIG" in display
+    assert "HOH" not in display
+    assert " NA C" not in display
 
 # ---------------------------------------------------------------------------
 # Endpoint contract: the redesigned dashboard's HTML/JS layer
@@ -743,3 +808,308 @@ def test_static_logo_endpoint_serves_svg(tmp_path: Path) -> None:
         server.server_close()
     assert response.headers["Content-Type"].startswith("image/svg+xml") or "svg" in body.lower()
     assert "AAI" in body
+
+# ---------------------------------------------------------------------------
+# Regression coverage for the functional dashboard wiring
+# ---------------------------------------------------------------------------
+def test_find_structure_prefers_prepared_solute_over_solvated_topology(
+    tmp_path: Path,
+) -> None:
+    run = tmp_path / "run"
+    prepared = run / "setup" / "prepared.pdb"
+    topology = run / "simulation" / "topology.pdb"
+    solvated = run / "setup" / "solvated.pdb"
+    for path, marker in (
+        (prepared, "PREPARED"),
+        (topology, "TOPOLOGY"),
+        (solvated, "SOLVATED"),
+    ):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"REMARK {marker}\n{_tiny_pdb()}\n", encoding="utf-8")
+
+    assert protein_preview.find_structure(run) == prepared
+
+
+def test_read_metrics_falls_back_to_openmm_energy_csv(tmp_path: Path) -> None:
+    sim = tmp_path / "run" / "simulation"
+    sim.mkdir(parents=True)
+    (sim / "energy.csv").write_text(
+        '#"Step","Time (ps)","Potential Energy (kJ/mole)",'
+        '"Kinetic Energy (kJ/mole)","Total Energy (kJ/mole)",'
+        '"Temperature (K)","Box Volume (nm^3)","Density (g/mL)",'
+        '"Speed (ns/day)","Progress (%)"\n'
+        '100,2.0,-1000.5,200.5,-800.0,299.5,12.0,0.997,8.25,50.0\n',
+        encoding="utf-8",
+    )
+
+    metrics = read_metrics(tmp_path / "run")
+
+    assert len(metrics) == 1
+    assert metrics[0]["step"] == "100"
+    assert metrics[0]["simulation_time_ns"] == "0.002"
+    assert metrics[0]["potential_energy"] == "-1000.5"
+    assert metrics[0]["temperature"] == "299.5"
+    assert metrics[0]["density"] == "0.997"
+    assert metrics[0]["speed"] == "8.25"
+
+
+def test_ligands_endpoint_returns_detected_instances(tmp_path: Path) -> None:
+    run = tmp_path / "run"
+    prepared = run / "setup" / "prepared.pdb"
+    prepared.parent.mkdir(parents=True)
+    prepared.write_text(
+        "\n".join(
+            [
+                "ATOM      1  N   ALA A   1       0.000   0.000   0.000  1.00  0.00           N",
+                "HETATM    2  C1  EPE B 101       4.000   4.000   4.000  1.00 10.00           C",
+                "HETATM    3  O1  EPE B 101       4.300   4.300   4.300  1.00 10.00           O",
+                "END",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    server, base_url = start_test_server(run)
+    try:
+        payload = json.loads(urlopen(f"{base_url}/api/ligands", timeout=5).read())
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert payload["valid"] is True
+    assert payload["resnames"] == ["EPE"]
+    assert payload["ligands"] == [
+        {"chain": "B", "resname": "EPE", "resi": "101", "explicit": False}
+    ]
+
+
+def test_results_endpoint_discovers_analysis_and_report_outputs(
+    tmp_path: Path,
+) -> None:
+    run = tmp_path / "run"
+    analysis = run / "analysis" / "rmsd"
+    report = run / "report"
+    analysis.mkdir(parents=True)
+    report.mkdir(parents=True)
+
+    (run / "analysis" / "analysis_manifest.json").write_text(
+        json.dumps(
+            {
+                "n_frames": 10,
+                "results": {
+                    "rmsd": {
+                        "status": "ok",
+                        "message": "RMSD complete",
+                    },
+                    "rg": {
+                        "status": "skipped",
+                        "message": "Not enough frames",
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (analysis / "rmsd.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+    (analysis / "rmsd.csv").write_text("frame,rmsd\n0,0.0\n", encoding="utf-8")
+    (report / "dashboard.html").write_text("<html></html>", encoding="utf-8")
+    (report / "report.md").write_text("# Report\n", encoding="utf-8")
+    (report / "slides.pptx").write_bytes(b"PK")
+    (report / "project_bundle.zip").write_bytes(b"PK")
+
+    server, base_url = start_test_server(run)
+    try:
+        payload = json.loads(urlopen(f"{base_url}/api/results", timeout=5).read())
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert payload["has_analysis"] is True
+    assert payload["has_report"] is True
+    assert {item["name"] for item in payload["analyses"]} == {"rmsd", "rg"}
+    rmsd = next(item for item in payload["analyses"] if item["name"] == "rmsd")
+    assert rmsd["plot"]["path"] == "analysis/rmsd/rmsd.png"
+    assert any(item["path"] == "analysis/rmsd/rmsd.csv" for item in rmsd["artifacts"])
+    assert [item["path"] for item in payload["reports"]] == [
+        "report/dashboard.html",
+        "report/report.md",
+        "report/slides.pptx",
+        "report/project_bundle.zip",
+    ]
+
+
+def test_artifact_download_route_sets_attachment_header(tmp_path: Path) -> None:
+    run = tmp_path / "run"
+    report = run / "report"
+    report.mkdir(parents=True)
+    (report / "report.md").write_text("# Report\n", encoding="utf-8")
+
+    server, base_url = start_test_server(run)
+    try:
+        response = urlopen(
+            f"{base_url}/artifacts/report/report.md?download=1",
+            timeout=5,
+        )
+        response.read()
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert response.headers["Content-Disposition"] == 'attachment; filename="report.md"'
+
+
+def test_frontend_assets_wire_functional_dashboard_sections() -> None:
+    import fastmdxplora.live as live_pkg
+
+    root = Path(live_pkg.__file__).parent
+    html = (root / "templates" / "dashboard.html").read_text(encoding="utf-8")
+    css = (root / "static" / "dashboard.css").read_text(encoding="utf-8")
+    dashboard_js = (root / "static" / "dashboard.js").read_text(encoding="utf-8")
+    charts_js = (root / "static" / "charts.js").read_text(encoding="utf-8")
+    viewer_js = (root / "static" / "molecule-viewer.js").read_text(encoding="utf-8")
+
+    assert 'id="reports-files"' in html
+    assert 'id="simulation-files"' in html
+    assert 'id="analysis-files"' in html
+    assert 'id="mini-preview-canvas"' in html
+    assert "[hidden]" in css and "display: none !important" in css
+    assert "/api/results" in dashboard_js
+    assert "renderFiles" in dashboard_js
+    assert "renderAnalysis" in dashboard_js
+    assert "ResizeObserver" in charts_js
+    assert "mini-preview-canvas" in viewer_js
+    assert "/structure/topology.pdb" in viewer_js
+
+
+def test_dashboard_refresh_seconds_are_injected_into_html(tmp_path: Path) -> None:
+    run = tmp_path / "run"
+    run.mkdir()
+    server, base_url = start_test_server(
+        run,
+        config=DashboardConfig(refresh_seconds=1.5),
+    )
+    try:
+        html = urlopen(base_url, timeout=5).read().decode("utf-8")
+    finally:
+        server.shutdown()
+        server.server_close()
+    assert 'data-refresh-seconds="1.5"' in html
+    assert 'id="setting-refresh-seconds" min="1" max="60" step="1" value="1.5"' in html
+
+
+def test_runner_live_frame_helper_calls_writer_with_valid_keyword(
+    tmp_path: Path, monkeypatch
+) -> None:
+    calls: list[dict] = []
+
+    def fake_write_openmm_live_frame(output_dir, **kwargs):
+        calls.append({"output_dir": output_dir, **kwargs})
+        return {"ok": True}
+
+    import fastmdxplora.live.live_frames as live_frames_module
+
+    monkeypatch.setattr(
+        live_frames_module,
+        "write_openmm_live_frame",
+        fake_write_openmm_live_frame,
+    )
+
+    class FakeState:
+        def getPositions(self):
+            return "positions"
+
+    class FakeContext:
+        def getState(self, **_kwargs):
+            return FakeState()
+
+    simulation = SimpleNamespace(context=FakeContext(), topology="topology")
+    telemetry = SimpleNamespace(root=tmp_path / "simulation")
+    omm = {"PDBFile": SimpleNamespace(writeFile=lambda *_args, **_kwargs: None)}
+
+    _maybe_write_live_frame(
+        omm,
+        simulation,
+        telemetry,
+        250,
+        stage="nvt",
+        simulation_time_ns=0.0005,
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["pdbfile_writer"] is omm["PDBFile"].writeFile
+    assert calls[0]["frame_index"] == 250
+    assert calls[0]["stage"] == "nvt"
+    assert calls[0]["archive"] is True
+
+
+def test_dashboard_frame_interval_is_forwarded_to_explore_config() -> None:
+    config = {"simulation": {"temperature_K": 300.0}}
+    args = SimpleNamespace(dashboard_frame_interval=125)
+    _enable_dashboard_telemetry(config, args)
+    assert config["simulation"]["live_telemetry"] is True
+    assert config["simulation"]["telemetry_interval"] == 125
+    assert config["simulation"]["temperature_K"] == 300.0
+
+
+def test_results_endpoint_pairs_png_preview_with_svg_download(tmp_path: Path) -> None:
+    run = tmp_path / "run"
+    analysis = run / "analysis" / "rg"
+    analysis.mkdir(parents=True)
+    (run / "analysis" / "analysis_manifest.json").write_text(
+        json.dumps({"results": {"rg": {"status": "ok", "message": "rg: ok"}}}),
+        encoding="utf-8",
+    )
+    (analysis / "rg.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+    (analysis / "rg.svg").write_text(
+        '<svg xmlns="http://www.w3.org/2000/svg"></svg>', encoding="utf-8"
+    )
+    (analysis / "rg.dat").write_text("frame,rg_nm\n0,1.0\n", encoding="utf-8")
+
+    server, base_url = start_test_server(run)
+    try:
+        payload = json.loads(urlopen(f"{base_url}/api/results", timeout=5).read())
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    record = payload["analyses"][0]
+    assert record["plot"]["path"] == "analysis/rg/rg.png"
+    assert record["plot"]["svg_path"] == "analysis/rg/rg.svg"
+    assert record["plot"]["svg_download_href"].startswith("/artifacts/analysis/rg/rg.svg")
+    assert payload["svg_figure_count"] == 1
+
+
+def test_svg_bundle_endpoint_downloads_generated_vector_figures(tmp_path: Path) -> None:
+    import io
+    import zipfile
+
+    run = tmp_path / "run"
+    figure = run / "analysis" / "rmsd" / "rmsd.svg"
+    figure.parent.mkdir(parents=True)
+    figure.write_text('<svg xmlns="http://www.w3.org/2000/svg"></svg>', encoding="utf-8")
+
+    server, base_url = start_test_server(run)
+    try:
+        response = urlopen(f"{base_url}/analysis-figures-svg.zip", timeout=5)
+        data = response.read()
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert response.headers["Content-Type"] == "application/zip"
+    assert "fastmdxplora_svg_figures.zip" in response.headers["Content-Disposition"]
+    with zipfile.ZipFile(io.BytesIO(data)) as archive:
+        assert archive.namelist() == ["analysis/rmsd/rmsd.svg"]
+
+
+def test_dashboard_assets_include_svg_download_and_first_model_miniviewer_fix() -> None:
+    root = Path(__file__).resolve().parents[1]
+    html = (root / "src" / "fastmdxplora" / "live" / "templates" / "dashboard.html").read_text(encoding="utf-8")
+    dashboard_js = (root / "src" / "fastmdxplora" / "live" / "static" / "dashboard.js").read_text(encoding="utf-8")
+    viewer_js = (root / "src" / "fastmdxplora" / "live" / "static" / "molecule-viewer.js").read_text(encoding="utf-8")
+
+    assert 'id="download-all-svg"' in html
+    assert "Download SVG" in dashboard_js
+    assert "const hadModel" in viewer_js
+    assert "opts.center !== false || !hadModel" in viewer_js
+    assert "resolveProteinSelection" in viewer_js

--- a/tests/test_live_dashboard.py
+++ b/tests/test_live_dashboard.py
@@ -1,3 +1,13 @@
+"""Tests for the local live dashboard.
+
+These tests assert:
+
+  - endpoint contracts (URLs, response keys) the frontend binds to,
+  - failure isolation (traversal, missing files, empty run),
+  - the redesigned HTML/CSS/JS assets exist on disk and contain the
+    expected AAI-branded module structure.
+"""
+
 from __future__ import annotations
 
 import json
@@ -6,34 +16,57 @@ from pathlib import Path
 from urllib.error import HTTPError
 from urllib.request import urlopen
 
+import pytest
+
 from fastmdxplora.cli.main import _build_parser
 from fastmdxplora.live import protein_preview
+from fastmdxplora.live.ligand_detection import detect_ligands, normalise_ligand_resname
+from fastmdxplora.live.live_frames import write_live_frame, write_openmm_live_frame
 from fastmdxplora.live.protein_preview import protein_preview_payload
-from fastmdxplora.live.server import start_dashboard_session, start_test_server
-from fastmdxplora.live.telemetry import TelemetryWriter, analyze_health, read_events, read_metrics, read_status
+from fastmdxplora.live.server import (
+    DashboardConfig,
+    make_handler,
+    start_dashboard_session,
+    start_test_server,
+)
+from fastmdxplora.live.structure_info import count_structure, ligand_atom_counts
+from fastmdxplora.live.telemetry import (
+    TelemetryWriter,
+    analyze_health,
+    read_events,
+    read_metrics,
+    read_status,
+)
+from fastmdxplora.live.trajectory_playback import (
+    PlaybackUnavailable,
+    neighborhood_residues,
+    playback_info,
+)
 
 
+# ---------------------------------------------------------------------------
+# Fixture: tiny four-atom helper used by several tests
+# ---------------------------------------------------------------------------
+def _tiny_pdb() -> str:
+    return "\n".join(
+        [
+            "ATOM      1  CA  ALA A   1       0.000   0.000   0.000  1.00 10.00           C",
+            "ATOM      2  CA  GLY A   2       1.500   0.400   0.300  1.00 10.00           C",
+            "ATOM      3  CA  SER A   3       2.800   1.200   0.000  1.00 10.00           C",
+            "ATOM      4  CA  LEU A   4       4.100   1.400   0.900  1.00 10.00           C",
+            "END",
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Telemetry basics (unchanged behavior)
+# ---------------------------------------------------------------------------
 def test_telemetry_writer_creates_status_metrics_and_events(tmp_path: Path) -> None:
     simulation_dir = tmp_path / "run" / "simulation"
-    writer = TelemetryWriter(
-        simulation_dir,
-        total_steps=100,
-        planned_frames=10,
-        timestep_fs=2.0,
-        platform="CPU",
-        target_temperature_K=300.0,
-    )
-
+    writer = TelemetryWriter(simulation_dir, total_steps=100, planned_frames=10, timestep_fs=2.0, platform="CPU", target_temperature_K=300.0)
     writer.write_status(stage="production", status="running", current_step=25)
-    writer.append_metric(
-        stage="production",
-        step=25,
-        simulation_time_ns=0.00005,
-        potential_energy=-123.4,
-        total_energy=-100.0,
-        temperature=299.0,
-        progress_percent=25.0,
-    )
+    writer.append_metric(stage="production", step=25, simulation_time_ns=0.00005, potential_energy=-123.4, total_energy=-100.0, temperature=299.0, progress_percent=25.0)
     writer.event("frame written")
 
     status = read_status(tmp_path / "run")
@@ -50,7 +83,6 @@ def test_telemetry_writer_file_errors_do_not_raise(tmp_path: Path) -> None:
     blocked_path = tmp_path / "not_a_directory"
     blocked_path.write_text("occupied", encoding="utf-8")
     writer = TelemetryWriter(blocked_path)
-
     writer.write_status(stage="production")
     writer.append_metric(stage="production", step=1)
     writer.event("event")
@@ -58,301 +90,13 @@ def test_telemetry_writer_file_errors_do_not_raise(tmp_path: Path) -> None:
 
 def test_health_detects_nan_and_energy_spike() -> None:
     status = {"status": "running", "last_update_timestamp": "2999-01-01T00:00:00+00:00"}
-
     nan_health = analyze_health(status, [{"stage": "production", "total_energy": "nan"}])
     assert nan_health["state"] == "failed"
     assert "numerically unstable" in nan_health["explanation"]
 
-    spike_health = analyze_health(
-        status,
-        [
-            {"stage": "production", "total_energy": "-100.0"},
-            {"stage": "production", "total_energy": "50000.0"},
-        ],
-    )
+    spike_health = analyze_health(status, [{"stage": "production", "total_energy": "-100.0"}, {"stage": "production", "total_energy": "50000.0"}])
     assert spike_health["state"] == "warning"
     assert "Energy increased sharply" in spike_health["explanation"]
-
-
-def test_dashboard_server_serves_status_metrics_and_shell(tmp_path: Path) -> None:
-    run = tmp_path / "run"
-    writer = TelemetryWriter(run / "simulation", total_steps=10)
-    writer.write_status(stage="NVT", status="running", current_step=3)
-    writer.append_metric(stage="NVT", step=3, total_energy=-10.0)
-    (run / "report").mkdir(parents=True)
-    (run / "report" / "dashboard.html").write_text("<html>static</html>", encoding="utf-8")
-
-    server, base_url = start_test_server(run)
-    try:
-        status_payload = json.loads(urlopen(f"{base_url}/api/status", timeout=5).read())
-        metrics_payload = json.loads(urlopen(f"{base_url}/api/metrics", timeout=5).read())
-        html = urlopen(f"{base_url}/", timeout=5).read().decode("utf-8")
-    finally:
-        server.shutdown()
-        server.server_close()
-
-    assert status_payload["status"]["stage"] == "NVT"
-    assert metrics_payload["metrics"][-1]["total_energy"] == "-10.0"
-    assert "Live Simulation" in html
-    assert "Dashboard" in html
-    assert "Analysis Plots" in html
-    assert "Generated Files" in html
-    assert "System Info" in html
-    assert "Run Status" in html
-    assert "/api/status" in html
-    assert "/api/results" in html
-    assert "/api/protein-preview" in html
-    assert "/static/3Dmol-min.js" in html
-    assert "structure_url" in html
-    assert "live-grid" in html
-    assert "live-main-column" in html
-    assert "live-bottom-grid" in html
-    assert "protein-preview-card" in html
-    assert "max-height:520px" in html
-    assert "protein-preview-frame" in html
-    assert "height:340px" in html
-    assert "max-height:340px" in html
-    assert "protein-preview-frame img" in html
-    assert "object-fit:contain" in html
-    assert "#protein-viewer, #protein-3dmol-viewer" in html
-    assert "viewer-3dmol" in html
-    assert "protein-3dmol-viewer" in html
-    assert "$3Dmol.createViewer" in html
-    assert "backgroundColor:\"#08111f\"" in html
-    assert "addModel(proteinViewer3DmolPdb, \"pdb\")" in html
-    assert 'setStyle({}, {cartoon: {color:"spectrum"}})' in html
-    assert "proteinViewer3Dmol.spin(active)" in html
-    assert "proteinViewer3Dmol.zoomTo()" in html
-    assert "PyMOL Preview" in html
-    assert "Interactive 3D" in html
-    assert "Spin" in html
-    assert "Reset view" in html
-    assert 'id="protein-expand"' in html
-    assert 'id="protein-collapse"' in html
-    assert 'onclick="setProteinPreviewExpanded(true)"' in html
-    assert 'onclick="setProteinPreviewExpanded(false)"' in html
-    assert "protein-preview-card expanded" not in html
-    assert "protein-preview-full" not in html
-    assert html.index('id="stage"') < html.index("<h2>Protein Preview</h2>")
-    assert html.index('id="progress-fill"') < html.index("<h2>Protein Preview</h2>")
-    assert html.index('id="metrics-chart"') < html.index("<h2>Protein Preview</h2>")
-    assert "viewer-canvas" in html
-    assert "parsePdbTrace" in html
-    assert "load3DmolViewer" in html
-    assert "loadSchematicViewer" in html
-    assert "schematic fallback" in html
-    assert "PyMOL render" in html
-    assert "Interactive 3Dmol cartoon viewer" in html
-    assert 'id="protein-view-static">PyMOL Preview' in html
-    assert 'id="protein-view-3d">Interactive 3D' in html
-    assert '<div class="protein-view" id="protein-viewer-wrap">' in html
-    assert '<div class="protein-view hidden" id="protein-fallback-wrap">' in html
-    assert '<div class="protein-view hidden" id="protein-static-wrap">' in html
-    assert "regenerate-preview" in html
-    assert "setProteinPreviewExpanded" in html
-    assert "https://" not in html
-    assert "cdn" not in html.lower()
-    assert "plot-footer" in html
-    assert "plot-title" in html
-    assert "artifact-path" in html
-    assert "display_path" in html
-    assert "-webkit-line-clamp:2" in html
-    assert "overflow-wrap:anywhere" in html
-    assert "size-button" in html
-    assert "refresh-results" in html
-    assert "Last refreshed" in html
-    assert "Analysis outputs not available yet" in html
-    assert "Quick Actions" in html
-    assert "Phase Summary" in html
-    assert "Live Status Summary" in html
-    assert "Results Dashboard" not in html
-    assert "Key Plots" not in html
-    assert "dashboard-key-plots" not in html
-    assert "<iframe" not in html
-    assert "static-dashboard-frame" not in html
-
-
-def test_artifacts_and_results_rescan_after_server_start(tmp_path: Path) -> None:
-    run = tmp_path / "run"
-    (run / "simulation").mkdir(parents=True)
-    (run / "simulation" / "live_status.json").write_text("{}", encoding="utf-8")
-
-    server, base_url = start_test_server(run)
-    try:
-        initial = json.loads(urlopen(f"{base_url}/api/results", timeout=5).read())
-        assert initial["has_analysis"] is False
-        assert initial["has_report"] is False
-
-        (run / "analysis" / "rmsd").mkdir(parents=True)
-        (run / "analysis" / "rmsd" / "rmsd.png").write_bytes(b"png")
-        (run / "analysis" / "sasa").mkdir(parents=True)
-        (run / "analysis" / "sasa" / "sasa.png").write_bytes(b"png")
-        (run / "report" / "dashboard_assets").mkdir(parents=True)
-        (run / "report" / "dashboard_assets" / "cluster_hierarchical_dendrogram_dashboard.png").write_bytes(b"png")
-        (run / "report" / "report.md").write_text("# Report", encoding="utf-8")
-        (run / "report" / "dashboard.html").write_text("<html>new</html>", encoding="utf-8")
-
-        artifacts_response = urlopen(f"{base_url}/api/artifacts", timeout=5)
-        artifacts_payload = json.loads(artifacts_response.read())
-        results_payload = json.loads(urlopen(f"{base_url}/api/results", timeout=5).read())
-    finally:
-        server.shutdown()
-        server.server_close()
-
-    assert artifacts_response.headers["Cache-Control"] == "no-store"
-    artifact_paths = {record["path"] for record in artifacts_payload["artifacts"]}
-    assert "analysis/rmsd/rmsd.png" in artifact_paths
-    assert "report/report.md" in artifact_paths
-    report_record = next(record for record in artifacts_payload["artifacts"] if record["path"] == "report/dashboard.html")
-    assert report_record["display_path"] == "report/dashboard.html"
-    assert results_payload["has_analysis"] is True
-    assert results_payload["has_report"] is True
-    titles = {plot["title"] for plot in results_payload["plots"]}
-    assert "RMSD" in titles
-    assert "Hierarchical dendrogram" in titles
-    assert "cluster_hierarchical_dendrogram_dashboard.png" not in titles
-    categories = {plot["category"] for plot in results_payload["plots"]}
-    assert "Core Metrics" in categories
-    assert "Additional Analysis" in categories
-    assert "Clustering" in categories
-    rmsd_plot = next(plot for plot in results_payload["plots"] if plot["title"] == "RMSD")
-    assert rmsd_plot["href"].endswith(f"?v={int((run / 'analysis' / 'rmsd' / 'rmsd.png').stat().st_mtime)}")
-    assert rmsd_plot["display_path"] == ".../rmsd/rmsd.png"
-    dendrogram = next(plot for plot in results_payload["plots"] if plot["title"] == "Hierarchical dendrogram")
-    assert dendrogram["mode"] == "dashboard view"
-    assert dendrogram["display_path"] == ".../dashboard_assets/cluster_hierarchical_dendrogram_dashboard.png"
-    assert results_payload["dashboard"]["path"] == "report/dashboard.html"
-    assert any(record["path"] == "report/dashboard.html" for record in results_payload["reports"])
-
-
-def test_live_json_endpoints_are_no_store(tmp_path: Path) -> None:
-    run = tmp_path / "run"
-    writer = TelemetryWriter(run / "simulation")
-    writer.write_status(stage="production")
-
-    server, base_url = start_test_server(run)
-    try:
-        for endpoint in ("status", "metrics", "events", "artifacts", "results", "protein-preview"):
-            response = urlopen(f"{base_url}/api/{endpoint}", timeout=5)
-            response.read()
-            assert response.headers["Cache-Control"] == "no-store"
-    finally:
-        server.shutdown()
-        server.server_close()
-
-
-def test_live_json_endpoints_are_sane_for_empty_run(tmp_path: Path) -> None:
-    run = tmp_path / "empty_run"
-
-    server, base_url = start_test_server(run)
-    try:
-        status_payload = json.loads(urlopen(f"{base_url}/api/status", timeout=5).read())
-        metrics_payload = json.loads(urlopen(f"{base_url}/api/metrics", timeout=5).read())
-        events_payload = json.loads(urlopen(f"{base_url}/api/events", timeout=5).read())
-        artifacts_payload = json.loads(urlopen(f"{base_url}/api/artifacts", timeout=5).read())
-        results_payload = json.loads(urlopen(f"{base_url}/api/results", timeout=5).read())
-    finally:
-        server.shutdown()
-        server.server_close()
-
-    assert status_payload["status"] == {}
-    assert status_payload["health"]["state"] == "unknown"
-    assert metrics_payload["metrics"] == []
-    assert events_payload["events"] == []
-    assert artifacts_payload["artifacts"] == []
-    assert results_payload["has_analysis"] is False
-    assert results_payload["has_report"] is False
-    assert results_payload["plots"] == []
-
-
-def test_live_server_rejects_artifact_path_traversal(tmp_path: Path) -> None:
-    run = tmp_path / "run"
-    run.mkdir()
-    outside = tmp_path / "outside.txt"
-    outside.write_text("secret", encoding="utf-8")
-
-    server, base_url = start_test_server(run)
-    try:
-        try:
-            urlopen(f"{base_url}/artifacts/../outside.txt", timeout=5)
-        except HTTPError as exc:
-            assert exc.code in {403, 404}
-        else:
-            raise AssertionError("path traversal unexpectedly succeeded")
-    finally:
-        server.shutdown()
-        server.server_close()
-
-
-def test_live_server_does_not_serve_static_path_traversal(tmp_path: Path) -> None:
-    run = tmp_path / "run"
-    run.mkdir()
-
-    server, base_url = start_test_server(run)
-    try:
-        try:
-            urlopen(f"{base_url}/static/../server.py", timeout=5)
-        except HTTPError as exc:
-            assert exc.code == 404
-        else:
-            raise AssertionError("static traversal unexpectedly succeeded")
-    finally:
-        server.shutdown()
-        server.server_close()
-
-
-def test_static_3dmol_asset_is_served_locally(tmp_path: Path) -> None:
-    run = tmp_path / "run"
-    run.mkdir()
-
-    server, base_url = start_test_server(run)
-    try:
-        response = urlopen(f"{base_url}/static/3Dmol-min.js", timeout=5)
-        body = response.read().decode("utf-8", errors="ignore")
-    finally:
-        server.shutdown()
-        server.server_close()
-
-    assert response.headers["Cache-Control"] == "no-store"
-    assert "$3Dmol" in body
-    assert "http://" not in body[:1000]
-    assert "https://" not in body[:1000]
-
-
-def test_dashboard_session_uses_next_port_when_requested_port_is_busy(
-    tmp_path: Path,
-) -> None:
-    run = tmp_path / "run"
-    run.mkdir()
-    blocker = socket.socket()
-    blocker.bind(("127.0.0.1", 0))
-    blocker.listen()
-    requested_port = blocker.getsockname()[1]
-
-    session = start_dashboard_session(
-        output=run,
-        host="127.0.0.1",
-        port=requested_port,
-        max_port_tries=5,
-    )
-    try:
-        assert session.requested_port == requested_port
-        assert session.port != requested_port
-        assert session.port_was_changed is True
-        assert session.url == f"http://127.0.0.1:{session.port}"
-    finally:
-        session.stop()
-        blocker.close()
-
-
-def test_dashboard_session_stop_is_safe(tmp_path: Path) -> None:
-    run = tmp_path / "run"
-    run.mkdir()
-    session = start_dashboard_session(output=run, port=0)
-
-    assert session.thread.is_alive()
-    session.stop()
-    assert not session.thread.is_alive()
 
 
 def test_telemetry_readers_handle_missing_and_malformed_files(tmp_path: Path) -> None:
@@ -370,54 +114,26 @@ def test_telemetry_readers_handle_missing_and_malformed_files(tmp_path: Path) ->
 
     assert read_status(run) == {}
     assert isinstance(read_metrics(run), list)
-    assert read_events(run) == [
-        {"timestamp": "", "level": "info", "message": "free-form event without tabs"}
-    ]
+    assert read_events(run) == [{"timestamp": "", "level": "info", "message": "free-form event without tabs"}]
 
 
 def test_analyze_health_temperature_and_stale_warning() -> None:
-    stale = analyze_health(
-        {"status": "running", "last_update_timestamp": "2000-01-01T00:00:00+00:00"},
-        [],
-        stale_after_seconds=1,
-    )
+    stale = analyze_health({"status": "running", "last_update_timestamp": "2000-01-01T00:00:00+00:00"}, [], stale_after_seconds=1)
     assert stale["state"] == "warning"
     assert "stale" in stale["message"].lower()
 
-    hot = analyze_health(
-        {"status": "running", "target_temperature_K": 300.0},
-        [{"temperature": "420.0"}],
-    )
+    hot = analyze_health({"status": "running", "target_temperature_K": 300.0}, [{"temperature": "420.0"}])
     assert hot["state"] == "warning"
     assert "Temperature" in hot["message"]
 
 
+# ---------------------------------------------------------------------------
+# Protein preview behaviour (unchanged endpoint contract)
+# ---------------------------------------------------------------------------
 def test_protein_preview_unavailable_without_structure(tmp_path: Path) -> None:
     payload = protein_preview_payload(tmp_path / "run")
-
     assert payload["available"] is False
     assert payload["message"] == "No topology/PDB found yet."
-
-
-def test_protein_preview_requires_pymol_when_missing(tmp_path: Path, monkeypatch) -> None:
-    monkeypatch.setattr("fastmdxplora.live.protein_preview._find_pymol_executable", lambda _root: None)
-    run = tmp_path / "run"
-    topology = run / "simulation" / "topology.pdb"
-    topology.parent.mkdir(parents=True)
-    topology.write_text(_tiny_pdb(), encoding="utf-8")
-
-    payload = protein_preview_payload(run)
-
-    assert payload["available"] is True
-    assert payload["static_available"] is False
-    assert payload["static_mode"] is None
-    assert payload["static_image_url"] is None
-    assert payload["structure_available"] is True
-    assert payload["viewer_available"] is True
-    assert payload["viewer_mode"] == "3dmol"
-    assert payload["fallback_available"] is True
-    assert payload["fallback_mode"] == "schematic"
-    assert "PyMOL preview unavailable" in payload["message"]
 
 
 def test_protein_preview_uses_existing_image_without_structure(tmp_path: Path) -> None:
@@ -427,79 +143,14 @@ def test_protein_preview_uses_existing_image_without_structure(tmp_path: Path) -
     preview.write_bytes(b"\x89PNG\r\n\x1a\n")
 
     payload = protein_preview_payload(run)
-
     assert payload["available"] is True
     assert payload["static_available"] is True
     assert payload["static_mode"] == "existing"
     assert payload["path"] == "report/dashboard_assets/protein_preview.png"
-    assert payload["structure_available"] is False
-    assert payload["viewer_available"] is False
-
-
-def test_protein_preview_finds_manifest_system_path_and_handles_missing_viewer(
-    tmp_path: Path,
-    monkeypatch,
-) -> None:
-    system_pdb = tmp_path / "source.pdb"
-    system_pdb.write_text(_tiny_pdb(), encoding="utf-8")
-    run = tmp_path / "run"
-    run.mkdir()
-    (run / "manifest.json").write_text(json.dumps({"system": str(system_pdb)}), encoding="utf-8")
-
-    monkeypatch.setattr("fastmdxplora.live.protein_preview._find_pymol_executable", lambda _root: None)
-    monkeypatch.setattr("fastmdxplora.live.protein_preview.viewer_asset_available", lambda: False)
-
-    payload = protein_preview_payload(run)
-
-    assert payload["available"] is True
-    assert payload["static_available"] is False
-    assert Path(payload["structure_path"]).resolve() == system_pdb.resolve()
-    assert payload["structure_url"] is None
-    assert payload["structure_available"] is False
-    assert payload["viewer_available"] is False
-    assert payload["fallback_available"] is False
-    assert payload["fallback_mode"] is None
-
-
-def test_protein_preview_api_finds_topology(tmp_path: Path, monkeypatch) -> None:
-    def _fake_render(_pymol, _structure, output_path):
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        output_path.write_bytes(b"\x89PNG\r\n\x1a\n")
-
-    monkeypatch.setattr("fastmdxplora.live.protein_preview._find_pymol_executable", lambda _root: "/fake/pymol")
-    monkeypatch.setattr("fastmdxplora.live.protein_preview._render_with_pymol", _fake_render)
-    run = tmp_path / "run"
-    topology = run / "simulation" / "topology.pdb"
-    topology.parent.mkdir(parents=True)
-    topology.write_text(_tiny_pdb(), encoding="utf-8")
-
-    server, base_url = start_test_server(run)
-    try:
-        payload = json.loads(urlopen(f"{base_url}/api/protein-preview", timeout=5).read())
-    finally:
-        server.shutdown()
-        server.server_close()
-
-    assert payload["available"] is True
-    assert "mode" not in payload
-    assert payload["static_available"] is True
-    assert payload["static_mode"] == "pymol"
-    assert payload["path"] == "simulation/protein_preview.png"
-    assert "?v=" in payload["href"]
-    assert payload["image_url"] == payload["href"]
-    assert payload["static_image_url"] == payload["href"]
-    assert payload["structure_path"] == "simulation/topology.pdb"
-    assert payload["structure_url"].startswith("/structure/topology.pdb?v=")
-    assert payload["structure_available"] is True
-    assert payload["viewer_available"] is True
-    assert payload["viewer_mode"] == "3dmol"
-    assert payload["fallback_available"] is True
-    assert payload["fallback_mode"] == "schematic"
-    assert (run / payload["path"]).read_bytes().startswith(b"\x89PNG")
 
 
 def test_structure_route_serves_topology(tmp_path: Path, monkeypatch) -> None:
-    monkeypatch.setattr("fastmdxplora.live.protein_preview._find_pymol_executable", lambda _root: None)
+    monkeypatch.setattr(protein_preview, "_find_pymol_executable", lambda _root: None)
     run = tmp_path / "run"
     topology = run / "simulation" / "topology.pdb"
     topology.parent.mkdir(parents=True)
@@ -514,8 +165,7 @@ def test_structure_route_serves_topology(tmp_path: Path, monkeypatch) -> None:
         server.server_close()
 
     assert response.headers["Cache-Control"] == "no-store"
-    assert "ATOM" in body
-    assert "ALA" in body
+    assert "ATOM" in body and "ALA" in body
 
 
 def test_pymol_script_uses_padded_uncropped_camera(tmp_path: Path, monkeypatch) -> None:
@@ -530,7 +180,6 @@ def test_pymol_script_uses_padded_uncropped_camera(tmp_path: Path, monkeypatch) 
         output.write_bytes(b"\x89PNG\r\n\x1a\n")
 
     monkeypatch.setattr(protein_preview.subprocess, "run", _fake_run)
-
     protein_preview._render_with_pymol("/fake/pymol", structure, output)
 
     script = captured["script"]
@@ -539,7 +188,6 @@ def test_pymol_script_uses_padded_uncropped_camera(tmp_path: Path, monkeypatch) 
     assert "spectrum count, rainbow, prot, byres=1" in script
     assert "set_color fastmdx_res_1" in script
     assert "color fastmdx_res_1, prot and resi 1 and chain A" in script
-    assert "set_color fastmdx_res_4" in script
     assert "set ray_opaque_background, off" in script
     assert "set cartoon_fancy_helices, 1" in script
     assert "set cartoon_smooth_loops, 1" in script
@@ -559,20 +207,539 @@ def test_dashboard_serve_command_parses() -> None:
     args = _build_parser().parse_args(
         ["dashboard", "serve", "--output", "local_runs/my_run", "--port", "8766"]
     )
-
     assert args.command == "dashboard"
     assert args.dashboard_command == "serve"
     assert args.output == "local_runs/my_run"
     assert args.port == 8766
 
 
-def _tiny_pdb() -> str:
-    return "\n".join(
-        [
-            "ATOM      1  CA  ALA A   1       0.000   0.000   0.000  1.00 10.00           C",
-            "ATOM      2  CA  GLY A   2       1.500   0.400   0.300  1.00 10.00           C",
-            "ATOM      3  CA  SER A   3       2.800   1.200   0.000  1.00 10.00           C",
-            "ATOM      4  CA  LEU A   4       4.100   1.400   0.900  1.00 10.00           C",
-            "END",
-        ]
-    )
+# ---------------------------------------------------------------------------
+# New dashboards: structure_info, ligand_detection, live_frames, trajectory_playback
+# ---------------------------------------------------------------------------
+def test_count_structure_basic_protein(tmp_path: Path) -> None:
+    (tmp_path / "topology.pdb").write_text(_tiny_pdb(), encoding="utf-8")
+    info = count_structure(tmp_path / "topology.pdb")
+    assert info["valid"] is True
+    assert info["n_chains"] == 1
+    assert info["protein_residues"] == 4
+    assert info["water_residues"] == 0
+    assert info["ions"] == 0
+    assert info["ligand_residues_total"] == 0
+
+
+def test_count_structure_water_atom_record_not_double_counted(tmp_path: Path) -> None:
+    # Many PDBs list waters as ATOM HOH. They must not appear in
+    # protein_residues.
+    pdb = "\n".join([
+        "ATOM      1  N   ALA A   1       0.000   0.000   0.000  1.00  0.00           N",
+        "ATOM      2  CA  ALA A   1       0.000   0.000   0.000  1.00  0.00           C",
+        "ATOM      3  OH2 HOH B  10       5.000   5.000   5.000  1.00  0.00           O",
+        "END",
+    ])
+    (tmp_path / "topology.pdb").write_text(pdb, encoding="utf-8")
+    info = count_structure(tmp_path / "topology.pdb")
+    assert info["valid"] is True
+    assert info["protein_residues"] == 1
+    assert info["water_residues"] == 1
+
+
+def test_count_structure_detects_ligand(tmp_path: Path) -> None:
+    pdb = "\n".join([
+        "ATOM      1  N   ALA A   1       0.000   0.000   0.000  1.00  0.00           N",
+        "ATOM      2  CA  ALA A   1       0.000   0.000   0.000  1.00  0.00           C",
+        "HETATM    3  C1  EPE A 100       4.000   4.000   4.000  1.00 10.00           C",
+        "HETATM    4  O1  EPE A 100       4.300   4.300   4.300  1.00 10.00           O",
+        "END",
+    ])
+    (tmp_path / "topology.pdb").write_text(pdb, encoding="utf-8")
+    info = count_structure(tmp_path / "topology.pdb")
+    assert "EPE" in info["ligand_resnames"]
+
+
+def test_count_structure_handles_missing(tmp_path: Path) -> None:
+    info = count_structure(tmp_path / "no.pdb")
+    assert info["valid"] is False
+
+
+def test_count_structure_rejects_too_large_files(tmp_path: Path) -> None:
+    big = tmp_path / "huge.pdb"
+    big.write_text("HEADER\n", encoding="utf-8")
+    big.write_bytes(b"X" * (9 * 1024 * 1024))  # > 8 MB
+    info = count_structure(big)
+    assert info["valid"] is False
+    assert info["reason"] == "too-large"
+
+
+def test_detect_ligands_basic(tmp_path: Path) -> None:
+    pdb = "\n".join([
+        "HETATM    1  C1  EPE A 100       4.000   4.000   4.000  1.00 10.00           C",
+        "HETATM    2  C2  BEN B   1       5.000   5.000   5.000  1.00 10.00           C",
+        "ATOM      3  N   ALA A   1       0.000   0.000   0.000  1.00  0.00           N",
+        "END",
+    ])
+    (tmp_path / "topology.pdb").write_text(pdb, encoding="utf-8")
+    info = count_structure(tmp_path / "topology.pdb")
+    keys = [(ins["chain"], ins["resname"], ins["resi"]) for ins in info["ligand_instances"]]
+    detected = detect_ligands(keys)
+    assert set(detected["resnames"]) >= {"EPE"}
+
+
+def test_detect_ligands_respects_explicit_override() -> None:
+    keys = [("A", "NA", "1")]
+    out = detect_ligands(keys, explicit=["NA"])
+    assert out["resnames"] == ["NA"]
+    assert out["instances"][0]["explicit"] is True
+
+
+def test_detect_ligands_excludes_water_and_ions() -> None:
+    keys = [("A", "HOH", "1"), ("A", "NA", "2"), ("A", "EPE", "3")]
+    out = detect_ligands(keys)
+    assert sorted(out["resnames"]) == ["EPE"]
+
+
+def test_detect_ligands_includes_cofactors_when_requested() -> None:
+    keys = [("A", "GOL", "1"), ("A", "EPE", "2")]
+    default = detect_ligands(keys)
+    with_cof = detect_ligands(keys, include_cofactors=True)
+    assert "GOL" in with_cof["cofactors"]
+    assert "GOL" not in default["resnames"]
+    assert "GOL" in with_cof["resnames"]
+
+
+def test_detect_ligands_lexicographic_sort(tmp_path: Path) -> None:
+    # Single chain so the (chain, resname, resi) sort key collapses to
+    # numeric resi ordering only.
+    keys = [("A", "EPE", str(r)) for r in [10, 2, 100]]
+    detected = detect_ligands(keys)
+    assert [ins["resi"] for ins in detected["instances"]] == ["2", "10", "100"]
+
+
+def test_ligand_atom_counts_distinguishes_ligands(tmp_path: Path) -> None:
+    pdb = "\n".join([
+        "HETATM    1  C1  EPE A 100       4.000   4.000   4.000  1.00 10.00           C",
+        "HETATM    2  C2  EPE A 100       4.300   4.300   4.300  1.00 10.00           C",
+        "HETATM    3  C1  BEN B   1       5.000   5.000   5.000  1.00 10.00           C",
+        "HETATM    4  H1  HOH A   2       5.500   5.500   5.500  1.00  0.00           H",
+        "END",
+    ])
+    (tmp_path / "topology.pdb").write_text(pdb, encoding="utf-8")
+    counts = ligand_atom_counts(tmp_path / "topology.pdb")
+    assert counts == {"EPE": 2, "BEN": 1}
+
+
+def test_normalise_ligand_resname() -> None:
+    assert normalise_ligand_resname("epe") == "EPE"
+    assert normalise_ligand_resname("LIG ") == "LIG"
+    assert normalise_ligand_resname("") is None
+    assert normalise_ligand_resname(None) is None
+
+
+def test_write_live_frame_round_trip(tmp_path: Path) -> None:
+    sim = tmp_path / "simulation"
+    result = write_live_frame(sim, pdb_text=_tiny_pdb(), frame_index=42)
+    assert result["ok"] is True
+    assert (sim / "live_frame.pdb").is_file()
+    index = json.loads((sim / "live_frame_index.json").read_text(encoding="utf-8"))
+    assert index["live_frame_available"] is True
+    assert index["live_frame_index"] == 42
+
+
+def test_write_live_frame_handles_missing_directory_safely(tmp_path: Path) -> None:
+    # write_live_frame must not crash when the target "directory" is a
+    # regular file. Putting a regular file at the target slot makes
+    # Path.mkdir(parents=True, exist_ok=True) fail both on POSIX and
+    # Windows. Cross-platform safe; the original /nonexistent/... path
+    # was environment-dependent on Windows because C:\ is normally
+    # writable so the parent.mkdir succeeded.
+    blocked = tmp_path / "i_am_a_file"
+    blocked.write_text("not a directory", encoding="utf-8")
+    result = write_live_frame(blocked, pdb_text="ATOM\n", frame_index=1)
+    assert result["ok"] is False
+
+
+def test_playback_returns_unavailable_when_missing(tmp_path: Path) -> None:
+    info = playback_info(tmp_path)
+    assert info["playback_available"] is False
+
+
+def test_playback_generation_failure_is_safe(tmp_path: Path, monkeypatch) -> None:
+    # Force a failure inside the writer.
+    import fastmdxplora.live.trajectory_playback as mod
+    monkeypatch.setattr(mod, "_import_openmm", lambda: None)
+    (tmp_path / "simulation").mkdir(parents=True)
+    (tmp_path / "simulation" / "topology.pdb").write_text(_tiny_pdb(), encoding="utf-8")
+    (tmp_path / "simulation" / "production.dcd").write_bytes(b"\x00\x00")
+    info = playback_info(tmp_path)
+    assert info["playback_available"] is False
+    assert info["reason"] == "openmm-not-installed"
+
+
+def test_neighborhood_residues_per_atom_check(tmp_path: Path) -> None:
+    # Atom-wide coordinates in standard PDB column widths so the parser
+    # finds the values in the right slots (cols 31-38, 39-46, 47-54).
+    pdb = "\n".join([
+        "HETATM    1  C1  EPE A 100       4.000   4.000   4.000  1.00 10.00           C",
+        "ATOM      2  N   ALA A   1       4.500   4.500   4.500  1.00  0.00           N",  # near
+        "ATOM      3  N   ALA A   2      30.000  30.000  30.000  1.00  0.00           N",  # far
+        "END",
+    ])
+    (tmp_path / "topology.pdb").write_text(pdb, encoding="utf-8")
+    residues = neighborhood_residues(topology_path=tmp_path / "topology.pdb", ligand_resname="EPE", cutoff_angstrom=5.0)
+    assert ("A", 1) in residues
+    assert ("A", 2) not in residues
+
+
+# ---------------------------------------------------------------------------
+# Endpoint contract: the redesigned dashboard's HTML/JS layer
+# ---------------------------------------------------------------------------
+def test_dashboard_html_uses_separated_template() -> None:
+    """The HTML shell lives on disk next to the module rather than as a giant f-string."""
+    template_path = Path(make_handler.__module__.split(".")[0])
+    import fastmdxplora.live as live_pkg
+    layout = Path(live_pkg.__file__).with_name("templates") / "dashboard.html"
+    assert layout.is_file()
+
+
+def test_dashboard_html_has_aai_branding(tmp_path: Path) -> None:
+    run = tmp_path / "run"
+    writer = TelemetryWriter(run / "simulation")
+    writer.write_status(stage="NVT")
+    server, base_url = start_test_server(run)
+    try:
+        html = urlopen(f"{base_url}/", timeout=5).read().decode("utf-8")
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    # Branding hierarchy
+    assert "AAI Research Lab" in html or "aai-research-logo" in html
+    assert "FastMDXplora" in html
+    assert "Fully Automated SysTem for Molecular Dynamics eXploration" in html
+
+    # Sidebar / top bar / nav structure
+    assert "sidebar" in html
+    assert "top-bar" in html
+    assert "data-view-link" in html
+
+    # Asset wiring
+    assert "/static/dashboard.css" in html
+    assert "/static/dashboard.js" in html
+    assert "/static/charts.js" in html
+    assert "/static/molecule-viewer.js" in html
+    assert "/static/3Dmol-min.js" in html
+    assert "/static/aai-research-logo.svg" in html or "/static/aai-research-mark.svg" in html
+
+    # Pages
+    for page in ("overview", "live", "viewer", "analysis", "files", "settings"):
+        assert f'data-page="{page}"' in html
+
+    # Loading screen + branded particles
+    assert "loading-screen" in html
+
+    # No CDN references
+    assert "cdn" not in html.lower()
+    assert "googleapis" not in html.lower()
+    # The documentation + GitHub sidebar links are the only legitimate
+    # external refs, both harmless but explicit.
+    for allowed in (
+        "https://fastmdxplora.readthedocs.io",
+        "https://github.com/aai-research-lab/FastMDXplora",
+    ):
+        assert allowed in html
+    assert html.count("https://") == 2
+
+
+def test_dashboard_css_uses_black_scientific_palette() -> None:
+    css_path = Path(make_handler.__module__.split(".")[0])
+    import fastmdxplora.live as live_pkg
+    css = (Path(live_pkg.__file__).with_name("static") / "dashboard.css").read_text(encoding="utf-8")
+    for token in ("--background-primary", "--accent-cyan", "--accent-violet",
+                  "--text-primary", "prefers-reduced-motion", "Inter"):
+        assert token in css
+
+
+def test_dashboard_endpoint_no_inline_html_css() -> None:
+    """The server.py module no longer contains the giant HTML f-string.
+
+    We assert the absence of known-fingerprinted fragments from the old
+    inline template — a tautology-free check.
+    """
+    server_path = Path(make_handler.__module__.split(".")[0])
+    import fastmdxplora.live as live_pkg
+    src = (Path(live_pkg.__file__).with_name("server.py")).read_text(encoding="utf-8")
+    for marker in (
+        'onclick="setProteinPreviewExpanded',
+        'spectrum count, rainbow, prot, byres=1',
+        'function setProteinPreviewExpanded(expanded)',
+    ):
+        assert marker not in src, f"legacy inline marker found: {marker!r}"
+
+
+def test_dashboard_server_serves_new_routes(tmp_path: Path) -> None:
+    run = tmp_path / "run"
+    sim = run / "simulation"
+    sim.mkdir(parents=True)
+    (sim / "topology.pdb").write_text(_tiny_pdb(), encoding="utf-8")
+    write_live_frame(sim, pdb_text=_tiny_pdb(), frame_index=10)
+
+    server, base_url = start_test_server(run)
+    try:
+        for path in (
+            "/api/status",
+            "/api/metrics",
+            "/api/events",
+            "/api/artifacts",
+            "/api/files",          # alias
+            "/api/results",
+            "/api/analyses",       # alias
+            "/api/protein-preview",
+            "/api/structure-info",
+            "/api/ligands",
+            "/api/live-frame-index",
+            "/api/live-coordinates",
+            "/api/playback-info",
+            "/structure/topology.pdb",
+            "/structure/live-frame.pdb",
+        ):
+            response = urlopen(f"{base_url}{path}", timeout=5)
+            response.read()
+            assert response.headers["Cache-Control"] == "no-store", path
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_structure_info_endpoint_payload_keys(tmp_path: Path) -> None:
+    run = tmp_path / "run"
+    sim = run / "simulation"
+    sim.mkdir(parents=True)
+    (sim / "topology.pdb").write_text(_tiny_pdb(), encoding="utf-8")
+    server, base_url = start_test_server(run, config=DashboardConfig(ligand_resname="LIG"))
+    try:
+        payload = json.loads(urlopen(f"{base_url}/api/structure-info", timeout=5).read())
+    finally:
+        server.shutdown()
+        server.server_close()
+    assert payload["valid"] is True
+    assert payload["n_chains"] == 1
+    assert payload["protein_residues"] == 4
+    assert payload["explicit_ligand"] == "LIG"
+
+
+def test_live_frame_endpoint_serves_pdb(tmp_path: Path) -> None:
+    run = tmp_path / "run"
+    sim = run / "simulation"
+    sim.mkdir(parents=True)
+    write_live_frame(sim, pdb_text=_tiny_pdb(), frame_index=5)
+    server, base_url = start_test_server(run)
+    try:
+        body = urlopen(f"{base_url}/structure/live-frame.pdb", timeout=5).read().decode("utf-8")
+    finally:
+        server.shutdown()
+        server.server_close()
+    assert "ATOM" in body and "ALA" in body
+
+
+def test_live_frame_endpoint_404_when_missing(tmp_path: Path) -> None:
+    run = tmp_path / "run"
+    sim = run / "simulation"
+    sim.mkdir(parents=True)
+    server, base_url = start_test_server(run)
+    try:
+        try:
+            urlopen(f"{base_url}/structure/live-frame.pdb", timeout=5)
+        except HTTPError as exc:
+            assert exc.code == 404
+        else:
+            raise AssertionError("expected 404 on missing live frame")
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_playback_info_unavailable_when_no_trajectory(tmp_path: Path) -> None:
+    run = tmp_path / "run"
+    run.mkdir()
+    server, base_url = start_test_server(run)
+    try:
+        payload = json.loads(urlopen(f"{base_url}/api/playback-info", timeout=5).read())
+    finally:
+        server.shutdown()
+        server.server_close()
+    assert payload["playback_available"] is False
+
+
+def test_artifacts_response_includes_files(tmp_path: Path) -> None:
+    run = tmp_path / "run"
+    sim = run / "simulation"
+    sim.mkdir(parents=True)
+    (sim / "live_status.json").write_text("{}", encoding="utf-8")
+    server, base_url = start_test_server(run)
+    try:
+        payload = json.loads(urlopen(f"{base_url}/api/files", timeout=5).read())
+    finally:
+        server.shutdown()
+        server.server_close()
+    assert any(record["path"].endswith("live_status.json") for record in payload["artifacts"])
+
+
+def test_results_response_keys_match_dashboard_bindings(tmp_path: Path) -> None:
+    run = tmp_path / "run"
+    sim = run / "simulation"
+    sim.mkdir(parents=True)
+    (sim / "live_status.json").write_text("{}", encoding="utf-8")
+    server, base_url = start_test_server(run)
+    try:
+        payload = json.loads(urlopen(f"{base_url}/api/results", timeout=5).read())
+    finally:
+        server.shutdown()
+        server.server_close()
+    for key in ("refreshed_at", "has_analysis", "has_report", "summary", "system", "phases", "plots", "key_plots", "reports", "artifacts"):
+        assert key in payload
+
+
+def test_dashboard_session_uses_next_port_when_busy(tmp_path: Path) -> None:
+    run = tmp_path / "run"
+    run.mkdir()
+    blocker = socket.socket()
+    blocker.bind(("127.0.0.1", 0))
+    blocker.listen()
+    requested_port = blocker.getsockname()[1]
+    session = start_dashboard_session(output=run, host="127.0.0.1", port=requested_port, max_port_tries=5)
+    try:
+        assert session.requested_port == requested_port
+        assert session.port != requested_port
+        assert session.port_was_changed is True
+    finally:
+        session.stop()
+        blocker.close()
+
+
+def test_dashboard_session_stop_is_safe(tmp_path: Path) -> None:
+    run = tmp_path / "run"
+    run.mkdir()
+    session = start_dashboard_session(output=run, port=0)
+    assert session.thread.is_alive()
+    session.stop()
+    assert not session.thread.is_alive()
+
+
+def test_live_server_rejects_artifact_path_traversal(tmp_path: Path) -> None:
+    run = tmp_path / "run"
+    run.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret", encoding="utf-8")
+    server, base_url = start_test_server(run)
+    try:
+        try:
+            urlopen(f"{base_url}/artifacts/../outside.txt", timeout=5)
+        except HTTPError as exc:
+            assert exc.code in {403, 404}
+        else:
+            raise AssertionError("path traversal unexpectedly succeeded")
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_live_server_does_not_serve_static_path_traversal(tmp_path: Path) -> None:
+    run = tmp_path / "run"
+    run.mkdir()
+    server, base_url = start_test_server(run)
+    try:
+        try:
+            urlopen(f"{base_url}/static/../server.py", timeout=5)
+        except HTTPError as exc:
+            assert exc.code == 404
+        else:
+            raise AssertionError("static traversal unexpectedly succeeded")
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_static_3dmol_asset_is_served_locally(tmp_path: Path) -> None:
+    run = tmp_path / "run"
+    run.mkdir()
+    server, base_url = start_test_server(run)
+    try:
+        response = urlopen(f"{base_url}/static/3Dmol-min.js", timeout=5)
+        body = response.read().decode("utf-8", errors="ignore")
+    finally:
+        server.shutdown()
+        server.server_close()
+    assert response.headers["Cache-Control"] == "no-store"
+    assert "$3Dmol" in body
+    assert "http://" not in body[:1000]
+    assert "https://" not in body[:1000]
+
+
+def test_live_json_endpoints_are_no_store(tmp_path: Path) -> None:
+    run = tmp_path / "run"
+    writer = TelemetryWriter(run / "simulation")
+    writer.write_status(stage="production")
+    server, base_url = start_test_server(run)
+    try:
+        for endpoint in (
+            "status", "metrics", "events", "artifacts", "results", "files",
+            "protein-preview", "structure-info", "ligands",
+            "live-frame-index", "live-coordinates", "playback-info",
+            "analyses",
+        ):
+            response = urlopen(f"{base_url}/api/{endpoint}", timeout=5)
+            response.read()
+            assert response.headers["Cache-Control"] == "no-store", endpoint
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_live_json_endpoints_are_sane_for_empty_run(tmp_path: Path) -> None:
+    run = tmp_path / "empty_run"
+    server, base_url = start_test_server(run)
+    try:
+        status_payload = json.loads(urlopen(f"{base_url}/api/status", timeout=5).read())
+        metrics_payload = json.loads(urlopen(f"{base_url}/api/metrics", timeout=5).read())
+        events_payload = json.loads(urlopen(f"{base_url}/api/events", timeout=5).read())
+        artifacts_payload = json.loads(urlopen(f"{base_url}/api/artifacts", timeout=5).read())
+        results_payload = json.loads(urlopen(f"{base_url}/api/results", timeout=5).read())
+        structure_payload = json.loads(urlopen(f"{base_url}/api/structure-info", timeout=5).read())
+        ligands_payload = json.loads(urlopen(f"{base_url}/api/ligands", timeout=5).read())
+    finally:
+        server.shutdown()
+        server.server_close()
+    assert status_payload["status"] == {}
+    assert status_payload["health"]["state"] == "unknown"
+    assert metrics_payload["metrics"] == []
+    assert events_payload["events"] == []
+    assert artifacts_payload["artifacts"] == []
+    assert results_payload["has_analysis"] is False
+    assert results_payload["has_report"] is False
+    assert results_payload["plots"] == []
+    assert structure_payload["valid"] is False
+    assert ligands_payload["valid"] is False
+
+
+def test_aai_logo_assets_are_packaged(tmp_path: Path) -> None:
+    import fastmdxplora.live as live_pkg
+    static = Path(live_pkg.__file__).with_name("static")
+    assert (static / "aai-research-logo.svg").is_file()
+    assert (static / "aai-research-mark.svg").is_file()
+    assert (static / "dashboard.css").is_file()
+    assert (static / "dashboard.js").is_file()
+    assert (static / "charts.js").is_file()
+    assert (static / "molecule-viewer.js").is_file()
+
+
+def test_static_logo_endpoint_serves_svg(tmp_path: Path) -> None:
+    run = tmp_path / "run"
+    run.mkdir()
+    server, base_url = start_test_server(run)
+    try:
+        response = urlopen(f"{base_url}/static/aai-research-logo.svg", timeout=5)
+        body = response.read().decode("utf-8", errors="ignore")
+    finally:
+        server.shutdown()
+        server.server_close()
+    assert response.headers["Content-Type"].startswith("image/svg+xml") or "svg" in body.lower()
+    assert "AAI" in body

--- a/tests/test_plotting_style.py
+++ b/tests/test_plotting_style.py
@@ -60,3 +60,18 @@ def test_save_figure_applies_paper_style_to_colorbar(tmp_path):
 
     assert out.is_file()
     assert cbar.ax.yaxis.label.get_fontsize() == PAPER_LABEL_SIZE
+
+
+def test_save_figure_also_writes_true_vector_svg(tmp_path):
+    fig, ax = new_figure(title="Vector export", xlabel="Time (ns)", ylabel="Value")
+    ax.plot([0.0, 0.5, 1.0], [1.0, 1.5, 1.2])
+
+    png = save_figure(fig, tmp_path / "vector_plot.png")
+    svg = tmp_path / "vector_plot.svg"
+
+    assert png.is_file()
+    assert svg.is_file()
+    text = svg.read_text(encoding="utf-8")
+    assert "<svg" in text
+    assert "Time (ns)" in text
+    assert "Value" in text


### PR DESCRIPTION
Added a dashboard-first FastMDXplora workflow with a new simulation builder.
Added the polished terminal banner and pops us where fastmdx or fastmdxplora is typed into terminal.
Redesigned the dashboard with live telemetry, molecular visualization, trajectory playback, analysis results, and file downloads.
Added publication-ready PNG/SVG figures and improved artifact discovery.
Preserved the existing OpenMM setup, simulation, analysis, and reporting pipeline.

