### PR TITLE
fix(validation): make ligand contact comparison trustworthy

### DIFF
--- a/src/fastmdxplora/analysis/analyze.py
+++ b/src/fastmdxplora/analysis/analyze.py
@@ -45,6 +45,7 @@ def run(
     output_dir: Path,
     trajectory: str | None = None,
     topology: str | None = None,
+    ligand_resname: str | None = None,
     include: list[str] | None = None,
     exclude: list[str] | None = None,
     options: dict[str, dict[str, Any]] | None = None,
@@ -112,7 +113,9 @@ def run(
     # Detect a ligand from the setup manifest so scope-based selections can
     # include it (solute = protein + ligand) and so ligand-specific analyses
     # know the residue name. Absent or unreadable manifest -> no ligand.
-    ligand_resname = _detect_ligand_resname(project_root)
+    resolved_ligand_resname = (
+        ligand_resname or _detect_ligand_resname(project_root)
+    )
 
     ao = AnalysisOrchestrator(
         trajectory=str(traj_path),
@@ -120,7 +123,7 @@ def run(
         output_dir=output_dir,
         selection=selection,
         scope=scope,
-        ligand_resname=ligand_resname,
+        ligand_resname=resolved_ligand_resname,
         stride=stride,
         first=first,
         last=last,

--- a/src/fastmdxplora/cli/main.py
+++ b/src/fastmdxplora/cli/main.py
@@ -155,6 +155,8 @@ _ANALYSIS_OPTIONS: list[tuple[str, str, dict[str, Any]]] = [
         "help": "Trajectory file (default: simulation/production.dcd)."}),
     ("topology", "topology", {"type": str, "metavar": "PATH",
         "help": "Topology file (default: simulation/topology.pdb)."}),
+    ("ligand-resname", "ligand_resname", {"type": str, "metavar": "NAME",
+        "help": "Ligand residue name for ligand-aware analyses."}),
     ("analyses", "include", {"nargs": "+", "metavar": "NAME",
         "help": "Subset of analyses to run (e.g. rmsd rmsf rg). Default: all."}),
     ("exclude-analyses", "exclude", {"nargs": "+", "metavar": "NAME",

--- a/src/fastmdxplora/validation/cross_tool.py
+++ b/src/fastmdxplora/validation/cross_tool.py
@@ -122,7 +122,9 @@ def our_kind_family(kind: str) -> str | None:
 # threshold is pinned as a test. CONFIRM these against that file before
 # trusting a harmonized run; they are parameters to ProLIF's classes.
 HARMONIZED_PARAMETERS = {
-    "Hydrophobic": {"distance": 4.5},
+    # FastMDXplora's native hydrophobic rule is 0.40 nm (4.0 A). Keep the
+    # independent tool on the same geometric cutoff for the judged table.
+    "Hydrophobic": {"distance": 4.0},
     "Cationic": {"distance": 4.5},
     "Anionic": {"distance": 4.5},
 }
@@ -225,7 +227,7 @@ def trajectory_and_topology(run_dir: Path, manifest: dict) -> tuple[Path, Path]:
     return traj, top
 
 
-def ligand_resname(run_dir: Path) -> str:
+def _configured_ligand_resname(run_dir: Path) -> str | None:
     cfg = run_dir / "resolved_config.yml"
     if cfg.exists():
         import yaml
@@ -233,7 +235,46 @@ def ligand_resname(run_dir: Path) -> str:
         name = (data.get("setup") or {}).get("ligand_name")
         if name:
             return name
+
+    return None
+
+
+def ligand_resname(run_dir: Path) -> str:
+    name = _configured_ligand_resname(run_dir)
+    if name:
+        return name
     sys.exit("ligand_name not found in resolved_config.yml; pass --ligand")
+
+
+def topology_has_resname(topology: Path, resname: str) -> bool:
+    """Return whether a PDB topology contains the requested residue name."""
+    target = str(resname).upper()
+    for line in topology.read_text(errors="replace").splitlines():
+        if line.startswith(("ATOM  ", "HETATM")):
+            if line[17:20].strip().upper() == target:
+                return True
+    return False
+
+
+def unmeasured_interaction_families(run_dir: Path) -> set[str]:
+    """Read interaction kinds that native analysis explicitly refused.
+
+    A refused kind is not a zero-occupancy measurement. It must be excluded
+    from a cross-tool numeric comparison until both tools measure the same
+    claim.
+    """
+    options = run_dir / "analysis" / "pl_interactions" / "options.json"
+    if not options.is_file():
+        return set()
+    try:
+        data = json.loads(options.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return set()
+    refused = ((data.get("findings") or {}).get("not_measured") or {})
+    families = set()
+    for kind in refused:
+        families.add(our_kind_family(kind) or str(kind))
+    return families
 
 
 def healed_trajectory(run_dir: Path, traj: Path, top: Path) -> Path:  # pragma: no cover - needs ProLIF/MDAnalysis and a finished run
@@ -259,6 +300,29 @@ def healed_trajectory(run_dir: Path, traj: Path, top: Path) -> Path:  # pragma: 
     return healed
 
 
+class _ReimageLigand:
+    """Move the ligand to the protein's triclinic minimum-image copy."""
+
+    def __init__(self, ligand, protein):
+        self.ligand = ligand
+        self.protein = protein
+
+    def __call__(self, ts):
+        import numpy as np
+        from MDAnalysis.lib.mdamath import triclinic_vectors
+
+        vectors = triclinic_vectors(ts.dimensions)
+        if not np.any(vectors):
+            return ts
+        ligand_center = self.ligand.positions.mean(axis=0)
+        protein_center = self.protein.positions.mean(axis=0)
+        delta = ligand_center - protein_center
+        fractional = np.linalg.solve(vectors.T, delta)
+        minimum_image = (fractional - np.rint(fractional)) @ vectors
+        self.ligand.positions += minimum_image - delta
+        return ts
+
+
 def prolif_occupancy(traj: Path, top: Path, resname: str,
                      harmonized: bool) -> dict[tuple[str, str], float]:  # pragma: no cover - needs ProLIF/MDAnalysis and a finished run
     mda, plf = _reference_tools()
@@ -280,6 +344,11 @@ def prolif_occupancy(traj: Path, top: Path, resname: str,
         lig.guess_bonds()
     if len(lig) == 0:
         sys.exit(f"no atoms with resname {resname} in the topology")
+    # Molecule healing makes each molecule whole, but it does not guarantee
+    # that the ligand and protein are in the same periodic image. Native
+    # FastMDXplora distances use the minimum image; apply the same triclinic
+    # reimaging before ProLIF sees the AtomGroups.
+    u.trajectory.add_transformations(_ReimageLigand(lig, prot))
     kinds = sorted(set(PROLIF_TO_FAMILY))
     params = HARMONIZED_PARAMETERS if harmonized else {}
     fp = plf.Fingerprint(
@@ -477,11 +546,17 @@ def cmd_interactions(args):  # pragma: no cover - needs ProLIF/MDAnalysis and a 
     traj = healed_trajectory(run_dir, traj, top)
     resname = args.ligand or ligand_resname(run_dir)
     ours = our_occupancy(run_dir, manifest)
+    excluded = unmeasured_interaction_families(run_dir)
+    if excluded:
+        print("[excluded] native interaction families not measured: "
+              f"{', '.join(sorted(excluded))}")
     for harmonized in ((True, False) if args.both else (args.harmonized,)):
         ref = prolif_occupancy(traj, top, resname, harmonized)
         label = "harmonized" if harmonized else "defaults"
         rows, worst = [], 0.0
         for key in sorted(set(ours) | set(ref)):
+            if key[1] in excluded:
+                continue
             got = ours.get(key, (0.0, 0.0))
             a_lo, a_hi = got if isinstance(got, tuple) else (got, got)
             b = ref.get(key, 0.0)
@@ -607,10 +682,32 @@ def cmd_negative(args):  # pragma: no cover - needs ProLIF/MDAnalysis and a fini
     run_dir = Path(args.run_dir)
     manifest = load_manifest(run_dir)
     cavity = {c.strip() for c in args.cavity.split(",")}
-    ours = our_occupancy(run_dir, manifest)
     traj, top = trajectory_and_topology(run_dir, manifest)
+    resname = args.ligand or _configured_ligand_resname(run_dir)
+    if not resname:
+        sys.exit("ligand_name not found in resolved_config.yml; pass --ligand")
+
+    # An explicitly ligand-free negative control has no valid native
+    # pl_interactions table and cannot be sent through the ligand-contact
+    # comparison path. Its preregistered claim is that the ligand was removed;
+    # verify that claim directly from the topology instead of manufacturing a
+    # zero interaction table.
+    if not topology_has_resname(top, resname):
+        evidence = run_dir / "benchmark_negative_control.json"
+        evidence.write_text(json.dumps({
+            "ligand_resname": resname,
+            "present_in_topology": False,
+            "cavity_residues": sorted(cavity, key=int),
+            "status": "ligand-free control verified",
+        }, indent=2) + "\n", encoding="utf-8")
+        print(f"[control] no {resname} residue in trajectory topology")
+        print(f"[written] {evidence}")
+        print("[verdict] negative control holds by explicit ligand removal; "
+              "ligand-contact occupancy is not applicable")
+        return
+
+    ours = our_occupancy(run_dir, manifest)
     traj = healed_trajectory(run_dir, traj, top)
-    resname = args.ligand or ligand_resname(run_dir)
     ref = prolif_occupancy(traj, top, resname, harmonized=True)
     bad = []
     # Ours is judged on the FLOOR: the measured max-pair occupancy. The

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -81,6 +81,15 @@ def test_cli_help_subprocess() -> None:
     assert "report" in result.stdout
 
 
+def test_cli_analyze_accepts_explicit_ligand_resname() -> None:
+    from fastmdxplora.cli.main import _build_parser
+
+    args = _build_parser().parse_args([
+        "analyze", "--system", "3PTB", "--ligand-resname", "BEN",
+    ])
+    assert args.ligand_resname == "BEN"
+
+
 def test_cli_no_args_starts_dashboard_home() -> None:
     cli_main_module = sys.modules["fastmdxplora.cli.main"]
     with patch.object(cli_main_module, "_cmd_dashboard_home", return_value=0) as home:

--- a/tests/test_cross_tool_helpers.py
+++ b/tests/test_cross_tool_helpers.py
@@ -17,13 +17,16 @@ from pathlib import Path
 import pytest
 
 from fastmdxplora.validation.cross_tool import (
+    HARMONIZED_PARAMETERS,
     _numeric_column,
     _occupancy_from_csv,
     find_artifact,
     load_manifest,
     our_kind_family,
+    topology_has_resname,
     residue_label,
     trajectory_and_topology,
+    unmeasured_interaction_families,
 )
 
 
@@ -58,6 +61,32 @@ class TestJoiningTwoToolsTables:
         """
         assert our_kind_family("water_bridge") is None
         assert our_kind_family("something novel") is None
+
+    def test_harmonized_hydrophobic_cutoff_matches_native_rule(self):
+        assert HARMONIZED_PARAMETERS["Hydrophobic"]["distance"] == pytest.approx(4.0)
+
+    def test_native_not_measured_families_are_read_from_options(self, tmp_path):
+        adir = tmp_path / "analysis" / "pl_interactions"
+        adir.mkdir(parents=True)
+        (adir / "options.json").write_text(json.dumps({
+            "findings": {
+                "not_measured": {
+                    "salt_bridge": "charge ambiguous",
+                    "pi_cation": "charge ambiguous",
+                }
+            }
+        }), encoding="utf-8")
+        assert unmeasured_interaction_families(tmp_path) == {
+            "salt_bridge", "pi_cation"
+        }
+
+    def test_topology_residue_presence_can_prove_ligand_removal(self, tmp_path):
+        top = tmp_path / "trajectory_topology.pdb"
+        top.write_text(
+            "ATOM      1  CA  ALA A   1       0.000   0.000   0.000\nEND\n",
+            encoding="utf-8",
+        )
+        assert not topology_has_resname(top, "BNZ")
 
 
 class TestFindingArtifactsAfterTheFerry:

--- a/tests/test_cross_tool_helpers.py
+++ b/tests/test_cross_tool_helpers.py
@@ -80,6 +80,13 @@ class TestJoiningTwoToolsTables:
             "salt_bridge", "pi_cation"
         }
 
+    def test_missing_or_malformed_options_are_not_measurements(self, tmp_path):
+        assert unmeasured_interaction_families(tmp_path) == set()
+        adir = tmp_path / "analysis" / "pl_interactions"
+        adir.mkdir(parents=True)
+        (adir / "options.json").write_text("{not-json", encoding="utf-8")
+        assert unmeasured_interaction_families(tmp_path) == set()
+
     def test_topology_residue_presence_can_prove_ligand_removal(self, tmp_path):
         top = tmp_path / "trajectory_topology.pdb"
         top.write_text(
@@ -87,6 +94,56 @@ class TestJoiningTwoToolsTables:
             encoding="utf-8",
         )
         assert not topology_has_resname(top, "BNZ")
+
+        top.write_text(
+            "HETATM    1  C1  BNZ A   1       0.000   0.000   0.000\nEND\n",
+            encoding="utf-8",
+        )
+        assert topology_has_resname(top, "bnz")
+
+
+class TestPeriodicLigandReimaging:
+    @staticmethod
+    def _stub_mdanalysis(monkeypatch):
+        import sys
+        import types
+
+        import numpy as np
+
+        mda = types.ModuleType("MDAnalysis")
+        lib = types.ModuleType("MDAnalysis.lib")
+        math = types.ModuleType("MDAnalysis.lib.mdamath")
+        math.triclinic_vectors = lambda dimensions: np.diag(dimensions[:3])
+        monkeypatch.setitem(sys.modules, "MDAnalysis", mda)
+        monkeypatch.setitem(sys.modules, "MDAnalysis.lib", lib)
+        monkeypatch.setitem(sys.modules, "MDAnalysis.lib.mdamath", math)
+
+    def test_zero_box_is_a_no_op(self, monkeypatch):
+        self._stub_mdanalysis(monkeypatch)
+        import numpy as np
+
+        from fastmdxplora.validation.cross_tool import _ReimageLigand
+
+        ligand = type("Atoms", (), {"positions": np.array([[9.0, 0.0, 0.0]])})()
+        protein = type("Atoms", (), {"positions": np.array([[1.0, 0.0, 0.0]])})()
+        ts = type("Timestep", (), {"dimensions": np.zeros(6)})()
+        before = ligand.positions.copy()
+        assert _ReimageLigand(ligand, protein)(ts) is ts
+        assert np.array_equal(ligand.positions, before)
+
+    def test_ligand_moves_to_the_triclinic_minimum_image(self, monkeypatch):
+        self._stub_mdanalysis(monkeypatch)
+        import numpy as np
+
+        from fastmdxplora.validation.cross_tool import _ReimageLigand
+
+        ligand = type("Atoms", (), {"positions": np.array([[9.0, 0.0, 0.0]])})()
+        protein = type("Atoms", (), {"positions": np.array([[1.0, 0.0, 0.0]])})()
+        ts = type("Timestep", (), {
+            "dimensions": np.array([10.0, 10.0, 10.0, 90.0, 90.0, 90.0])
+        })()
+        _ReimageLigand(ligand, protein)(ts)
+        assert ligand.positions[0, 0] == pytest.approx(-1.0)
 
 
 class TestFindingArtifactsAfterTheFerry:


### PR DESCRIPTION
## Summary
- forward explicit ligand residue names through the analysis CLI
- align the ProLIF hydrophobic cutoff with the native 4.0 A rule
- exclude native interaction families explicitly recorded as not measured
- reimage ligands into the protein minimum-image copy before ProLIF
- support ligand-free negative controls without fabricating an interaction table
- ignore local `.hermes/` validation artifacts

## Tests
- `env -u PYTHONPATH -u PYTHONHOME .venv/bin/pytest -q` — 3040 passed, 82 skipped, 105 deselected
- affected clean-branch suite — 139 passed, 1 skipped

## Scope
This PR contains code/tests only. Validation reports, run outputs, and local configuration remain untracked and ignored under `.hermes/`.