### PR TITLE
Match FastMDAnalysis hydrogen-bond counting in compatibility mode

### DIFF
--- a/src/fastmdxplora/analysis/hbonds.py
+++ b/src/fastmdxplora/analysis/hbonds.py
@@ -72,6 +72,8 @@ class HBonds(Analysis):
         *,
         method: str = "baker_hubbard",
         freq: float = 0.1,
+        candidate_freq: float | None = None,
+        count_multiplier: int = 1,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -83,7 +85,18 @@ class HBonds(Analysis):
             )
         self.method: str = method
         self.freq: float = float(freq)
-        self.options.update(method=self.method, freq=self.freq)
+        self.candidate_freq: float = (
+            self.freq if candidate_freq is None else float(candidate_freq)
+        )
+        self.count_multiplier: int = int(count_multiplier)
+        if self.count_multiplier < 1:
+            raise ValueError("count_multiplier must be at least 1")
+        self.options.update(
+            method=self.method,
+            freq=self.freq,
+            candidate_freq=self.candidate_freq,
+            count_multiplier=self.count_multiplier,
+        )
 
     def compute(self, traj: md.Trajectory) -> pd.DataFrame:
         """Compute per-frame H-bond counts.
@@ -117,10 +130,13 @@ class HBonds(Analysis):
             # bonds frame by frame using its definitions (an O(n_frames)
             # loop, but MDTraj's vectorized distance/angle is fast).
             bonds = md.baker_hubbard(
-                traj, freq=self.freq, exclude_water=True, periodic=False
+                traj,
+                freq=self.candidate_freq,
+                exclude_water=True,
+                periodic=False,
             )
             self._aggregated_bonds = bonds  # stash for the figure caption
-            counts = _per_frame_baker_hubbard(traj, bonds)
+            counts = self.count_multiplier * _per_frame_baker_hubbard(traj, bonds)
 
         return pd.DataFrame({"frame": np.arange(traj.n_frames), "n_hbonds": counts})
 

--- a/src/fastmdxplora/cli/main.py
+++ b/src/fastmdxplora/cli/main.py
@@ -327,7 +327,15 @@ def _normalize_analysis_options(kwargs: dict[str, Any]) -> dict[str, Any]:
                 "probe_radius": 0.14,
                 "n_sphere_points": 960,
             },
-            "hbonds": {"method": "baker_hubbard", "freq": 0.1},
+            # FastMDAnalysis reports both donor/acceptor directions and
+            # counts transient Baker-Hubbard bonds, rather than filtering
+            # the per-frame series by the occupancy threshold first.
+            "hbonds": {
+                "method": "baker_hubbard",
+                "freq": 0.1,
+                "candidate_freq": 0.0,
+                "count_multiplier": 2,
+            },
             "dimred": {"methods": ["pca"], "n_components": 2},
             "cluster": {"methods": ["hierarchical"], "n_clusters": 6},
         }

--- a/tests/test_cli_flags.py
+++ b/tests/test_cli_flags.py
@@ -259,7 +259,10 @@ class TestAnalysisCompatibility:
             "mode": "total", "probe_radius": 0.14, "n_sphere_points": 960
         }
         assert kwargs["options"]["hbonds"] == {
-            "method": "baker_hubbard", "freq": 0.1
+            "method": "baker_hubbard",
+            "freq": 0.1,
+            "candidate_freq": 0.0,
+            "count_multiplier": 2,
         }
         assert kwargs["options"]["dimred"] == {"methods": ["pca"], "n_components": 2}
         assert kwargs["options"]["cluster"] == {


### PR DESCRIPTION
- Add configurable candidate frequency and count multiplier to H-bond analysis
- Match FastMDAnalysis transient-bond and two-sided counting behavior
- Keep existing FastMDXplora defaults unchanged
- Update the compatibility profile and regression tests