### PR TITLE
Fix state discovery and 2D metadynamics analysis

### DIFF
--- a/src/fastmdxplora/analysis/metad_surface.py
+++ b/src/fastmdxplora/analysis/metad_surface.py
@@ -71,25 +71,72 @@ class MetadynamicsSurface(Analysis):
                 "recompute it."
             )
         record = json.loads(path.read_text(encoding="utf-8"))
-        grid = np.asarray(record.get("grid") or [], dtype=float)
-        energy = np.asarray(
-            [np.nan if value is None else float(value)
-             for value in (record.get("free_energy_kjmol") or [])],
-            dtype=float)
-
         self._refused = record.get("refused")
         self._provisional = bool(record.get("provisional"))
         self._evidence = record.get("evidence") or {}
-        if not len(grid) or not len(energy):
+        dimensions = int(record.get("dimensions") or 1)
+        self._dimensions = dimensions
+
+        if dimensions == 1:
+            grid = np.asarray(record.get("grid") or [], dtype=float)
+            energy = np.asarray(
+                [np.nan if value is None else float(value)
+                 for value in (record.get("free_energy_kjmol") or [])],
+                dtype=float)
+            if len(grid) and len(energy):
+                return {"coordinate": grid, "free_energy_kjmol": energy}
+        elif dimensions == 2:
+            axes = tuple(np.asarray(axis, dtype=float)
+                         for axis in (record.get("axes") or []))
+            energy = np.asarray(
+                record.get("free_energy_kjmol") or [], dtype=float)
+            expected = tuple(len(axis) for axis in axes)
+            if energy.size and (
+                    len(axes) != dimensions or energy.shape != expected):
+                raise ValueError(
+                    "The metadynamics record says it is two-dimensional, "
+                    f"but its axes have lengths {expected} and its free-energy "
+                    f"array has shape {energy.shape}. A surface needs one "
+                    "array dimension per collective-variable axis."
+                )
+            if energy.size and np.isfinite(energy).any():
+                per_dimension = self._evidence.get("per_dimension") or []
+                self._axis_names = tuple(
+                    str(per_dimension[index].get("name", f"cv{index + 1}"))
+                    if index < len(per_dimension) else f"cv{index + 1}"
+                    for index in range(dimensions))
+                return {
+                    "dimensions": dimensions,
+                    "axes": axes,
+                    "axis_names": self._axis_names,
+                    "free_energy_kjmol": energy,
+                }
+        else:
             raise ValueError(
-                "The metadynamics record holds no surface: "
-                + (str(self._refused) if self._refused
-                   else "the coordinate did not move, so there is nothing "
-                        "along it to draw.")
+                f"The metadynamics record has {dimensions} dimensions; this "
+                "analysis can draw one- and two-dimensional surfaces."
             )
-        return {"coordinate": grid, "free_energy_kjmol": energy}
+
+        raise ValueError(
+            "The metadynamics record holds no surface: "
+            + (str(self._refused) if self._refused
+               else "the coordinate did not move, so there is nothing "
+                    "along it to draw.")
+        )
 
     def plot(self, result: dict[str, Any], ax: plt.Axes) -> None:
+        if result.get("dimensions") == 2:
+            first, second = result["axes"]
+            energy = result["free_energy_kjmol"]
+            image = ax.contourf(first, second, energy.T, levels=24)
+            ax.figure.colorbar(image, ax=ax, label="Free energy (kJ/mol)")
+            lowest = np.unravel_index(np.nanargmin(energy), energy.shape)
+            ax.plot(first[lowest[0]], second[lowest[1]], marker="o",
+                    markersize=4, color="white", markeredgecolor="#555555")
+            if self._provisional:
+                ax.set_title(f"{self.figure_title()} (provisional)")
+            return
+
         coordinate = result["coordinate"]
         energy = result["free_energy_kjmol"]
         ax.plot(coordinate, energy, linewidth=1.6)
@@ -118,13 +165,34 @@ class MetadynamicsSurface(Analysis):
             ax.set_title(f"{self.figure_title()} (provisional)")
 
     def default_ylabel(self) -> str:
+        if getattr(self, "_dimensions", 1) == 2:
+            return getattr(self, "_axis_names", ("cv1", "cv2"))[1]
         return "Free energy (kJ/mol)"
 
     def default_xlabel(self) -> str:
+        if getattr(self, "_dimensions", 1) == 2:
+            return getattr(self, "_axis_names", ("cv1", "cv2"))[0]
         return "Collective variable"
 
     def save_data(self, result: dict[str, Any], path: Path) -> Path:
         path.parent.mkdir(parents=True, exist_ok=True)
