### PR TITLE
fix: preserve phase provenance in direct analysis

### DIFF
--- a/src/fastmdxplora/cli/main.py
+++ b/src/fastmdxplora/cli/main.py
@@ -1229,6 +1229,7 @@ def _cmd_phase(phase: str, args: argparse.Namespace) -> int:
     try:
         fmdx._presenter.phase_start(phase)  # noqa: SLF001 -- internal hook
         result = method(**kwargs)
+        fmdx.results.append(result)
         fmdx._presenter.phase_end(phase, status=result.status)
         fmdx._write_manifest()  # noqa: SLF001 -- single-phase still records
     except KeyboardInterrupt:

--- a/src/fastmdxplora/orchestrator.py
+++ b/src/fastmdxplora/orchestrator.py
@@ -908,6 +908,42 @@ class FastMDXplora:
             source_provenance,
         )
 
+        manifest_path = self.output_dir / "manifest.json"
+        previous: dict[str, Any] = {}
+        if manifest_path.is_file():
+            try:
+                with manifest_path.open(encoding="utf-8") as fh:
+                    loaded = json.load(fh)
+                if isinstance(loaded, dict):
+                    previous = loaded
+            except (OSError, json.JSONDecodeError):
+                # A malformed or unreadable previous manifest must not stop
+                # the phase from recording its own result.
+                previous = {}
+
+        phase_records: dict[str, dict[str, Any]] = {}
+        phase_order: list[str] = []
+        previous_phases = previous.get("phases", [])
+        if not isinstance(previous_phases, list):
+            previous_phases = []
+        for record in previous_phases:
+            if not isinstance(record, dict) or not record.get("name"):
+                continue
+            name = str(record["name"])
+            phase_records[name] = record
+            if name not in phase_order:
+                phase_order.append(name)
+        current_phases = [result.to_dict() for result in self.results]
+        for record in current_phases:
+            name = str(record["name"])
+            if name not in phase_records:
+                phase_order.append(name)
+            phase_records[name] = record
+
+        previous_options = previous.get("options", {})
+        options = dict(previous_options) if isinstance(previous_options, dict) else {}
+        options.update(self.options)
+
         manifest = {
             "tool": "FastMDXplora",
             "version": __version__,
@@ -927,10 +963,9 @@ class FastMDXplora:
             "citation": __citation__,
             "system": self.system,
             "output_dir": str(self.output_dir),
-            "phases": [r.to_dict() for r in self.results],
-            "options": self.options,
+            "phases": [phase_records[name] for name in phase_order],
+            "options": options,
         }
-        manifest_path = self.output_dir / "manifest.json"
         with manifest_path.open("w", encoding="utf-8") as fh:
             json.dump(manifest, fh, indent=2)
         logger.debug("Wrote manifest: %s", manifest_path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 import pytest
 
 from fastmdxplora.dependencies import missing_dependencies
-from fastmdxplora.orchestrator import FastMDXplora
+from fastmdxplora.orchestrator import FastMDXplora, PhaseResult
 from fastmdxplora.cli.main import main
 
 
@@ -216,6 +216,26 @@ def test_cli_report_can_rerun_from_existing_output_without_system(tmp_path: Path
     assert (out / "report" / "report.md").exists()
 
 
+def test_cli_single_phase_manifest_preserves_and_records_phase(tmp_path: Path) -> None:
+    pdb = _make_pdb_stub(tmp_path)
+    out = tmp_path / "run"
+    out.mkdir()
+    (out / "manifest.json").write_text(json.dumps({
+        "system": str(pdb),
+        "phases": [{"name": "simulation", "status": "ok"}],
+    }), encoding="utf-8")
+    result = PhaseResult(name="analysis", status="ok")
+
+    with patch("fastmdxplora.orchestrator.FastMDXplora._run_phase", return_value=result):
+        rc = main(["analyze", "-system", str(pdb), "--output", str(out)])
+
+    assert rc == 0
+    manifest = json.loads((out / "manifest.json").read_text(encoding="utf-8"))
+    assert [phase["name"] for phase in manifest["phases"]] == [
+        "simulation", "analysis"
+    ]
+
+
 def test_cli_explore_no_report(tmp_path: Path) -> None:
     pdb = _make_pdb_stub(tmp_path)
     out = tmp_path / "run"
@@ -370,7 +390,7 @@ def test_cli_phase_dashboard_uses_cli_output_path(tmp_path: Path) -> None:
     ) as start, patch.object(
         FastMDXplora,
         "setup",
-        return_value=SimpleNamespace(status="ok"),
+        return_value=PhaseResult(name="setup", status="ok"),
     ):
         rc = main(
             [
@@ -405,7 +425,7 @@ def test_cli_dashboard_uses_cli_output_path_for_other_phases(
     ) as start, patch.object(
         FastMDXplora,
         method_name,
-        return_value=SimpleNamespace(status="ok"),
+        return_value=PhaseResult(name=command, status="ok"),
     ):
         rc = main(
             [
@@ -476,7 +496,7 @@ def test_cli_dashboard_implies_live_telemetry_for_simulation(tmp_path: Path) -> 
     ), patch.object(
         FastMDXplora,
         "simulate",
-        return_value=SimpleNamespace(status="ok"),
+        return_value=PhaseResult(name="simulation", status="ok"),
     ) as simulate:
         rc = main(
             [

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import pytest
 
 from fastmdxplora import FastMDXplora
-from fastmdxplora.orchestrator import PHASES
+from fastmdxplora.orchestrator import PHASES, PhaseResult
 
 # Orchestration tests verify the pipeline wiring, not MD physics. We mock the
 # MD engine (see _mock_md below) so the simulation phase produces a real, tiny
@@ -173,6 +173,50 @@ def test_explore_writes_manifest(tmp_path: Path) -> None:
     assert manifest["tool"] == "FastMDXplora"
     assert manifest["doi"] == "10.1002/jcc.70350"
     assert len(manifest["phases"]) == len(PHASES)
+
+
+def test_single_phase_manifest_preserves_existing_phases(tmp_path: Path) -> None:
+    """A direct phase command must not erase earlier phase provenance."""
+    pdb = _make_pdb_stub(tmp_path)
+    output = tmp_path / "run"
+    output.mkdir()
+    (output / "manifest.json").write_text(json.dumps({
+        "tool": "FastMDXplora",
+        "phases": [
+            {"name": "simulation", "status": "stale"},
+            {"name": "simulation", "status": "ok"},
+        ],
+    }))
+    fmdx = FastMDXplora(system=str(pdb), output_dir=output)
+    fmdx.results.append(PhaseResult(name="analysis", status="ok"))
+
+    fmdx._write_manifest()
+
+    manifest = json.loads((output / "manifest.json").read_text())
+    assert [phase["name"] for phase in manifest["phases"]] == [
+        "simulation", "analysis"
+    ]
+    assert manifest["phases"][0]["status"] == "ok"
+
+
+def test_manifest_with_invalid_phase_and_option_shapes_is_recoverable(
+    tmp_path: Path,
+) -> None:
+    """A malformed prior manifest must not block recording a new phase."""
+    pdb = _make_pdb_stub(tmp_path)
+    output = tmp_path / "run"
+    output.mkdir()
+    (output / "manifest.json").write_text(json.dumps({
+        "phases": None,
+        "options": "not-a-mapping",
+    }))
+    fmdx = FastMDXplora(system=str(pdb), output_dir=output)
+    fmdx.results.append(PhaseResult(name="analysis", status="ok"))
+
+    fmdx._write_manifest()
+
+    manifest = json.loads((output / "manifest.json").read_text())
+    assert [phase["name"] for phase in manifest["phases"]] == ["analysis"]
 
 
 def test_explore_include(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Preserve completed phase records when a direct single-phase command rewrites `manifest.json`.
- Record the current direct CLI phase result before manifest serialization.
- Preserve phase ordering, replace duplicate historical phase names with the latest record, and recover from malformed phase/option shapes.
- Keep the existing `energy.csv` thermodynamics discovery fix from `main` covered without duplicating it in this PR.

## Test plan
- Focused CLI/orchestrator/thermodynamics regression tests: 10 passed.
- Full suite: 3130 passed, 82 skipped, 105 deselected.
- `git diff --check`: passed.
- Added-line security scan: no hardcoded secrets or unsafe execution patterns.

## Context
This addresses the provenance loss observed when running `fastmdx analyze` against a completed simulation output. Private validation artifacts and `.hermes/` records are not included.