+        if result.get("dimensions") == 2:
+            first, second = result["axes"]
+            first_name, second_name = result["axis_names"]
+            header = f"# {first_name} {second_name} free_energy_kjmol"
+            if self._provisional:
+                header += ("\n# provisional: the bias had not settled "
+                           "when this was cut")
+            lines = [header]
+            energy = result["free_energy_kjmol"]
+            for i, x in enumerate(first):
+                for j, y in enumerate(second):
+                    value = energy[i, j]
+                    shown = "nan" if np.isnan(value) else f"{value:.6f}"
+                    lines.append(f"{x:.6f} {y:.6f} {shown}")
+            path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+            return path
+
         header = "# coordinate free_energy_kjmol"
         if self._provisional:
             header += "\n# provisional: the bias had not settled when this was cut"

--- a/src/fastmdxplora/analysis/orchestrator.py
+++ b/src/fastmdxplora/analysis/orchestrator.py
@@ -571,6 +571,7 @@ class AnalysisOrchestrator:
             here = Path(getattr(self, "output_dir", ".") or ".")
             for parent in (here, here.parent, here.parent.parent):
                 for candidate in (
+                    parent / "simulation" / "energy.csv",
                     parent / "simulation" / "state_data.csv",
                     parent / "state_data.csv",
                     parent / "simulation" / "production_state.csv",

--- a/src/fastmdxplora/analysis/reweighted_averages.py
+++ b/src/fastmdxplora/analysis/reweighted_averages.py
@@ -250,7 +250,7 @@ C_OF_T_GRID_POINTS = 320
 
 
 def felt_bias(hills: Any, heights: np.ndarray, *, times: Any, values: Any,
-              periodic: bool) -> np.ndarray:
+              periodic: "bool | tuple[bool, ...]") -> np.ndarray:
     """The bias each frame felt, measured the short way round on a circle.
 
     A frame at -175 degrees is fifteen degrees from a hill at +170, not three
@@ -266,6 +266,25 @@ def felt_bias(hills: Any, heights: np.ndarray, *, times: Any, values: Any,
     generic weighting arithmetic and PLUMED's conventions belong here.
     """
     frames = np.asarray(values, dtype=float)
+    if getattr(hills, "n_dims", 1) > 1:
+        from fastmdxplora.simulation.metad_surface import bias_from_hills_nd
+
+        if frames.ndim != 2 or frames.shape[1] != hills.n_dims:
+            raise ValueError(
+                f"The hills hold {hills.n_dims} biased variables but frame "
+                f"coordinates have shape {frames.shape}."
+            )
+        wrap = tuple(periodic) if not isinstance(periodic, bool) else (
+            (periodic,) * hills.n_dims)
+        frame_times = np.asarray(times, dtype=float)
+        total = np.zeros(frames.shape[0], dtype=float)
+        for index, (when, where) in enumerate(zip(frame_times, frames)):
+            laid = int(np.searchsorted(hills.time_ps, when, side="right"))
+            total[index] = bias_from_hills_nd(
+                hills, where[None, :], heights=heights, upto=laid,
+                periodic=wrap)[0]
+        return total
+
     shifts = (-2.0 * np.pi, 0.0, 2.0 * np.pi) if periodic else (0.0,)
     total = np.zeros(frames.size, dtype=float)
     for shift in shifts:
@@ -276,7 +295,7 @@ def felt_bias(hills: Any, heights: np.ndarray, *, times: Any, values: Any,
 
 
 def c_of_t(hills: Any, times_ps: np.ndarray, temperature_K: float,
-           periodic: bool = False) -> np.ndarray:
+           periodic: "bool | tuple[bool, ...]" = False) -> np.ndarray:
     """The offset that makes a running bias usable for reweighting.
 
     The bias grows as hills accumulate, so exp(V(s,t)/RT) grows with time
@@ -298,6 +317,11 @@ def c_of_t(hills: Any, times_ps: np.ndarray, temperature_K: float,
     and the y -> infinity limit of that, which is the ratio to a flat
     integral, is the form for a run that was not tempered.
     """
+    if getattr(hills, "n_dims", 1) > 1:
+        wrap = tuple(periodic) if not isinstance(periodic, bool) else (
+            (periodic,) * hills.n_dims)
+        return _c_of_t_nd(hills, times_ps, temperature_K, periodic=wrap)
+
     kT = KB_KJ_PER_MOL_K * float(temperature_K)
     order = np.argsort(hills.time_ps)
     hill_times = np.asarray(hills.time_ps, dtype=float)[order]
@@ -361,6 +385,84 @@ def c_of_t(hills: Any, times_ps: np.ndarray, temperature_K: float,
     return np.interp(np.asarray(times_ps, dtype=float), checkpoints, offsets)
 
 
+def _c_of_t_nd(
+    hills: Any,
+    times_ps: np.ndarray,
+    temperature_K: float,
+    *,
+    periodic: tuple[bool, ...],
+) -> np.ndarray:
+    """Multidimensional c(t), integrated on one axis per biased variable."""
+    from fastmdxplora.simulation.metad_surface import Hills, bias_from_hills_nd
+
+    if len(periodic) != hills.n_dims:
+        raise ValueError(
+            f"The hills hold {hills.n_dims} variables but periodicity has "
+            f"{len(periodic)} entries."
+        )
+
+    kT = KB_KJ_PER_MOL_K * float(temperature_K)
+    order = np.argsort(hills.time_ps)
+    ordered = Hills(
+        time_ps=np.asarray(hills.time_ps, dtype=float)[order],
+        centre=np.asarray(hills.centre, dtype=float)[order],
+        sigma=np.asarray(hills.sigma, dtype=float)[order],
+        height=np.asarray(hills.height, dtype=float)[order],
+        bias_factor=float(hills.bias_factor),
+    )
+    heights = deposited_heights(hills)[order]
+
+    # Keep the integration budget bounded as dimensions grow. Forty points
+    # per axis in 2D gives 1,600 integration points; higher-dimensional runs
+    # retain approximately that total with a floor of eight per axis.
+    points_per_axis = max(8, int(round(1600 ** (1.0 / hills.n_dims))))
+    axes: list[np.ndarray] = []
+    for dim in range(hills.n_dims):
+        centres = ordered.column(dim)
+        sigmas = ordered.sigma_column(dim)
+        if periodic[dim]:
+            axes.append(np.linspace(-np.pi, np.pi, points_per_axis))
+        else:
+            span = 3.0 * float(np.max(sigmas))
+            axes.append(np.linspace(float(np.min(centres)) - span,
+                                    float(np.max(centres)) + span,
+                                    points_per_axis))
+    mesh = np.meshgrid(*axes, indexing="ij")
+    points = np.column_stack([axis.ravel() for axis in mesh])
+
+    times = np.asarray(times_ps, dtype=float)
+    checkpoints = np.linspace(
+        float(np.min(times)), float(np.max(times)),
+        min(C_OF_T_CHECKPOINTS, max(2, times.size)))
+    upto = np.searchsorted(ordered.time_ps, checkpoints, side="left")
+
+    factor = float(hills.bias_factor)
+    if factor > 1.0:
+        scale_numerator = factor / (factor - 1.0)
+        scale_denominator = 1.0 / (factor - 1.0)
+    else:
+        scale_numerator, scale_denominator = 1.0, 0.0
+
+    def log_integral(values: np.ndarray) -> float:
+        peak = float(np.max(values))
+        return float(np.log(np.sum(np.exp(values - peak))) + peak)
+
+    bias = np.zeros(points.shape[0], dtype=float)
+    offsets = np.empty(checkpoints.size, dtype=float)
+    cursor = 0
+    for index, stop in enumerate(upto):
+        if stop > cursor:
+            bias += bias_from_hills_nd(
+                ordered, points, heights=heights, start=cursor,
+                upto=int(stop), periodic=periodic)
+            cursor = int(stop)
+        offsets[index] = kT * (
+            log_integral(scale_numerator * bias / kT)
+            - log_integral(scale_denominator * bias / kT))
+
+    return np.interp(times, checkpoints, offsets)
+
+
 # ---------------------------------------------------------------------------
 # The weights for a run
 # ---------------------------------------------------------------------------
@@ -407,13 +509,20 @@ def weights_for_run(
         return None, provenance
 
     colvar = read_colvar(colvar_path)
-    cv_name = next((name for name in colvar
-                    if name not in ("time",) and not name.endswith("bias")),
-                   None)
-    if cv_name is None or "time" not in colvar:
+    cv_names = [name for name in colvar
+                if name != "time" and not name.endswith("bias")]
+    if not cv_names or "time" not in colvar:
         provenance["reason"] = (
             "COLVAR holds no collective variable column, so the frames "
             "cannot be placed on the coordinate the bias acted along.")
+        return None, provenance
+    if len(cv_names) != hills.n_dims:
+        provenance["reason"] = (
+            f"HILLS contains {hills.n_dims} biased variable(s), but COLVAR "
+            f"contains {len(cv_names)} collective-variable column(s) "
+            f"({', '.join(cv_names)}). Reweighting needs exactly one COLVAR "
+            "coordinate for each HILLS dimension."
+        )
         return None, provenance
 
     times = np.asarray(frame_times_ps, dtype=float)
@@ -424,7 +533,11 @@ def weights_for_run(
     # Frames written outside the recorded window would extrapolate; numpy
     # clamps to the end values instead, which is the right behaviour for the
     # one or two frames that can fall outside by a single stride.
-    frame_cv = np.interp(times, colvar["time"], colvar[cv_name])
+    frame_columns = [
+        np.interp(times, colvar["time"], colvar[name])
+        for name in cv_names]
+    frame_cv = (frame_columns[0] if hills.n_dims == 1
+                else np.column_stack(frame_columns))
 
     # A torsion is a circle, and every Gaussian sum below has to measure the
     # separation the short way round: a frame at -175 degrees is 15 degrees
@@ -432,8 +545,16 @@ def weights_for_run(
     # anything is summed, because both the felt bias and the offset need it.
     from fastmdxplora.simulation.umbrella import PERIODIC_VARIABLES
 
-    variable = _configured_cv(output_dir) or cv_name
-    periodic = variable in PERIODIC_VARIABLES
+    if hills.n_dims == 1:
+        variable: Any = _configured_cv(output_dir) or cv_names[0]
+        periodic: Any = variable in PERIODIC_VARIABLES
+    else:
+        from fastmdxplora.simulation.metad_surface import periodic_dimensions
+
+        variable = cv_names
+        script = _find(output_dir, "plumed.dat")
+        periodic = (periodic_dimensions(script, hills.n_dims)
+                    if script is not None else (False,) * hills.n_dims)
 
     heights = deposited_heights(hills)
     felt = felt_bias(
@@ -472,7 +593,9 @@ def weights_for_run(
         ours = felt_bias(
             hills, heights,
             times=before_deposition(hills, colvar["time"]),
-            values=colvar[cv_name], periodic=periodic)
+            values=(colvar[cv_names[0]] if hills.n_dims == 1 else
+                    np.column_stack([colvar[name] for name in cv_names])),
+            periodic=periodic)
         theirs = colvar[bias_column]
         spread = float(np.max(theirs) - np.min(theirs))
         if spread > 0:
@@ -488,7 +611,7 @@ def weights_for_run(
         # name is kept where it can be found, with the label beside it.
         "collective_variable": variable,
         "periodic": periodic,
-        "colvar_column": cv_name,
+        "colvar_column": (cv_names[0] if hills.n_dims == 1 else cv_names),
         "temperature_K": temperature,
         "temperature_from_record": measured,
         "settled": settled,

--- a/src/fastmdxplora/analysis/thermodynamics.py
+++ b/src/fastmdxplora/analysis/thermodynamics.py
@@ -124,6 +124,7 @@ class Thermodynamics(Analysis):
         here = Path(self.output_dir)
         for parent in (here.parent.parent, here.parent, here):
             for candidate in (
+                parent / "simulation" / "energy.csv",
                 parent / "simulation" / "state_data.csv",
                 parent / "state_data.csv",
                 parent / "simulation" / "production_state.csv",

--- a/src/fastmdxplora/simulation/metad_surface.py
+++ b/src/fastmdxplora/simulation/metad_surface.py
@@ -196,6 +196,82 @@ def read_hills(path: str | Path) -> Hills:
     )
 
 
+def periodic_dimensions(
+    script_path: str | Path,
+    n_dims: int,
+) -> tuple[bool, ...]:
+    """Which biased variables are circular, from PLUMED's own definitions."""
+    import re
+
+    path = Path(script_path)
+    text = (path.read_text(encoding="utf-8").upper()
+            if path.is_file() else "")
+    circular = ("TORSION", "ANGLE")
+    if n_dims == 1:
+        return (any(
+            f"{action}\n" in text or f"{action} " in text
+            for action in circular),)
+
+    actions = dict(re.findall(
+        r"^\s*(CV\d+)\s*:\s*(\w+)", text, re.MULTILINE))
+    return tuple(
+        actions.get(f"CV{i + 1}", "") in circular
+        for i in range(n_dims))
+
+
+def bias_from_hills_nd(
+    hills: Hills,
+    points: np.ndarray,
+    *,
+    heights: "np.ndarray | None" = None,
+    start: int = 0,
+    upto: "int | None" = None,
+    periodic: "tuple[bool, ...] | None" = None,
+    chunk: int = 512,
+) -> np.ndarray:
+    """Gaussian bias at N-dimensional points, with per-axis periodicity."""
+    coordinates = np.asarray(points, dtype=float)
+    if coordinates.ndim != 2 or coordinates.shape[1] != hills.n_dims:
+        raise ValueError(
+            f"The hills hold {hills.n_dims} variables and bias points have "
+            f"shape {coordinates.shape}; expected one column per variable."
+        )
+
+    first = max(0, int(start))
+    stop = len(hills) if upto is None else min(len(hills), int(upto))
+    if stop <= first:
+        return np.zeros(coordinates.shape[0], dtype=float)
+
+    wrap = tuple(periodic or (False,) * hills.n_dims)
+    if len(wrap) != hills.n_dims:
+        raise ValueError(
+            f"The hills hold {hills.n_dims} variables but periodicity has "
+            f"{len(wrap)} entries."
+        )
+
+    centres = np.asarray(hills.centre, dtype=float)
+    sigmas = np.asarray(hills.sigma, dtype=float)
+    if centres.ndim == 1:
+        centres = centres[:, None]
+        sigmas = sigmas[:, None]
+    amplitudes = (np.asarray(hills.height, dtype=float)
+                  if heights is None else np.asarray(heights, dtype=float))
+
+    bias = np.zeros(coordinates.shape[0], dtype=float)
+    for block_start in range(first, stop, chunk):
+        block = slice(block_start, min(block_start + chunk, stop))
+        exponent = np.zeros((coordinates.shape[0], centres[block].shape[0]))
+        for dim in range(hills.n_dims):
+            delta = (coordinates[:, dim][:, None]
+                     - centres[block][:, dim][None, :])
+            if wrap[dim]:
+                delta = (delta + np.pi) % (2.0 * np.pi) - np.pi
+            exponent += (
+                delta ** 2 / (2.0 * sigmas[block][:, dim][None, :] ** 2))
+        bias += (amplitudes[block][None, :] * np.exp(-exponent)).sum(axis=1)
+    return bias
+
+
 def surface_from_hills(
     hills: Hills, grid: np.ndarray, *, upto: int | None = None,
     periodic: bool = False,
@@ -353,30 +429,11 @@ def surface_from_hills_nd(
             f"The hills hold {n_dims} variables and {len(axes)} axes were "
             "given. A surface needs one axis per biased variable."
         )
-    wrap = tuple(periodic or (False,) * n_dims)
-
     mesh = np.meshgrid(*axes, indexing="ij")
     shape = mesh[0].shape
     points = np.column_stack([m.ravel() for m in mesh])
-
-    bias = np.zeros(points.shape[0], dtype=float)
-    centres = hills.centre[:stop]
-    sigmas = hills.sigma[:stop]
-    heights = hills.height[:stop]
-    if centres.ndim == 1:
-        centres = centres[:, None]
-        sigmas = sigmas[:, None]
-
-    for start in range(0, stop, chunk):
-        block = slice(start, min(start + chunk, stop))
-        exponent = np.zeros((points.shape[0], centres[block].shape[0]))
-        for dim in range(n_dims):
-            delta = points[:, dim][:, None] - centres[block][:, dim][None, :]
-            if wrap[dim]:
-                # The short way round, as in one dimension.
-                delta = (delta + np.pi) % (2.0 * np.pi) - np.pi
-            exponent += (delta ** 2) / (2.0 * sigmas[block][:, dim][None, :] ** 2)
-        bias += (heights[block][None, :] * np.exp(-exponent)).sum(axis=1)
+    bias = bias_from_hills_nd(
+        hills, points, upto=stop, periodic=periodic, chunk=chunk)
 
     if hills.bias_factor > 1.0:
         free = -bias * (hills.bias_factor / (hills.bias_factor - 1.0))

--- a/src/fastmdxplora/simulation/pipeline.py
+++ b/src/fastmdxplora/simulation/pipeline.py
@@ -200,7 +200,7 @@ def _write_metadynamics_surface(output_dir: Path, presenter: Any) -> str | None:
     import numpy as np
 
     from fastmdxplora.simulation.metad_surface import (
-        compute_surface, compute_surface_2d, read_hills)
+        compute_surface, compute_surface_2d, periodic_dimensions, read_hills)
 
     hills = output_dir / "HILLS"
     if not hills.is_file():
@@ -232,26 +232,14 @@ def _write_metadynamics_surface(output_dir: Path, presenter: Any) -> str | None:
         # and it sits beside the hills it produced. Without this the barrier
         # came out at 60.7 kJ/mol on a run whose periodic value was 30.
         script = output_dir / "plumed.dat"
-        text = (script.read_text(encoding="utf-8").upper()
-                if script.is_file() else "")
-        circular = ("TORSION", "ANGLE")
+        per_dim = periodic_dimensions(script, n_dims)
         if n_dims == 1:
-            periodic = any(
-                f"{action}\n" in text or f"{action} " in text
-                for action in circular)
-            outcome = compute_surface(hills, sampled, periodic=periodic)
+            outcome = compute_surface(hills, sampled, periodic=per_dim[0])
         else:
             # Per variable, from its own definition line. A run biasing a
             # torsion against a distance is periodic in one and not the
             # other, and a single flag for both wraps the distance around
             # a circle it does not live on.
-            import re
-
-            actions = dict(re.findall(
-                r"^\s*(CV\d+)\s*:\s*(\w+)", text, re.MULTILINE))
-            per_dim = tuple(
-                actions.get(f"CV{i + 1}", "") in circular
-                for i in range(n_dims))
             names = tuple(f"cv{i + 1}" for i in range(n_dims))
             outcome = compute_surface_2d(
                 hills, sampled, periodic=per_dim, names=names)

--- a/tests/test_metad_surface_analysis.py
+++ b/tests/test_metad_surface_analysis.py
@@ -31,7 +31,42 @@ def _record(run: Path, *, provisional=False, refused=None, empty=False) -> Path:
     return run
 
 
+def _record_2d(run: Path) -> Path:
+    (run / "simulation").mkdir(parents=True, exist_ok=True)
+    first = np.linspace(-np.pi, np.pi, 8)
+    second = np.linspace(-np.pi, np.pi, 6)
+    energy = ((1.0 - np.cos(first[:, None]))
+              + 2.0 * (1.0 - np.cos(second[None, :])))
+    record = {
+        "refused": None,
+        "provisional": False,
+        "evidence": {
+            "per_dimension": [
+                {"name": "cv1", "periodic": True},
+                {"name": "cv2", "periodic": True},
+            ],
+        },
+        "dimensions": 2,
+        "grid": None,
+        "axes": [first.tolist(), second.tolist()],
+        "free_energy_kjmol": energy.tolist(),
+    }
+    (run / "simulation" / "metadynamics_surface.json").write_text(
+        json.dumps(record), encoding="utf-8")
+    return run
+
+
 class TestItDrawsWhatTheRunComputed:
+    def test_the_one_dimensional_result_keeps_its_existing_shape(
+            self, tmp_path) -> None:
+        _record(tmp_path)
+        analysis = MetadynamicsSurface(output_dir=tmp_path / "analysis")
+
+        result = analysis.compute(None)
+
+        assert set(result) == {"coordinate", "free_energy_kjmol"}
+        assert result["coordinate"].shape == result["free_energy_kjmol"].shape
+
     def test_a_settled_surface_is_drawn(self, tmp_path) -> None:
         _record(tmp_path)
         result = MetadynamicsSurface(output_dir=tmp_path / "analysis").run(None)
@@ -59,6 +94,34 @@ class TestItDrawsWhatTheRunComputed:
         with pytest.raises(FileNotFoundError) as caught:
             analysis.compute(None)
         assert "metadynamics" in str(caught.value)
+
+
+class TestATwoDimensionalSurfaceKeepsBothCoordinates:
+    def test_grid_may_be_null_when_axes_describe_the_surface(
+            self, tmp_path) -> None:
+        _record_2d(tmp_path)
+        analysis = MetadynamicsSurface(output_dir=tmp_path / "analysis")
+
+        result = analysis.compute(None)
+
+        assert result["dimensions"] == 2
+        assert tuple(len(axis) for axis in result["axes"]) == (8, 6)
+        assert result["free_energy_kjmol"].shape == (8, 6)
+
+    def test_plotting_and_export_use_both_cv_axes(self, tmp_path) -> None:
+        _record_2d(tmp_path)
+        analysis = MetadynamicsSurface(output_dir=tmp_path / "analysis")
+
+        completed = analysis.run(None)
+
+        assert completed.status == "ok"
+        assert completed.figure_path.is_file()
+        lines = completed.data_path.read_text(encoding="utf-8").splitlines()
+        assert lines[0] == "# cv1 cv2 free_energy_kjmol"
+        values = np.loadtxt(completed.data_path)
+        assert values.shape == (8 * 6, 3)
+        assert len(np.unique(values[:, 0])) == 8
+        assert len(np.unique(values[:, 1])) == 6
 
 
 class TestAProvisionalSurfaceIsStillDrawn:

--- a/tests/test_reweighted_averages.py
+++ b/tests/test_reweighted_averages.py
@@ -97,6 +97,67 @@ def _bias_from_hills(hill_times, centres, sigma, height, at_times, at_values):
     return out
 
 
+def _write_2d_run(directory: Path, *, colvar_dimensions: int = 2) -> Path:
+    """Two periodic torsions with hills and COLVAR in PLUMED's real layout."""
+    simulation = directory / "simulation"
+    simulation.mkdir(parents=True, exist_ok=True)
+    times = np.arange(1.0, 31.0)
+    centres = np.column_stack([
+        np.where((times % 2) == 0, np.pi - 0.08, -np.pi + 0.08),
+        np.where((times % 3) == 0, np.pi - 0.12, -np.pi + 0.12),
+    ])
+    sigmas = np.array([0.20, 0.25])
+    deposited = 0.6
+    bias_factor = 10.0
+    stored = deposited * bias_factor / (bias_factor - 1.0)
+    simulation.joinpath("HILLS").write_text(
+        "#! FIELDS time cv1 cv2 sigma_cv1 sigma_cv2 height biasf\n"
+        + "\n".join(
+            f"{time:.4f} {where[0]:.8f} {where[1]:.8f} "
+            f"{sigmas[0]:.4f} {sigmas[1]:.4f} {stored:.8f} {bias_factor:g}"
+            for time, where in zip(times, centres))
+        + "\n", encoding="utf-8")
+
+    colvar_times = np.arange(0.5, 30.5, 0.5)
+    values = np.column_stack([
+        np.where((np.arange(colvar_times.size) % 2) == 0,
+                 np.pi - 0.04, -np.pi + 0.04),
+        np.where((np.arange(colvar_times.size) % 3) == 0,
+                 np.pi - 0.06, -np.pi + 0.06),
+    ])
+    reference = np.zeros(colvar_times.size)
+    for index, (when, where) in enumerate(zip(colvar_times, values)):
+        laid = times < when
+        delta = where[None, :] - centres[laid]
+        delta = (delta + np.pi) % (2.0 * np.pi) - np.pi
+        reference[index] = np.sum(
+            deposited * np.exp(-0.5 * np.sum(
+                (delta / sigmas[None, :]) ** 2, axis=1)))
+
+    fields = "time cv1 cv2 metad.bias" if colvar_dimensions == 2 \
+        else "time cv1 metad.bias"
+    rows = []
+    for time, where, bias in zip(colvar_times, values, reference):
+        coordinates = (f"{where[0]:.8f} {where[1]:.8f}"
+                       if colvar_dimensions == 2 else f"{where[0]:.8f}")
+        rows.append(f"{time:.4f} {coordinates} {bias:.8f}")
+    simulation.joinpath("COLVAR").write_text(
+        f"#! FIELDS {fields}\n" + "\n".join(rows) + "\n",
+        encoding="utf-8")
+    simulation.joinpath("plumed.dat").write_text(
+        "cv1: TORSION ATOMS=1,2,3,4\n"
+        "cv2: TORSION ATOMS=5,6,7,8\n"
+        "metad: METAD ARG=cv1,cv2 SIGMA=0.20,0.25 FILE=HILLS\n",
+        encoding="utf-8")
+    simulation.joinpath("metadynamics_surface.json").write_text(
+        json.dumps({"provisional": False}), encoding="utf-8")
+    simulation.joinpath("simulation_parameters.json").write_text(
+        json.dumps({"temperature_K": 300.0}), encoding="utf-8")
+    analysis = directory / "analysis"
+    analysis.mkdir(parents=True, exist_ok=True)
+    return analysis
+
+
 class _Result:
     """Stands in for an AnalysisResult."""
 
@@ -134,6 +195,33 @@ class TestItReadsWhatPlumedWrote:
         # A real run should sit far below the 0.01 this is checked
         # against elsewhere; 11% is what a convention error looks like.
         assert provenance["largest_disagreement_with_plumed"] < 1e-5
+
+
+class TestMultidimensionalMetadynamics:
+    def test_two_colvar_coordinates_are_interpolated_and_weighted(
+            self, tmp_path: Path) -> None:
+        analysis = _write_2d_run(tmp_path)
+
+        weights, provenance = weights_for_run(
+            analysis, np.linspace(1.0, 30.0, 20))
+
+        assert weights is not None
+        assert weights.values.shape == (20,)
+        assert np.all(np.isfinite(weights.values))
+        assert provenance["colvar_column"] == ["cv1", "cv2"]
+        assert provenance["periodic"] == (True, True)
+        assert provenance["largest_disagreement_with_plumed"] < 1e-6
+
+    def test_hills_and_colvar_dimensions_must_match(
+            self, tmp_path: Path) -> None:
+        analysis = _write_2d_run(tmp_path, colvar_dimensions=1)
+
+        weights, provenance = weights_for_run(
+            analysis, np.linspace(1.0, 30.0, 20))
+
+        assert weights is None
+        assert "HILLS contains 2 biased variable" in provenance["reason"]
+        assert "COLVAR contains 1 collective-variable" in provenance["reason"]
 
 
 class TestAnUnbiasedRunIsLeftAlone:

--- a/tests/test_thermodynamics.py
+++ b/tests/test_thermodynamics.py
@@ -158,13 +158,44 @@ class TestTheOutputsItWrites:
         assert ax.texts
         plt.close("all")
 
-    def test_it_discovers_the_record_beside_a_run(self, tmp_path):
+    def test_it_discovers_the_record_the_runner_writes(self, tmp_path):
         """The path that fails on a cluster, where nothing is where the
         laptop put it."""
         run = tmp_path / "run"
         (run / "simulation").mkdir(parents=True)
-        _state(run / "simulation")
+        state = _state(run / "simulation").rename(
+            run / "simulation" / "energy.csv")
         analysis = Thermodynamics()
         analysis.output_dir = run / "analysis" / "thermodynamics"
         analysis.output_dir.mkdir(parents=True)
-        assert analysis._state_path() is not None
+        analysis.compute(None)
+
+        assert analysis.findings["thermodynamics"]["source"] == str(state)
+
+    @pytest.mark.parametrize("relative_path", [
+        Path("simulation/state_data.csv"),
+        Path("state_data.csv"),
+        Path("simulation/production_state.csv"),
+    ])
+    def test_it_retains_legacy_record_names(self, tmp_path, relative_path):
+        run = tmp_path / "run"
+        state = run / relative_path
+        state.parent.mkdir(parents=True, exist_ok=True)
+        _state(state.parent).rename(state)
+        analysis = Thermodynamics()
+        analysis.output_dir = run / "analysis" / "thermodynamics"
+        analysis.output_dir.mkdir(parents=True)
+
+        assert analysis._state_path() == state
+
+    def test_an_explicit_record_takes_precedence(self, tmp_path):
+        run = tmp_path / "run"
+        (run / "simulation").mkdir(parents=True)
+        _state(run / "simulation").rename(run / "simulation" / "energy.csv")
+        (tmp_path / "explicit").mkdir()
+        explicit = _state(tmp_path / "explicit")
+        analysis = Thermodynamics(state_csv=str(explicit))
+        analysis.output_dir = run / "analysis" / "thermodynamics"
+        analysis.output_dir.mkdir(parents=True)
+
+        assert analysis._state_path() == explicit


### PR DESCRIPTION
## Summary
- discover FastMDX-generated simulation/energy.csv in thermodynamics while preserving explicit state_csv and legacy filenames
- add true 2D metadynamics surface analysis from axes/free_energy_kjmol records, including contour plotting and dimensional data export
- make metadynamics reweighting dimension-aware by interpolating all biased COLVAR CVs, sharing simulation-layer periodic handling, and reporting explicit HILLS/COLVAR dimensionality mismatches

## Validation
- PYTHONPATH=/tmp/fastmdx-test-deps:src MPLCONFIGDIR=/tmp/fastmdx-matplotlib /home/victory/miniforge3/envs/xplora/bin/python -m pytest -q tests/test_metad_surface.py tests/test_metad_surface_analysis.py tests/test_metadynamics.py tests/test_reweight.py tests/test_reweighted_averages.py tests/test_report_reweighted.py
- PYTHONPATH=/tmp/fastmdx-test-deps:src MPLCONFIGDIR=/tmp/fastmdx-matplotlib /home/victory/miniforge3/envs/xplora/bin/python -m pytest -q tests/test_analyses_do_not_disturb_each_other.py tests/test_analysis_layer.py tests/test_analysis_scope.py tests/test_concrete_analyses.py tests/test_sub3_analyses.py
- PYTHONPATH=/tmp/fastmdx-test-deps:src /home/victory/miniforge3/envs/xplora/bin/python -m compileall -q src/fastmdxplora/analysis/metad_surface.py src/fastmdxplora/analysis/reweighted_averages.py src/fastmdxplora/simulation/metad_surface.py src/fastmdxplora/simulation/pipeline.py
- git diff --check